### PR TITLE
Add document upload/analysis to Knowledge and export actions for research reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Document upload + analysis** — Added `/api/knowledge/upload` and Knowledge UI flow to upload text-based docs (`.txt`, `.md`, `.csv`, `.json`, `.xml`, `.html`), index them into the knowledge base, and generate a quick AI analysis summary
+- **Research export actions** — Research detail view now supports direct export to Markdown/JSON and print-to-PDF for sharing reports
 - **`/jobs` command** — View recent research and swarm job status directly from Telegram with status emojis and relative timestamps
 - **`/research` command** — Start research directly from Telegram with `/research <query>` shortcut
 - **Memory Curator delegation** — Telegram assistant can now delegate to the Memory Curator sub-agent for memory health analysis and fixes

--- a/packages/server/src/routes/knowledge.ts
+++ b/packages/server/src/routes/knowledge.ts
@@ -20,12 +20,63 @@ const learnSchema = z.object({
   force: z.boolean().optional(),
 });
 
+const uploadSchema = z.object({
+  fileName: z.string().min(1, "File name is required").max(255, "File name too long"),
+  content: z.string().min(1, "File content is required").max(2_000_000, "File too large (max 2MB text)"),
+  mimeType: z.string().optional(),
+  analyze: z.boolean().optional(),
+});
+
 const patchSourceSchema = z.object({
   tags: z.string().nullable().optional(),
   maxAgeDays: z.number().int().positive().nullable().optional(),
 });
 
 export function registerKnowledgeRoutes(app: FastifyInstance, { ctx }: ServerContext): void {
+  // Learn from uploaded plain-text document
+  app.post<{ Body: { fileName: string; content: string; mimeType?: string; analyze?: boolean } }>("/api/knowledge/upload", async (request, reply) => {
+    const { fileName, content, mimeType, analyze } = validate(uploadSchema, request.body);
+    const ext = fileName.split(".").pop()?.toLowerCase();
+    const supported = new Set(["txt", "md", "markdown", "csv", "json", "xml", "html"]);
+    if (ext && !supported.has(ext)) {
+      return reply.status(415).send({
+        error: "Unsupported file type. Please upload a text-based document (.txt, .md, .csv, .json, .xml, .html)",
+      });
+    }
+
+    const safeName = fileName.replace(/[^a-zA-Z0-9._-]+/g, "-").slice(0, 120);
+    const sourceUrl = `upload://${Date.now()}-${safeName}`;
+
+    try {
+      const result = await learnFromContent(ctx.storage, ctx.llm, sourceUrl, fileName, content, { force: true });
+      let analysis: string | undefined;
+      if (analyze) {
+        const snippet = content.length > 12_000 ? `${content.slice(0, 12_000)}\n\n[truncated]` : content;
+        const response = await ctx.llm.chat([
+          {
+            role: "system",
+            content: "You analyze uploaded documents. Return concise markdown with: Summary, Key points (3-7 bullets), and Suggested follow-up questions.",
+          },
+          {
+            role: "user",
+            content: `Analyze this document. File: ${fileName}. MIME: ${mimeType ?? "unknown"}\n\n${snippet}`,
+          },
+        ]);
+        analysis = response.text;
+      }
+
+      return {
+        ok: true,
+        title: result.source.title,
+        sourceId: result.source.id,
+        chunks: result.chunksStored,
+        analysis,
+      };
+    } catch (err) {
+      return reply.status(500).send({ error: err instanceof Error ? err.message : "Failed to process uploaded document" });
+    }
+  });
+
   // List learned sources
   app.get("/api/knowledge/sources", async () => {
     return listSources(ctx.storage).map((s) => ({

--- a/packages/ui/src/api.ts
+++ b/packages/ui/src/api.ts
@@ -281,6 +281,14 @@ export function learnFromUrl(url: string, options?: { crawl?: boolean; force?: b
   });
 }
 
+
+export function uploadKnowledgeDocument(input: { fileName: string; content: string; mimeType?: string; analyze?: boolean }): Promise<{ ok: boolean; title: string; sourceId: string; chunks: number; analysis?: string }> {
+  return request("/knowledge/upload", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
 export function crawlSubPages(sourceId: string): Promise<{ ok: boolean; subPages: number; crawling?: boolean; message?: string }> {
   return request(`/knowledge/sources/${sourceId}/crawl`, {
     method: "POST",

--- a/packages/ui/src/hooks/use-knowledge.ts
+++ b/packages/ui/src/hooks/use-knowledge.ts
@@ -3,6 +3,7 @@ import {
   getKnowledgeSources,
   searchKnowledge,
   learnFromUrl,
+  uploadKnowledgeDocument,
   crawlSubPages,
   getCrawlStatus,
   getSourceChunks,
@@ -59,6 +60,17 @@ export function useLearnFromUrl() {
       url: string;
       options?: { crawl?: boolean; force?: boolean };
     }) => learnFromUrl(input.url, input.options),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: knowledgeKeys.all });
+    },
+  });
+}
+
+
+export function useUploadKnowledgeDocument() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { fileName: string; content: string; mimeType?: string; analyze?: boolean }) => uploadKnowledgeDocument(input),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: knowledgeKeys.all });
     },

