### PR TITLE
Normalize and unify timestamp handling across server, Telegram, and UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Debug toggle not persisting** — `loadConfig()` didn't read `debugResearch`, `workers`, or `knowledge` fields from config file, losing them on server restart
 - **Telegram HTML injection** — User content in bot command responses (goals, titles, labels) is now escaped to prevent HTML injection via `escapeHTML()`
 - **Docker missing plugin-swarm** — Dockerfile now includes `plugin-swarm` package in both build and runtime stages
+- **Timezone consistency across UI and Telegram jobs** — SQLite UTC timestamps are now normalized before parsing, preventing hour offsets and mismatched relative times between web UI and Telegram outputs.
 
 ### Added
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,7 @@ export type { Belief, Episode, BeliefChange, MemoryStats, MemoryExport, MemoryEx
 // Timezone
 export { formatDateTime } from "./timezone.js";
 export type { FormattedDateTime } from "./timezone.js";
+export { normalizeTimestamp, parseTimestamp } from "./timezone.js";
 
 // Auth
 export { authMigrations, createOwner, getOwner, getOwnerByEmail, verifyOwnerPassword, hasOwner, getJwtSecret, resetOwnerPassword } from "./auth.js";

--- a/packages/core/src/timezone.ts
+++ b/packages/core/src/timezone.ts
@@ -15,6 +15,26 @@ export interface FormattedDateTime {
 }
 
 /**
+ * Normalize timestamps coming from mixed sources.
+ *
+ * SQLite `datetime('now')` yields `YYYY-MM-DD HH:MM:SS` (UTC but no offset),
+ * while JS and APIs commonly use ISO 8601 with explicit timezone.
+ * This function converts SQLite-style UTC timestamps to proper ISO UTC format.
+ */
+export function normalizeTimestamp(raw: string): string {
+  const value = raw.trim();
+  const sqliteUtc = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?)$/;
+  const match = value.match(sqliteUtc);
+  if (match) return `${match[1]}T${match[2]}Z`;
+  return value;
+}
+
+/** Parse a timestamp into a Date with SQLite UTC normalization. */
+export function parseTimestamp(raw: string): Date {
+  return new Date(normalizeTimestamp(raw));
+}
+
+/**
  * Format the current date/time using the configured timezone.
  * @param timezone IANA timezone string (e.g. "America/Los_Angeles"). Undefined = server default.
  * @param now Optional Date object (defaults to new Date())

--- a/packages/core/test/timezone.test.ts
+++ b/packages/core/test/timezone.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatDateTime } from "../src/timezone.js";
+import { formatDateTime, normalizeTimestamp, parseTimestamp } from "../src/timezone.js";
 
 describe("formatDateTime", () => {
   const testDate = new Date("2026-02-28T14:15:00Z");
@@ -26,5 +26,23 @@ describe("formatDateTime", () => {
     const result = formatDateTime();
     expect(result.year).toBeGreaterThanOrEqual(2026);
     expect(result.date).toBeTruthy();
+  });
+});
+
+
+describe("timestamp normalization", () => {
+  it("normalizes SQLite UTC datetime to ISO-8601 UTC", () => {
+    expect(normalizeTimestamp("2026-02-28 14:15:00")).toBe("2026-02-28T14:15:00Z");
+    expect(normalizeTimestamp("2026-02-28 14:15:00.123")).toBe("2026-02-28T14:15:00.123Z");
+  });
+
+  it("keeps already-normalized timestamps unchanged", () => {
+    expect(normalizeTimestamp("2026-02-28T14:15:00Z")).toBe("2026-02-28T14:15:00Z");
+    expect(normalizeTimestamp("2026-02-28T14:15:00+02:00")).toBe("2026-02-28T14:15:00+02:00");
+  });
+
+  it("parses SQLite UTC timestamps correctly", () => {
+    const parsed = parseTimestamp("2026-02-28 14:15:00");
+    expect(parsed.toISOString()).toBe("2026-02-28T14:15:00.000Z");
   });
 });

--- a/packages/plugin-telegram/src/bot.ts
+++ b/packages/plugin-telegram/src/bot.ts
@@ -1,6 +1,6 @@
 import { Bot } from "grammy";
 import type { AgentPlugin, PluginContext } from "@personal-ai/core";
-import { listBeliefs, getThread, formatDateTime } from "@personal-ai/core";
+import { listBeliefs, getThread, formatDateTime, parseTimestamp } from "@personal-ai/core";
 import { listTasks } from "@personal-ai/plugin-tasks";
 import { listResearchJobs, createResearchJob, runResearchInBackground } from "@personal-ai/plugin-research";
 import type { ResearchContext } from "@personal-ai/plugin-research";
@@ -27,7 +27,7 @@ function toolStatus(toolName: string): string {
 }
 
 function formatRelativeTime(isoDate: string): string {
-  const diffMs = Date.now() - new Date(isoDate).getTime();
+  const diffMs = Date.now() - parseTimestamp(isoDate).getTime();
   const mins = Math.floor(diffMs / 60_000);
   if (mins < 1) return "just now";
   if (mins < 60) return `${mins}m ago`;
@@ -187,7 +187,7 @@ export function createBot(token: string, ctx: PluginContext, agentPlugin: AgentP
       }
       const lines = schedules.map((s) => {
         const interval = s.interval_hours >= 24 ? `${Math.round(s.interval_hours / 24)}d` : `${s.interval_hours}h`;
-        const next = formatDateTime(ctx.config.timezone, new Date(s.next_run_at)).full;
+        const next = formatDateTime(ctx.config.timezone, parseTimestamp(s.next_run_at)).full;
         return `\u{1F504} <b>${escapeHTML(s.label)}</b> (every ${interval})\n   Next: ${next}\n   ID: <code>${s.id}</code>`;
       });
       await tgCtx.reply(`<b>Active Schedules</b>\n\n${lines.join("\n\n")}`, { parse_mode: "HTML" });
@@ -202,7 +202,7 @@ export function createBot(token: string, ctx: PluginContext, agentPlugin: AgentP
       const researchJobs = listResearchJobs(ctx.storage).map((j) => ({ ...j, source: "research" as const }));
       const swarmJobs = listSwarmJobs(ctx.storage).map((j) => ({ ...j, source: "swarm" as const }));
       const allJobs = [...researchJobs, ...swarmJobs]
-        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+        .sort((a, b) => parseTimestamp(b.createdAt).getTime() - parseTimestamp(a.createdAt).getTime())
         .slice(0, 10);
 
       if (allJobs.length === 0) {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,7 +1,9 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { Routes, Route, Link, Navigate } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "./lib/query-client";
+import { useConfig } from "./hooks";
+import { setConfiguredTimezone } from "./lib/datetime";
 
 const ReactQueryDevtools = lazy(() =>
   import("@tanstack/react-query-devtools").then((mod) => ({
@@ -36,6 +38,16 @@ function NotFound() {
   );
 }
 
+function TimezoneSync() {
+  const { data } = useConfig();
+
+  useEffect(() => {
+    setConfiguredTimezone(data?.timezone);
+  }, [data?.timezone]);
+
+  return null;
+}
+
 function AuthGate({ children }: { children: React.ReactNode }) {
   const { loading, needsSetup, isAuthenticated } = useAuth();
 
@@ -63,6 +75,7 @@ export default function App() {
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
       <AuthProvider>
+        <TimezoneSync />
         <Routes>
           <Route path="/login" element={<Login />} />
           <Route path="/setup" element={<Setup />} />

--- a/packages/ui/src/components/BeliefCard.tsx
+++ b/packages/ui/src/components/BeliefCard.tsx
@@ -3,7 +3,8 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { Belief } from "../types";
-import { parseApiDate } from "@/lib/datetime";
+import { formatWithTimezone, parseApiDate } from "@/lib/datetime";
+import { useAppTimezone } from "@/hooks";
 
 const typeColorMap: Record<string, string> = {
   factual: "bg-blue-500/15 text-blue-400 border-blue-500/30",
@@ -21,6 +22,7 @@ interface BeliefCardProps {
 }
 
 export default function BeliefCard({ belief, onForget, onClick }: BeliefCardProps) {
+  const timezone = useAppTimezone();
   const confidencePercent = Math.round(belief.confidence * 100);
   const typeClass = typeColorMap[belief.type] ?? "bg-muted text-muted-foreground border-border";
   const isActive = belief.status === "active";
@@ -73,7 +75,7 @@ export default function BeliefCard({ belief, onForget, onClick }: BeliefCardProp
 
       {/* Footer */}
       <CardFooter className="flex items-center justify-between px-4 py-0 text-[11px] text-muted-foreground">
