### PR TITLE
test(e2e): reduce CI flakiness by increasing server startup timeouts

### DIFF
--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -8,7 +8,9 @@ import { startMockLLM } from "./mock-llm";
 const MOCK_LLM_PORT = 11435;
 const PAI_PORT = 3199;
 const HEALTH_URL = `http://127.0.0.1:${PAI_PORT}/api/health`;
-const MAX_WAIT_MS = 15_000;
+// CI runners can be slow when building cache, installing deps, and starting Node services.
+// Give the server enough time to boot to avoid startup race flakes.
+const MAX_WAIT_MS = 45_000;
 const POLL_INTERVAL_MS = 300;
 
 /** Path where we stash PIDs + temp dir path for teardown */

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -71,7 +71,7 @@ export async function loginViaAPI(page: Page): Promise<void> {
  * Wait for the PAI server to be healthy (polls /api/health).
  * Useful after operations that trigger reinitialize().
  */
-export async function waitForServer(timeoutMs = 10_000): Promise<void> {
+export async function waitForServer(timeoutMs = 20_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {


### PR DESCRIPTION
### Motivation

- CI E2E jobs were flaky due to the PAI server sometimes taking longer to become healthy on slower runners, causing Playwright tests to fail with startup race conditions.

### Description

- Increased the Playwright global setup health-check timeout from `15_000` to `45_000` in `tests/e2e/global-setup.ts` and added a short inline note explaining the rationale.
- Increased the E2E helper `waitForServer` default timeout from `10_000` to `20_000` in `tests/e2e/helpers.ts` to give reinitialize flows more headroom.

### Testing

- Ran `pnpm run verify` (typecheck + unit tests) and it completed successfully (`vitest` unit tests passed).
- Attempted `pnpm e2e` but it failed in this environment because Playwright browser binaries are not installed; `pnpm exec playwright install --with-deps chromium` also failed here due to environment apt/proxy errors, so full E2E verification could not be completed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ff690d174832f98b1f43406b30a53)