--- a/packages/ui/src/pages/Inbox.tsx
+++ b/packages/ui/src/pages/Inbox.tsx
@@ -24,9 +24,50 @@ import {
   ChevronUpIcon,
   LoaderIcon,
   MessageSquarePlusIcon,
+  FileTextIcon,
+  FileJsonIcon,
+  PrinterIcon,
 } from "lucide-react";
 
 const STORAGE_KEY = "pai-inbox-read";
+
+
+function saveBlob(content: string, type: string, filename: string): void {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function exportResearch(sections: { goal?: string; report?: string }, format: "md" | "txt" | "json"): void {
+  const nameBase = (sections.goal ?? "research-report").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 80) || "research-report";
+  const report = sections.report ?? "";
+  if (format === "json") {
+    saveBlob(JSON.stringify({ goal: sections.goal ?? "Research Report", report }, null, 2), "application/json", `${nameBase}.json`);
+    return;
+  }
+  if (format === "txt") {
+    saveBlob(`Goal: ${sections.goal ?? "Research Report"}
+
+${report}`, "text/plain;charset=utf-8", `${nameBase}.txt`);
+    return;
+  }
+  saveBlob(`# ${sections.goal ?? "Research Report"}
+
+${report}`, "text/markdown;charset=utf-8", `${nameBase}.md`);
+}
+
+function printResearchAsPdf(sections: { goal?: string; report?: string }): void {
+  const w = window.open("", "_blank", "noopener,noreferrer,width=900,height=700");
+  if (!w) return;
+  w.document.write(`<html><head><title>${sections.goal ?? "Research Report"}</title></head><body><h1>${sections.goal ?? "Research Report"}</h1><pre style="white-space:pre-wrap;font-family:system-ui">${(sections.report ?? "").replace(/</g, "&lt;")}</pre></body></html>`);
+  w.document.close();
+  w.focus();
+  w.print();
+}
 
 function loadReadIds(): Set<string> {
   try {
@@ -185,21 +226,50 @@ function InboxDetail({ id }: { id: string }) {
           </Button>
           <div className="flex items-center gap-2">
             {item?.type === "research" && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  rerunMutation.mutate(id, {
-                    onSuccess: () => toast.success("Research rerun started"),
-                    onError: () => toast.error("Failed to rerun research"),
-                  });
-                }}
-                disabled={rerunMutation.isPending}
-                className="gap-2"
-              >
-                <RefreshCwIcon className={`h-3 w-3 ${rerunMutation.isPending ? "animate-spin" : ""}`} />
-                Rerun
-              </Button>
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => exportResearch(sections, "md")}
+                  className="gap-2"
+                >
+                  <FileTextIcon className="h-3 w-3" />
+                  .md
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => exportResearch(sections, "json")}
+                  className="gap-2"
+                >
+                  <FileJsonIcon className="h-3 w-3" />
+                  .json
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => printResearchAsPdf(sections)}
+                  className="gap-2"
+                >
+                  <PrinterIcon className="h-3 w-3" />
+                  PDF
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    rerunMutation.mutate(id, {
+                      onSuccess: () => toast.success("Research rerun started"),
+                      onError: () => toast.error("Failed to rerun research"),
+                    });
+                  }}
+                  disabled={rerunMutation.isPending}
+                  className="gap-2"
+                >
+                  <RefreshCwIcon className={`h-3 w-3 ${rerunMutation.isPending ? "animate-spin" : ""}`} />
+                  Rerun
+                </Button>
+              </>
             )}
             <Button
               variant="outline"