-        <span>{parseApiDate(belief.created_at).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}</span>
+        <span>{formatWithTimezone(parseApiDate(belief.created_at), { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" }, timezone)}</span>
         <div className="flex items-center gap-2">
           {!isActive && (
             <Badge variant="destructive" className="text-[10px]">

--- a/packages/ui/src/components/BeliefCard.tsx
+++ b/packages/ui/src/components/BeliefCard.tsx
@@ -3,6 +3,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { Belief } from "../types";
+import { parseApiDate } from "@/lib/datetime";
 
 const typeColorMap: Record<string, string> = {
   factual: "bg-blue-500/15 text-blue-400 border-blue-500/30",
@@ -72,7 +73,7 @@ export default function BeliefCard({ belief, onForget, onClick }: BeliefCardProp
 
       {/* Footer */}
       <CardFooter className="flex items-center justify-between px-4 py-0 text-[11px] text-muted-foreground">
-        <span>{new Date(belief.created_at.replace(" ", "T")).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}</span>
+        <span>{parseApiDate(belief.created_at).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}</span>
         <div className="flex items-center gap-2">
           {!isActive && (
             <Badge variant="destructive" className="text-[10px]">

--- a/packages/ui/src/components/chat/ThreadSidebar.tsx
+++ b/packages/ui/src/components/chat/ThreadSidebar.tsx
@@ -34,6 +34,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { InfoBubble } from "../InfoBubble";
+import { parseApiDate } from "@/lib/datetime";
 
 interface ThreadSidebarProps {
   activeThreadId: string | null;
@@ -260,7 +261,7 @@ export function ThreadSidebar({
                         </Badge>
                       )}
                       <span>
-                        {new Date(thread.updatedAt).toLocaleDateString(
+                        {parseApiDate(thread.updatedAt).toLocaleDateString(
                           undefined,
                           { month: "short", day: "numeric" },
                         )}

--- a/packages/ui/src/components/chat/ThreadSidebar.tsx
+++ b/packages/ui/src/components/chat/ThreadSidebar.tsx
@@ -34,7 +34,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { InfoBubble } from "../InfoBubble";
-import { parseApiDate } from "@/lib/datetime";
+import { formatWithTimezone, parseApiDate } from "@/lib/datetime";
+import { useAppTimezone } from "@/hooks";
 
 interface ThreadSidebarProps {
   activeThreadId: string | null;
@@ -59,6 +60,7 @@ export function ThreadSidebar({
   isOpen,
   onToggle,
 }: ThreadSidebarProps) {
+  const timezone = useAppTimezone();
   const { data: threads = [], isLoading: threadsLoading } = useThreads();
   const deleteThreadMut = useDeleteThread();
   const renameThreadMut = useRenameThread();
@@ -261,10 +263,7 @@ export function ThreadSidebar({
                         </Badge>
                       )}
                       <span>
-                        {parseApiDate(thread.updatedAt).toLocaleDateString(
-                          undefined,
-                          { month: "short", day: "numeric" },
-                        )}
+                        {formatWithTimezone(parseApiDate(thread.updatedAt), { month: "short", day: "numeric" }, timezone)}
                       </span>
                     </div>
                   </>

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -10,3 +10,4 @@ export * from "./use-schedules";
 export * from "./use-config";
 export * from "./use-health";
 export * from "./use-learning";
+export * from "./use-timezone";

--- a/packages/ui/src/hooks/use-timezone.ts
+++ b/packages/ui/src/hooks/use-timezone.ts
@@ -1,0 +1,7 @@
+import { useConfig } from "./use-config";
+
+/** Returns configured IANA timezone, or undefined to use browser local timezone. */
+export function useAppTimezone(): string | undefined {
+  const { data } = useConfig();
+  return data?.timezone || undefined;
+}

--- a/packages/ui/src/lib/datetime.ts
+++ b/packages/ui/src/lib/datetime.ts
@@ -12,3 +12,19 @@ export function normalizeApiTimestamp(raw: string): string {
 export function parseApiDate(raw: string): Date {
   return new Date(normalizeApiTimestamp(raw));
 }
+
+let configuredTimezone: string | undefined;
+
+export function setConfiguredTimezone(timezone?: string): void {
+  configuredTimezone = timezone || undefined;
+}
+
+export function formatWithTimezone(
+  date: Date,
+  options: Intl.DateTimeFormatOptions,
+  timezone?: string,
+  locale?: string | string[],
+): string {
+  const resolvedTz = timezone ?? configuredTimezone;
+  return date.toLocaleString(locale, resolvedTz ? { ...options, timeZone: resolvedTz } : options);
+}

--- a/packages/ui/src/lib/datetime.ts
+++ b/packages/ui/src/lib/datetime.ts
@@ -1,0 +1,14 @@
+/**
+ * Normalize API timestamps so SQLite UTC strings are interpreted consistently.
+ */
+export function normalizeApiTimestamp(raw: string): string {
+  const value = raw.trim();
+  const sqliteUtc = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?)$/;
+  const match = value.match(sqliteUtc);
+  if (match) return `${match[1]}T${match[2]}Z`;
+  return value;
+}
+
+export function parseApiDate(raw: string): Date {
+  return new Date(normalizeApiTimestamp(raw));
+}

--- a/packages/ui/src/pages/Inbox.tsx
+++ b/packages/ui/src/pages/Inbox.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Separator } from "@/components/ui/separator";
 import MarkdownContent from "@/components/MarkdownContent";
 import { ResultRenderer } from "@/components/results/ResultRenderer";
+import { parseApiDate } from "@/lib/datetime";
 import {
   RefreshCwIcon,
   CheckCircle2Icon,
@@ -51,7 +52,7 @@ const priorityStyles: Record<string, string> = {
 };
 
 function timeAgo(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime();
+  const diff = Date.now() - parseApiDate(dateStr).getTime();
   const mins = Math.floor(diff / 60000);
   if (mins < 1) return "just now";
   if (mins < 60) return `${mins}m ago`;

--- a/packages/ui/src/pages/Jobs.tsx
+++ b/packages/ui/src/pages/Jobs.tsx
@@ -35,6 +35,7 @@ import type { BackgroundJobInfo, BlackboardEntry } from "../api";
 import type { SwarmAgent, ArtifactMeta } from "../types";
 import { useJobs, useJobDetail, useJobBlackboard, useJobAgents, useJobArtifacts, useCancelJob, useClearJobs, useConfig } from "@/hooks";
 import { ResultRenderer } from "@/components/results/ResultRenderer";
+import { parseApiDate } from "@/lib/datetime";
 
 const statusStyles: Record<string, string> = {
   running: "bg-blue-500/15 text-blue-400 border-blue-500/20",
@@ -80,7 +81,7 @@ const roleStyles: Record<string, string> = {
 };
 
 function timeAgo(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime();
+  const diff = Date.now() - parseApiDate(dateStr).getTime();
   const mins = Math.floor(diff / 60000);
   if (mins < 1) return "just now";
   if (mins < 60) return `${mins}m ago`;
@@ -91,7 +92,7 @@ function timeAgo(dateStr: string): string {
 
 function formatDuration(start: string, end: string | null): string {
   if (!end) return "running...";
-  const ms = new Date(end).getTime() - new Date(start).getTime();
+  const ms = parseApiDate(end).getTime() - parseApiDate(start).getTime();
   const secs = Math.floor(ms / 1000);
   if (secs < 60) return `${secs}s`;
   const mins = Math.floor(secs / 60);

--- a/packages/ui/src/pages/Knowledge.tsx
+++ b/packages/ui/src/pages/Knowledge.tsx
@@ -31,11 +31,11 @@ import {
   ChevronRightIcon,
 } from "lucide-react";
 import type { KnowledgeSource, KnowledgeSearchResult } from "../types";
-import { parseApiDate } from "@/lib/datetime";
+import { formatWithTimezone, parseApiDate } from "@/lib/datetime";
 
 function formatDate(dateStr: string): string {
   const d = parseApiDate(dateStr);
-  return isNaN(d.getTime()) ? dateStr : d.toLocaleDateString();
+  return isNaN(d.getTime()) ? dateStr : formatWithTimezone(d, { year: "numeric", month: "numeric", day: "numeric" } );
 }
 
 function parseTags(tags: string | null): string[] {
@@ -645,7 +645,7 @@ function SourceCard({ source: s, onClick }: { source: KnowledgeSource; onClick: 
           </div>
         )}
         <div className="flex items-center justify-between text-[10px] text-muted-foreground/60">
-          <span>{formatDate(s.learnedAt)}</span>
+          <span>{formatDate(s.learnedAt )}</span>
           <span className="font-mono">{s.id.slice(0, 8)}</span>
         </div>
       </CardContent>
@@ -736,7 +736,7 @@ function SourceDetailPanel({
               </div>
               <div>
                 <span className="mb-0.5 block text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Learned</span>
-                <span className="text-sm text-foreground">{formatDate(source.learnedAt)}</span>
+                <span className="text-sm text-foreground">{formatDate(source.learnedAt )}</span>
               </div>
             </div>
 

--- a/packages/ui/src/pages/Knowledge.tsx
+++ b/packages/ui/src/pages/Knowledge.tsx
@@ -31,9 +31,10 @@ import {
   ChevronRightIcon,
 } from "lucide-react";
 import type { KnowledgeSource, KnowledgeSearchResult } from "../types";
+import { parseApiDate } from "@/lib/datetime";
 
 function formatDate(dateStr: string): string {
-  const d = new Date(dateStr.replace(" ", "T"));
+  const d = parseApiDate(dateStr);
   return isNaN(d.getTime()) ? dateStr : d.toLocaleDateString();
 }
 

--- a/packages/ui/src/pages/Memory.tsx
+++ b/packages/ui/src/pages/Memory.tsx
@@ -27,7 +27,7 @@ import { cn } from "@/lib/utils";
 import { InfoBubble } from "../components/InfoBubble";
 import { Trash2Icon, HelpCircleIcon, PencilIcon, CheckIcon, XIcon } from "lucide-react";
 import type { Belief, BeliefType } from "../types";
-import { parseApiDate } from "@/lib/datetime";
+import { formatWithTimezone, parseApiDate } from "@/lib/datetime";
 
 const TYPES: BeliefType[] = ["factual", "preference", "procedural", "architectural", "insight", "meta"];
 
@@ -51,18 +51,18 @@ const typeDescriptions: Record<string, string> = {
 
 function formatDate(dateStr: string): string {
   const d = parseApiDate(dateStr);
-  return isNaN(d.getTime()) ? dateStr : d.toLocaleString();
+  return isNaN(d.getTime()) ? dateStr : formatWithTimezone(d, {} );
 }
 
 function sortBeliefs(results: Belief[], sortBy: string): Belief[] {
   return [...results].sort((a, b) => {
     switch (sortBy) {
       case "recent":
-        return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime();
+        return parseApiDate(b.updated_at).getTime() - parseApiDate(a.updated_at).getTime();
       case "importance":
         return b.importance - a.importance;
       case "created":
-        return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+        return parseApiDate(b.created_at).getTime() - parseApiDate(a.created_at).getTime();
       default:
         return b.confidence - a.confidence;
     }
@@ -673,8 +673,8 @@ function BeliefDetailPanel({
             )}
 
             <div className="space-y-2">
-              <DetailRow label="Created" value={formatDate(belief.created_at)} />
-              <DetailRow label="Updated" value={formatDate(belief.updated_at)} />
+              <DetailRow label="Created" value={formatDate(belief.created_at )} />
+              <DetailRow label="Updated" value={formatDate(belief.updated_at )} />
               <DetailRow label="ID" value={belief.id} mono />
             </div>
 

--- a/packages/ui/src/pages/Memory.tsx
+++ b/packages/ui/src/pages/Memory.tsx
@@ -27,6 +27,7 @@ import { cn } from "@/lib/utils";
 import { InfoBubble } from "../components/InfoBubble";
 import { Trash2Icon, HelpCircleIcon, PencilIcon, CheckIcon, XIcon } from "lucide-react";
 import type { Belief, BeliefType } from "../types";
+import { parseApiDate } from "@/lib/datetime";
 
 const TYPES: BeliefType[] = ["factual", "preference", "procedural", "architectural", "insight", "meta"];
 
@@ -49,7 +50,7 @@ const typeDescriptions: Record<string, string> = {
 };
 
 function formatDate(dateStr: string): string {
-  const d = new Date(dateStr.replace(" ", "T"));
+  const d = parseApiDate(dateStr);
   return isNaN(d.getTime()) ? dateStr : d.toLocaleString();
 }
 

--- a/packages/ui/src/pages/Schedules.tsx
+++ b/packages/ui/src/pages/Schedules.tsx
@@ -12,6 +12,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
+import { parseApiDate } from "@/lib/datetime";
 import {
   PlusIcon,
   Trash2Icon,
@@ -31,7 +32,7 @@ function formatInterval(hours: number): string {
 }
 
 function formatDateTime(iso: string): string {
-  const d = new Date(iso);
+  const d = parseApiDate(iso);
   if (isNaN(d.getTime())) return iso;
   return d.toLocaleString(undefined, {
     month: "short",
@@ -42,7 +43,7 @@ function formatDateTime(iso: string): string {
 }
 
 function timeUntil(iso: string): string {
-  const diff = new Date(iso).getTime() - Date.now();
+  const diff = parseApiDate(iso).getTime() - Date.now();
   if (diff < 0) return "due now";
   const hours = Math.floor(diff / (1000 * 60 * 60));
   const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));

--- a/packages/ui/src/pages/Schedules.tsx
+++ b/packages/ui/src/pages/Schedules.tsx
@@ -12,7 +12,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
-import { parseApiDate } from "@/lib/datetime";
+import { formatWithTimezone, parseApiDate } from "@/lib/datetime";
 import {
   PlusIcon,
   Trash2Icon,
@@ -34,12 +34,12 @@ function formatInterval(hours: number): string {
 function formatDateTime(iso: string): string {
   const d = parseApiDate(iso);
   if (isNaN(d.getTime())) return iso;
-  return d.toLocaleString(undefined, {
+  return formatWithTimezone(d, {
     month: "short",
     day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
-  });
+  } );
 }
 
 function timeUntil(iso: string): string {
@@ -320,10 +320,10 @@ function ScheduleRow({
         <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{s.goal}</p>
         <div className="mt-2 flex flex-wrap gap-3 text-xs text-muted-foreground">
           {!isPaused && (
-            <span>Next: {formatDateTime(s.nextRunAt)} ({timeUntil(s.nextRunAt)})</span>
+            <span>Next: {formatDateTime(s.nextRunAt )} ({timeUntil(s.nextRunAt)})</span>
           )}
           {s.lastRunAt && (
-            <span>Last: {formatDateTime(s.lastRunAt)}</span>
+            <span>Last: {formatDateTime(s.lastRunAt )}</span>
           )}
           <span className="font-mono text-[10px] opacity-50">{s.id}</span>
         </div>

--- a/packages/ui/src/pages/Settings.tsx
+++ b/packages/ui/src/pages/Settings.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
 import { InfoBubble } from "../components/InfoBubble";
 import { FolderIcon, FolderOpenIcon, ChevronUpIcon, ChevronDownIcon, BotIcon, CircleCheckIcon, CircleXIcon, LoaderIcon, CpuIcon } from "lucide-react";
 import type { LearningRun } from "@/api";
+import { parseApiDate } from "@/lib/datetime";
 
 const isCloudDeployment =
   typeof window !== "undefined" &&
@@ -622,7 +623,7 @@ export default function Settings() {
                   <span className="text-xs text-muted-foreground">Last learning run</span>
                   <span className="font-mono text-xs text-foreground/70">
                     {config.workers.lastRun.threads
-                      ? new Date(config.workers.lastRun.threads).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })
+                      ? parseApiDate(config.workers.lastRun.threads).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })
                       : "Never"}
                   </span>
                 </div>
@@ -769,7 +770,7 @@ export default function Settings() {
               {stats.newestBelief && (
                 <StatCard
                   label="Latest Update"
-                  value={new Date(stats.newestBelief).toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+                  value={parseApiDate(stats.newestBelief).toLocaleDateString(undefined, { month: "short", day: "numeric" })}
                 />
               )}
             </div>
@@ -912,7 +913,7 @@ function EditableRow({
 }
 
 function timeAgo(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime();
+  const diff = Date.now() - parseApiDate(dateStr).getTime();
   const mins = Math.floor(diff / 60000);
   if (mins < 1) return "just now";
   if (mins < 60) return `${mins}m ago`;

--- a/packages/ui/src/pages/Settings.tsx
+++ b/packages/ui/src/pages/Settings.tsx
@@ -12,7 +12,7 @@ import { cn } from "@/lib/utils";
 import { InfoBubble } from "../components/InfoBubble";
 import { FolderIcon, FolderOpenIcon, ChevronUpIcon, ChevronDownIcon, BotIcon, CircleCheckIcon, CircleXIcon, LoaderIcon, CpuIcon } from "lucide-react";
 import type { LearningRun } from "@/api";
-import { parseApiDate } from "@/lib/datetime";
+import { formatWithTimezone, parseApiDate } from "@/lib/datetime";
 
 const isCloudDeployment =
   typeof window !== "undefined" &&
@@ -623,7 +623,7 @@ export default function Settings() {
                   <span className="text-xs text-muted-foreground">Last learning run</span>
                   <span className="font-mono text-xs text-foreground/70">
                     {config.workers.lastRun.threads
-                      ? parseApiDate(config.workers.lastRun.threads).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })
+                      ? formatWithTimezone(parseApiDate(config.workers.lastRun.threads), { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" }, timezone || undefined)
                       : "Never"}
                   </span>
                 </div>
@@ -770,7 +770,7 @@ export default function Settings() {
               {stats.newestBelief && (
                 <StatCard
                   label="Latest Update"
-                  value={parseApiDate(stats.newestBelief).toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+                  value={formatWithTimezone(parseApiDate(stats.newestBelief), { month: "short", day: "numeric" }, timezone || undefined)}
                 />
               )}
             </div>

--- a/packages/ui/src/pages/Tasks.tsx
+++ b/packages/ui/src/pages/Tasks.tsx
@@ -34,11 +34,11 @@ import {
   CalendarIcon,
 } from "lucide-react";
 import type { Task, Goal } from "../types";
-import { parseApiDate } from "@/lib/datetime";
+import { formatWithTimezone, parseApiDate } from "@/lib/datetime";
 
 function formatDate(dateStr: string): string {
   const d = parseApiDate(dateStr);
-  return isNaN(d.getTime()) ? dateStr : d.toLocaleDateString();
+  return isNaN(d.getTime()) ? dateStr : formatWithTimezone(d, { year: "numeric", month: "numeric", day: "numeric" } );
 }
 
 function isOverdue(dueDateStr: string): boolean {
@@ -873,7 +873,7 @@ function TaskRow({
           {isDone && task.completed_at ? (
             <span className="flex items-center gap-1 text-[11px] text-green-500/70">
               <CheckCircle2Icon className="size-3" />
-              Completed {formatDate(task.completed_at)}
+              Completed {formatDate(task.completed_at )}
             </span>
           ) : (
             task.due_date && (
@@ -881,7 +881,7 @@ function TaskRow({
                 className={`flex items-center gap-1 text-[11px] ${isOverdue(task.due_date) ? "text-red-400" : "text-muted-foreground"}`}
               >
                 <CalendarIcon className="size-3" />
-                {formatDate(task.due_date)}
+                {formatDate(task.due_date )}
               </span>
             )
           )}

--- a/packages/ui/src/pages/Tasks.tsx
+++ b/packages/ui/src/pages/Tasks.tsx
@@ -34,14 +34,15 @@ import {
   CalendarIcon,
 } from "lucide-react";
 import type { Task, Goal } from "../types";
+import { parseApiDate } from "@/lib/datetime";
 
 function formatDate(dateStr: string): string {
-  const d = new Date(dateStr.replace(" ", "T"));
+  const d = parseApiDate(dateStr);
   return isNaN(d.getTime()) ? dateStr : d.toLocaleDateString();
 }
 
 function isOverdue(dueDateStr: string): boolean {
-  const due = new Date(dueDateStr.replace(" ", "T"));
+  const due = parseApiDate(dueDateStr);
   if (isNaN(due.getTime())) return false;
   const today = new Date();
   today.setHours(0, 0, 0, 0);

--- a/packages/ui/src/pages/Timeline.tsx
+++ b/packages/ui/src/pages/Timeline.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { InfoBubble } from "../components/InfoBubble";
 import { useBeliefs } from "@/hooks";
 import type { Belief, BeliefType } from "../types";
+import { parseApiDate } from "@/lib/datetime";
 
 const TYPES: BeliefType[] = ["factual", "preference", "procedural", "architectural", "insight", "meta"];
 
@@ -49,12 +50,12 @@ export default function Timeline() {
 
   // Sort by updated_at descending
   const beliefs = [...rawBeliefs].sort(
-    (a, b) => new Date(b.updated_at.replace(" ", "T")).getTime() - new Date(a.updated_at.replace(" ", "T")).getTime(),
+    (a, b) => parseApiDate(b.updated_at).getTime() - parseApiDate(a.updated_at).getTime(),
   );
 
   // Group by date
   const grouped = beliefs.reduce<Record<string, Belief[]>>((acc, belief) => {
-    const date = new Date(belief.updated_at.replace(" ", "T")).toLocaleDateString("en-US", {
+    const date = parseApiDate(belief.updated_at).toLocaleDateString("en-US", {
       weekday: "long",
       year: "numeric",
       month: "long",
@@ -172,7 +173,7 @@ export default function Timeline() {
                                 {belief.type}
                               </Badge>
                               <span className="font-mono text-[10px] text-muted-foreground">
-                                {new Date(belief.updated_at.replace(" ", "T")).toLocaleTimeString([], {
+                                {parseApiDate(belief.updated_at).toLocaleTimeString([], {
                                   hour: "2-digit",
                                   minute: "2-digit",
                                 })}

--- a/packages/ui/src/pages/Timeline.tsx
+++ b/packages/ui/src/pages/Timeline.tsx
@@ -6,9 +6,9 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { InfoBubble } from "../components/InfoBubble";
-import { useBeliefs } from "@/hooks";
+import { useBeliefs, useAppTimezone } from "@/hooks";
 import type { Belief, BeliefType } from "../types";
-import { parseApiDate } from "@/lib/datetime";
+import { formatWithTimezone, parseApiDate } from "@/lib/datetime";
 
 const TYPES: BeliefType[] = ["factual", "preference", "procedural", "architectural", "insight", "meta"];
 
@@ -40,6 +40,7 @@ const cardAccentColors: Record<string, string> = {
 };
 
 export default function Timeline() {
+  const timezone = useAppTimezone();
   const [filterType, setFilterType] = useState<string>("");
 
   useEffect(() => { document.title = "Timeline - pai"; }, []);
@@ -55,12 +56,12 @@ export default function Timeline() {
 
   // Group by date
   const grouped = beliefs.reduce<Record<string, Belief[]>>((acc, belief) => {
-    const date = parseApiDate(belief.updated_at).toLocaleDateString("en-US", {
+    const date = formatWithTimezone(parseApiDate(belief.updated_at), {
       weekday: "long",
       year: "numeric",
       month: "long",
       day: "numeric",
-    });
+    }, timezone);
     if (!acc[date]) acc[date] = [];
     acc[date].push(belief);
     return acc;
@@ -173,7 +174,7 @@ export default function Timeline() {
                                 {belief.type}
                               </Badge>
                               <span className="font-mono text-[10px] text-muted-foreground">
-                                {parseApiDate(belief.updated_at).toLocaleTimeString([], {
+                                {formatWithTimezone(parseApiDate(belief.updated_at), {
                                   hour: "2-digit",
                                   minute: "2-digit",
                                 })}


### PR DESCRIPTION
### Motivation
- Fix inconsistent times shown between the web UI and Telegram by treating SQLite `datetime('now')` strings as UTC and normalizing timestamps before parsing and formatting.

### Description
- Add `normalizeTimestamp(raw: string)` and `parseTimestamp(raw: string)` to `@personal-ai/core` and export them so server plugins can parse SQLite-style `YYYY-MM-DD HH:MM:SS` timestamps as UTC before converting to `Date` or formatting via `formatDateTime`.
- Update Telegram plugin to use `parseTimestamp` for relative times, job sorting, and schedule `next_run` formatting so Telegram outputs match UI timing.
- Add a small UI-side helper `parseApiDate` (`packages/ui/src/lib/datetime.ts`) that normalizes API timestamps and switch key UI pages/components (Inbox, Jobs, Schedules, Tasks, Memory, Timeline, Settings, Thread sidebar, Belief card, Job list, etc.) to use it when parsing server timestamps.
- Add unit tests that cover SQLite timestamp normalization and parsing (`packages/core/test/timezone.test.ts`) and update `CHANGELOG.md` to document the fix.

### Testing
- Ran `pnpm --filter @personal-ai/core test -- timezone.test.ts`; all timezone tests passed.
- Built the UI with `pnpm --filter @personal-ai/ui build`; build succeeded and produced the production bundle.
- Ran `pnpm --filter @personal-ai/plugin-telegram test`; this failed in the current environment due to Vite/Vitest workspace package entry resolution for `@personal-ai/core` (module entry resolution issue in the test harness), not due to timestamp logic itself.
- Attempting to start the server with `pnpm start` failed in this environment because `packages/server/dist/index.js` is not present (build artifact missing), so end-to-end runtime verification on a running server was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a693ea9f20832fb040119655191f35)