### PR TITLE
fix: mock @huggingface/transformers in llm tests for CI reliability

### DIFF
--- a/packages/core/test/llm.test.ts
+++ b/packages/core/test/llm.test.ts
@@ -8,6 +8,13 @@ vi.mock("ai", () => ({
   stepCountIs: vi.fn().mockReturnValue({ type: "step-count" }),
 }));
 
+vi.mock("@huggingface/transformers", () => ({
+  pipeline: vi.fn().mockResolvedValue(
+    vi.fn().mockResolvedValue({ data: new Float32Array(384).fill(0.1) }),
+  ),
+  env: {},
+}));
+
 import { generateText, embed as aiEmbed } from "ai";
 const mockGenerateText = vi.mocked(generateText);
 const mockEmbed = vi.mocked(aiEmbed);


### PR DESCRIPTION
The anthropic embed fallback test was loading the real HuggingFace
transformers pipeline, which fails in CI environments where the model
cannot be downloaded. Mock the module so the test verifies the fallback
logic without requiring a real ML model.
