### PR TITLE
ci: force Playwright E2E to use bundled Chromium binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       # E2E tests — only on Node 22 to save CI minutes
       - run: pnpm build
         if: matrix.node-version == 22
-      - run: pnpm exec playwright install --with-deps chromium
+      - run: PLAYWRIGHT_CHROMIUM_USE_HEADLESS_SHELL=0 pnpm exec playwright install --with-deps chromium
         if: matrix.node-version == 22
-      - run: pnpm e2e
+      - run: PLAYWRIGHT_CHROMIUM_USE_HEADLESS_SHELL=0 pnpm e2e
         if: matrix.node-version == 22


### PR DESCRIPTION
### Motivation
- Fix the CI E2E failure where Playwright attempts to launch `chromium_headless_shell` (missing on runner) by forcing Playwright to use the bundled Chromium binary.

### Description
- Set `PLAYWRIGHT_CHROMIUM_USE_HEADLESS_SHELL=0` for both the Playwright install step and the `pnpm e2e` execution in `.github/workflows/ci.yml` so Playwright installs and launches the bundled Chromium instead of the headless-shell binary.

### Testing
- Ran `pnpm run ci` (which runs `verify` + coverage) and `pnpm lint` locally and they passed; `pnpm e2e` in this environment still cannot download Playwright browser binaries due to CDN `403 Forbidden` but the workflow change addresses the original headless-shell launch failure observed in the referenced run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2ae7a5674832f901f6c706cb1dcfc)