### PR TITLE
Telegram: format raw JSON responses into readable Telegram sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Telegram raw JSON responses** — Bot now detects JSON-only responses and converts them into Telegram-friendly structured sections and bullet lists for readable delivery.
 - **Swarm results not delivered** — Push loop only handled `research-*` briefing IDs, silently dropping `swarm-*` reports
 - **Group chat research/swarm delivery** — Same root cause as above; both prefixes now resolve to originating chat
 - **Debug toggle not persisting** — `loadConfig()` didn't read `debugResearch`, `workers`, or `knowledge` fields from config file, losing them on server restart

--- a/packages/plugin-telegram/src/bot.ts
+++ b/packages/plugin-telegram/src/bot.ts
@@ -8,7 +8,7 @@ import { listSwarmJobs } from "@personal-ai/plugin-swarm";
 import { webSearch, formatSearchResults } from "@personal-ai/plugin-assistant/web-search";
 import { fetchPageAsMarkdown } from "@personal-ai/plugin-assistant/page-fetch";
 import { runAgentChat, createThread, clearThread as clearThreadMessages } from "./chat.js";
-import { markdownToTelegramHTML, splitMessage, escapeHTML } from "./formatter.js";
+import { markdownToTelegramHTML, splitMessage, escapeHTML, formatTelegramResponse } from "./formatter.js";
 import { bufferMessage, passiveProcess } from "./passive.js";
 
 /** Tool name → human-friendly status emoji */
@@ -301,13 +301,14 @@ export function createBot(token: string, ctx: PluginContext, agentPlugin: AgentP
         return;
       }
 