--- a/packages/ui/src/pages/Knowledge.tsx
+++ b/packages/ui/src/pages/Knowledge.tsx
@@ -12,6 +12,7 @@ import {
   useCrawlStatus,
   useSourceChunks,
   useLearnFromUrl,
+  useUploadKnowledgeDocument,
   useCrawlSubPages,
   useDeleteKnowledgeSource,
   useReindexKnowledge,
@@ -27,7 +28,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Trash2Icon, ExternalLinkIcon, SearchIcon, PlusIcon, AlertTriangleIcon,
-  RefreshCwIcon, LoaderIcon, EyeIcon, GlobeIcon, TagIcon, CheckIcon,
+  RefreshCwIcon, LoaderIcon, EyeIcon, GlobeIcon, TagIcon, CheckIcon, UploadIcon, FileTextIcon,
   ChevronRightIcon,
 } from "lucide-react";
 import type { KnowledgeSource, KnowledgeSearchResult } from "../types";
@@ -54,6 +55,8 @@ export default function Knowledge() {
   // --- UI toggle / dialog state ---
   const [selectedSource, setSelectedSource] = useState<KnowledgeSource | null>(null);
   const [showLearnDialog, setShowLearnDialog] = useState(false);
+  const [showUploadDialog, setShowUploadDialog] = useState(false);
+  const [uploadFile, setUploadFile] = useState<File | null>(null);
   const [learnUrl, setLearnUrl] = useState("");
   const [learnCrawl, setLearnCrawl] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<KnowledgeSource | null>(null);
@@ -75,6 +78,7 @@ export default function Knowledge() {
 
   // --- Mutations ---
   const learnMutation = useLearnFromUrl();
+  const uploadMutation = useUploadKnowledgeDocument();
   const crawlSubPagesMutation = useCrawlSubPages();
   const deleteMutation = useDeleteKnowledgeSource();
   const reindexMutation = useReindexKnowledge();
@@ -116,6 +120,26 @@ export default function Knowledge() {
       }
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to learn from URL");
+    }
+  };
+
+  const handleUploadDocument = async () => {
+    if (!uploadFile) return;
+    try {
+      const content = await uploadFile.text();
+      const result = await uploadMutation.mutateAsync({
+        fileName: uploadFile.name,
+        mimeType: uploadFile.type || undefined,
+        content,
+        analyze: true,
+      });
+      toast.success(`Uploaded "${result.title}" - ${result.chunks} chunks`);
+      if (result.analysis) {
+        toast.info("Document analysis is ready in the upload dialog.");
+      }
+      setShowUploadDialog(true);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to upload document");
     }
   };
 
