### PR TITLE
Fix Telegram displaying raw JSON for array responses

### DIFF
--- a/packages/plugin-telegram/src/formatter.ts
+++ b/packages/plugin-telegram/src/formatter.ts
@@ -198,7 +198,17 @@ export function formatTelegramResponse(text: string): string {
       if (parsed.length === 0) return text;
       const lines: string[] = ["**Results**"];
       for (const item of parsed) {
-        lines.push(`- ${isRecord(item) ? JSON.stringify(item) : formatPrimitive(item)}`);
+        if (isRecord(item)) {
+          // Format each object as a readable block with key-value pairs
+          const summary = Object.entries(item)
+            .filter(([, v]) => v === null || ["string", "number", "boolean"].includes(typeof v))
+            .slice(0, 6)
+            .map(([k, v]) => `**${humanizeKey(k)}:** ${formatPrimitive(v)}`)
+            .join(" | ");
+          lines.push(`- ${summary || "(complex item)"}`);
+        } else {
+          lines.push(`- ${formatPrimitive(item)}`);
+        }
       }
       return lines.join("\n");
     }

--- a/packages/plugin-telegram/test/formatter.test.ts
+++ b/packages/plugin-telegram/test/formatter.test.ts
@@ -50,6 +50,21 @@ describe("formatTelegramResponse", () => {
     const input = '{"ticker":"AMZN"';
     expect(formatTelegramResponse(input)).toBe(input);
   });
+
+  it("formats JSON arrays of objects as readable text, not raw JSON", () => {
+    const input = JSON.stringify([
+      { ticker: "AAPL", price: 185.5, change: "+2.3%" },
+      { ticker: "MSFT", price: 412.0, change: "-0.5%" },
+    ]);
+    const output = formatTelegramResponse(input);
+    expect(output).toContain("**Results**");
+    expect(output).toContain("**Ticker:** AAPL");
+    expect(output).toContain("**Price:** 185.5");
+    expect(output).toContain("**Ticker:** MSFT");
+    // Must NOT contain raw JSON
+    expect(output).not.toContain('{"ticker"');
+    expect(output).not.toContain('"price":');
+  });
 });
 describe("formatBriefingHTML", () => {
   it("formats full sections with all fields", () => {


### PR DESCRIPTION
When the LLM returned a JSON array of objects (e.g. stock tickers, search results), formatTelegramResponse used JSON.stringify on each item, sending raw JSON to users. Now formats array items as readable key-value pairs using the existing humanizeKey/formatPrimitive helpers.

https://claude.ai/code/session_01Uj2HP6a14vfiEJEwfxBa2v