-      const html = markdownToTelegramHTML(result.text);
+      const formattedText = formatTelegramResponse(result.text);
+      const html = markdownToTelegramHTML(formattedText);
       const parts = splitMessage(html);
 
       try {
         await bot.api.editMessageText(chatId, placeholder.message_id, parts[0]!, { parse_mode: "HTML" });
       } catch {
-        const plainParts = splitMessage(result.text);
+        const plainParts = splitMessage(formattedText);
         await bot.api.editMessageText(chatId, placeholder.message_id, plainParts[0]!);
         for (let i = 1; i < plainParts.length; i++) {
           await bot.api.sendMessage(chatId, plainParts[i]!);
@@ -319,7 +320,7 @@ export function createBot(token: string, ctx: PluginContext, agentPlugin: AgentP
         try {
           await bot.api.sendMessage(chatId, parts[i]!, { parse_mode: "HTML" });
         } catch {
-          await bot.api.sendMessage(chatId, splitMessage(result.text)[i] ?? parts[i]!);
+          await bot.api.sendMessage(chatId, splitMessage(formattedText)[i] ?? parts[i]!);
         }
       }
     } catch (err) {

--- a/packages/plugin-telegram/src/formatter.ts
+++ b/packages/plugin-telegram/src/formatter.ts
@@ -117,6 +117,104 @@ export function markdownToTelegramHTML(md: string): string {
   return result.trim();
 }
 
+function humanizeKey(key: string): string {
+  const withSpaces = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim();
+  if (!withSpaces) return key;
+  return withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function formatPrimitive(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  return String(value);
+}
+
+function formatObjectLines(value: Record<string, unknown>): string[] {
+  const lines: string[] = [];
+
+  for (const [key, raw] of Object.entries(value)) {
+    const label = humanizeKey(key);
+
+    if (raw === null || typeof raw === "string" || typeof raw === "number" || typeof raw === "boolean") {
+      lines.push(`- **${label}:** ${formatPrimitive(raw)}`);
+      continue;
+    }
+
+    if (Array.isArray(raw)) {
+      if (raw.length === 0) continue;
+      lines.push(`\n**${label}**`);
+      for (const item of raw) {
+        if (isRecord(item)) {
+          const summary = Object.entries(item)
+            .filter(([, v]) => v === null || ["string", "number", "boolean"].includes(typeof v))
+            .slice(0, 4)
+            .map(([k, v]) => `**${humanizeKey(k)}:** ${formatPrimitive(v)}`)
+            .join(" | ");
+          lines.push(`- ${summary || "(complex item)"}`);
+        } else {
+          lines.push(`- ${formatPrimitive(item)}`);
+        }
+      }
+      continue;
+    }
+
+    if (isRecord(raw)) {
+      lines.push(`\n**${label}**`);
+      for (const [childKey, childVal] of Object.entries(raw)) {
+        if (childVal === null || typeof childVal === "string" || typeof childVal === "number" || typeof childVal === "boolean") {
+          lines.push(`- **${humanizeKey(childKey)}:** ${formatPrimitive(childVal)}`);
+        }
+      }
+    }
+  }
+
+  return lines;
+}
+
+/**
+ * Format a model response for Telegram.
+ * If the response is raw JSON, convert it into a human-readable markdown summary.
+ */
+export function formatTelegramResponse(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return text;
+
+  const looksLikeJson = (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+    (trimmed.startsWith("[") && trimmed.endsWith("]"));
+
+  if (!looksLikeJson) return text;
+
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+
+    if (Array.isArray(parsed)) {
+      if (parsed.length === 0) return text;
+      const lines: string[] = ["**Results**"];
+      for (const item of parsed) {
+        lines.push(`- ${isRecord(item) ? JSON.stringify(item) : formatPrimitive(item)}`);
+      }
+      return lines.join("\n");
+    }
+
+    if (!isRecord(parsed)) return text;
+
+    const title = [parsed.ticker, parsed.company].filter((part): part is string => typeof part === "string" && part.length > 0)
+      .join(" — ");
+    const lines = [title ? `**${title}**` : "**Analysis Summary**", ...formatObjectLines(parsed)];
+
+    return lines.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+  } catch {
+    return text;
+  }
+}
+
 /**
  * Split a message into chunks that fit Telegram's 4096-char limit.
  * Tries to split at paragraph boundaries, then newlines, then hard-splits.

--- a/packages/plugin-telegram/src/index.ts
+++ b/packages/plugin-telegram/src/index.ts
@@ -14,7 +14,7 @@ import { startResearchPushLoop } from "./push.js";
 // Re-exports
 export { createBot } from "./bot.js";
 export { runAgentChat, createThread, deleteThread, clearThread } from "./chat.js";
-export { markdownToTelegramHTML, splitMessage, formatBriefingHTML, escapeHTML } from "./formatter.js";
+export { markdownToTelegramHTML, splitMessage, formatBriefingHTML, escapeHTML, formatTelegramResponse } from "./formatter.js";
 export { startResearchPushLoop } from "./push.js";
 
 /** Migrations for telegram_threads mapping table */

--- a/packages/plugin-telegram/test/formatter.test.ts
+++ b/packages/plugin-telegram/test/formatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatBriefingHTML, escapeHTML } from "../src/formatter.js";
+import { formatBriefingHTML, escapeHTML, formatTelegramResponse } from "../src/formatter.js";
 import type { BriefingSections } from "../src/formatter.js";
 
 describe("escapeHTML", () => {
@@ -29,6 +29,28 @@ describe("escapeHTML", () => {
   });
 });
 
+
+
+describe("formatTelegramResponse", () => {
+  it("formats raw JSON payloads into readable markdown sections", () => {
+    const output = formatTelegramResponse('{"ticker":"AMZN","company":"Amazon","metrics":{"price":208.39},"risks":["Outage","Earnings miss"]}');
+    expect(output).toContain("**AMZN — Amazon**");
+    expect(output).toContain("**Metrics**");
+    expect(output).toContain("- **Price:** 208.39");
+    expect(output).toContain("**Risks**");
+    expect(output).toContain("- Outage");
+  });
+
+  it("returns original text when response is not JSON", () => {
+    const input = "Here is your analysis in markdown.";
+    expect(formatTelegramResponse(input)).toBe(input);
+  });
+
+  it("returns original text for invalid JSON", () => {
+    const input = '{"ticker":"AMZN"';
+    expect(formatTelegramResponse(input)).toBe(input);
+  });
+});
 describe("formatBriefingHTML", () => {
   it("formats full sections with all fields", () => {
     const sections: BriefingSections = {


### PR DESCRIPTION
### Motivation

- Model replies that are pure JSON were being sent verbatim to Telegram, which is hard to read for users.
- The Telegram plugin should detect JSON-only responses and convert them into structured, human-friendly sections and bullet lists.
- Ensure the formatting integration is used consistently in both HTML and plain-text delivery paths.

### Description

- Added `formatTelegramResponse` to `packages/plugin-telegram/src/formatter.ts` which detects JSON objects/arrays and converts them into markdown-style summaries and bullet lists, with helper functions `humanizeKey`, `formatObjectLines`, and `formatPrimitive`.
- Updated `packages/plugin-telegram/src/bot.ts` to call `formatTelegramResponse` before converting with `markdownToTelegramHTML` and before fallback plain-text splitting, ensuring both HTML and non-HTML delivery use the formatted text.
- Exported `formatTelegramResponse` from `packages/plugin-telegram/src/index.ts` and updated `CHANGELOG.md` to document the fix for raw JSON responses.
- Added unit tests in `packages/plugin-telegram/test/formatter.test.ts` to assert correct formatting of JSON payloads, non-JSON inputs, and invalid JSON cases.

### Testing

- Ran Vitest unit tests for the Telegram formatter; the new tests in `packages/plugin-telegram/test/formatter.test.ts` passed.
- Existing `plugin-telegram` formatter tests were executed and remained green after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a67b31a634832f943452620795b9d3)