@@ -205,6 +229,7 @@ export default function Knowledge() {
   const isCrawling = crawlSubPagesMutation.isPending;
   const isReindexing = reindexMutation.isPending;
   const isLearning = learnMutation.isPending;
+  const isUploading = uploadMutation.isPending;
 
   const allTags = [...new Set(sources.flatMap((s) => parseTags(s.tags)))];
 
@@ -268,6 +293,14 @@ export default function Knowledge() {
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>Learn from URL</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="ghost" size="icon-xs" onClick={() => setShowUploadDialog(true)}>
+                    <UploadIcon className="size-4 text-muted-foreground" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Upload document</TooltipContent>
               </Tooltip>
             </div>
           </div>
@@ -591,6 +624,47 @@ export default function Knowledge() {
           </div>
         </DialogContent>
       </Dialog>
+
+      <Dialog open={showUploadDialog} onOpenChange={setShowUploadDialog}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle className="text-sm">Upload Document</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <p className="text-xs text-muted-foreground">
+              Upload a text-based document (.txt, .md, .csv, .json, .xml, .html). We will index it and generate a quick analysis.
+            </p>
+            <label className="flex cursor-pointer items-center justify-center gap-2 rounded-lg border border-dashed border-border/60 bg-card/30 px-3 py-6 text-xs text-muted-foreground hover:border-primary/40">
+              <FileTextIcon className="size-4" />
+              <span>{uploadFile ? uploadFile.name : "Choose file"}</span>
+              <input
+                type="file"
+                className="hidden"
+                accept=".txt,.md,.markdown,.csv,.json,.xml,.html"
+                onChange={(e) => setUploadFile(e.target.files?.[0] ?? null)}
+                disabled={isUploading}
+              />
+            </label>
+            {(uploadMutation.data?.analysis) && (
+              <div className="rounded-lg border border-border/40 bg-card/30 p-3">
+                <p className="mb-2 text-xs font-medium text-foreground">Analysis</p>
+                <ScrollArea className="max-h-48">
+                  <pre className="whitespace-pre-wrap text-xs text-muted-foreground">{uploadMutation.data.analysis}</pre>
+                </ScrollArea>
+              </div>
+            )}
+            <div className="flex justify-end gap-2">
+              <Button variant="ghost" size="sm" onClick={() => setShowUploadDialog(false)} disabled={isUploading}>
+                Close
+              </Button>
+              <Button size="sm" onClick={handleUploadDocument} disabled={isUploading || !uploadFile}>
+                {isUploading ? "Uploading..." : "Upload & Analyze"}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
 
       <Dialog open={!!showDeleteConfirm} onOpenChange={() => setShowDeleteConfirm(null)}>
         <DialogContent className="max-w-sm">


### PR DESCRIPTION
### Motivation

- Provide users a simple way to upload text-based documents into the knowledge base and get quick AI-driven analysis so uploaded docs can be searched and reused by agents. 
- Allow researchers to export/share research briefings (Markdown/JSON/PDF print) directly from the Inbox detail view.

### Description

- Server: added `POST /api/knowledge/upload` in `packages/server/src/routes/knowledge.ts` that validates text-based files (`.txt,.md,.csv,.json,.xml,.html`), calls `learnFromContent()` to index content as a knowledge source, and optionally runs an LLM analysis (summary, key points, follow-ups) when `analyze` is requested. 
- UI API & hooks: added `uploadKnowledgeDocument()` to `packages/ui/src/api.ts` and `useUploadKnowledgeDocument()` to `packages/ui/src/hooks/use-knowledge.ts` to wire the new endpoint and invalidate the knowledge cache on success. 
- Knowledge page: added upload button and dialog (file picker, supported formats), `Upload & Analyze` action, and inline display of returned LLM analysis in `packages/ui/src/pages/Knowledge.tsx`. 
- Inbox (research detail): added client-side export helpers to download research reports as `.md`/`.txt`/`.json` and a print-to-PDF flow in `packages/ui/src/pages/Inbox.tsx`. 
- Documentation: updated `CHANGELOG.md` to document the new upload/analysis and report export features.

### Testing

- Ran a full monorepo build with `pnpm build`, which completed successfully. 
- Built UI specifically with `pnpm --filter @personal-ai/ui build`, which succeeded and produced the production assets. 
- Attempted server typecheck with `pnpm --filter @personal-ai/server typecheck`, which failed in this environment due to workspace module type-resolution issues (errors referencing missing workspace module type declarations). 
- Attempted to call the running server from Playwright to capture a UI screenshot but the browser run could not connect to `:3141` (`ERR_EMPTY_RESPONSE`). 
- Attempted `pnpm pai memory remember ...` for an internal note but it failed because the configured LLM sidecar (Ollama) is not running in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a750c3016c832fac237de7e96a372d)