### PR TITLE
feat: guided onboarding wizard with LLM setup

### DIFF
--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -7,28 +7,53 @@ import type { Config } from "@personal-ai/core";
 
 type Provider = Config["llm"]["provider"];
 
-const PROVIDER_DEFAULTS: Record<Provider, { model: string; baseUrl: string; embedModel: string }> = {
+interface ProviderPreset {
+  provider: Provider;
+  model: string;
+  baseUrl: string;
+  embedModel: string;
+  needsKey: boolean;
+}
+
+export const PROVIDER_PRESETS: Record<string, ProviderPreset> = {
   ollama: {
+    provider: "ollama",
     model: "llama3.2",
     baseUrl: "http://127.0.0.1:11434",
     embedModel: "nomic-embed-text",
+    needsKey: false,
+  },
+  "ollama-cloud": {
+    provider: "openai",
+    model: "glm-5",
+    baseUrl: "https://ollama.com/v1",
+    embedModel: "nomic-embed-text",
+    needsKey: true,
   },
   openai: {
+    provider: "openai",
     model: "gpt-4o",
     baseUrl: "https://api.openai.com/v1",
     embedModel: "text-embedding-3-small",
+    needsKey: true,
   },
   anthropic: {
+    provider: "anthropic",
     model: "claude-sonnet-4-20250514",
     baseUrl: "https://api.anthropic.com",
     embedModel: "text-embedding-3-small",
+    needsKey: true,
   },
   google: {
+    provider: "google",
     model: "gemini-2.0-flash",
     baseUrl: "https://generativelanguage.googleapis.com/v1beta",
     embedModel: "text-embedding-004",
+    needsKey: true,
   },
 };
+
+const VALID_CHOICES = Object.keys(PROVIDER_PRESETS);
 
 function ask(rl: ReturnType<typeof createInterface>, question: string): Promise<string> {
   return new Promise((resolve) => {
@@ -46,22 +71,22 @@ export function createInitCommand(): Command {
         console.log("\n  pai init — Configure your persistent AI memory\n");
 
         // 1. Provider
-        const providerInput = await ask(rl, `  LLM provider (ollama/openai/anthropic/google) [ollama]: `);
-        const provider: Provider = (["ollama", "openai", "anthropic", "google"].includes(providerInput) ? providerInput : "ollama") as Provider;
-        const defaults = PROVIDER_DEFAULTS[provider];
+        const providerInput = await ask(rl, `  LLM provider (${VALID_CHOICES.join("/")}) [ollama]: `);
+        const choice = VALID_CHOICES.includes(providerInput) ? providerInput : "ollama";
+        const preset = PROVIDER_PRESETS[choice]!;
 
         // 2. Model
-        const modelInput = await ask(rl, `  Model name [${defaults.model}]: `);
-        const model = modelInput || defaults.model;
+        const modelInput = await ask(rl, `  Model name [${preset.model}]: `);
+        const model = modelInput || preset.model;
 
         // 3. Base URL
-        const baseUrlInput = await ask(rl, `  Base URL [${defaults.baseUrl}]: `);
-        const baseUrl = baseUrlInput || defaults.baseUrl;
+        const baseUrlInput = await ask(rl, `  Base URL [${preset.baseUrl}]: `);
+        const baseUrl = baseUrlInput || preset.baseUrl;
 
-        // 4. API key (for openai/anthropic)
+        // 4. API key
         let apiKey: string | undefined;
-        if (provider === "openai" || provider === "anthropic") {
-          const keyInput = await ask(rl, `  API key (required for ${provider}): `);
+        if (preset.needsKey) {
+          const keyInput = await ask(rl, `  API key (required for ${choice}): `);
           apiKey = keyInput || undefined;
           if (!apiKey) {
             console.log("\n  Warning: No API key provided. You can set PAI_LLM_API_KEY later.\n");
@@ -69,16 +94,15 @@ export function createInitCommand(): Command {
         }
 
         // 5. Embed model
-        const embedInput = await ask(rl, `  Embedding model [${defaults.embedModel}]: `);
-        const embedModel = embedInput || defaults.embedModel;
+        const embedInput = await ask(rl, `  Embedding model [${preset.embedModel}]: `);
+        const embedModel = embedInput || preset.embedModel;
 
-        // Close readline before health check (so we don't block on input)
         rl.close();
 
         // 6. Validate connection
-        console.log(`\n  Checking ${provider} connection...`);
+        console.log(`\n  Checking ${choice} connection...`);
         const llmConfig: Config["llm"] = {
-          provider,
+          provider: preset.provider,
           model,
           baseUrl,
           apiKey,
@@ -89,17 +113,14 @@ export function createInitCommand(): Command {
         const healthResult = await llm.health();
 
         if (healthResult.ok) {
-          console.log(`  Connected to ${provider} successfully.\n`);
+          console.log(`  Connected to ${choice} successfully.\n`);
         } else {
-          console.log(`  Warning: Could not connect to ${provider}. Config will be saved anyway.\n`);
+          console.log(`  Warning: Could not connect to ${choice}. Config will be saved anyway.\n`);
         }
 
         // 7. Write config file
         const dataDir = join(homedir(), ".personal-ai");
-        const configToWrite: Partial<Config> = {
-          llm: llmConfig,
-        };
-        writeConfig(dataDir, configToWrite);
+        writeConfig(dataDir, { llm: llmConfig } as Partial<Config>);
 
         // 8. Success
         console.log(`  Configuration saved to ${join(dataDir, "config.json")}`);

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { PROVIDER_PRESETS } from "../src/init.js";
+
+describe("pai init PROVIDER_PRESETS", () => {
+  it("includes ollama-cloud with correct base URL", () => {
+    const preset = PROVIDER_PRESETS["ollama-cloud"];
+    expect(preset).toBeDefined();
+    expect(preset.baseUrl).toBe("https://ollama.com/v1");
+    expect(preset.model).toBe("glm-5");
+    expect(preset.provider).toBe("openai");
+    expect(preset.needsKey).toBe(true);
+  });
+
+  it("includes all expected providers", () => {
+    const keys = Object.keys(PROVIDER_PRESETS);
+    expect(keys).toContain("ollama");
+    expect(keys).toContain("ollama-cloud");
+    expect(keys).toContain("openai");
+    expect(keys).toContain("anthropic");
+    expect(keys).toContain("google");
+  });
+
+  it("ollama local does not require a key", () => {
+    expect(PROVIDER_PRESETS.ollama.needsKey).toBe(false);
+  });
+
+  it("all cloud providers require a key", () => {
+    for (const [name, preset] of Object.entries(PROVIDER_PRESETS)) {
+      if (name === "ollama") continue;
+      expect(preset.needsKey).toBe(true);
+    }
+  });
+
+  it("all presets have valid base URLs", () => {
+    for (const preset of Object.values(PROVIDER_PRESETS)) {
+      expect(() => new URL(preset.baseUrl)).not.toThrow();
+    }
+  });
+});

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -3,7 +3,7 @@ import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
-import { writeConfig, loadConfigFile } from "@personal-ai/core";
+import { writeConfig, loadConfigFile, createLLMClient } from "@personal-ai/core";
 import type { Storage } from "@personal-ai/core";
 import type { ServerContext } from "../index.js";
 import { validate } from "../validate.js";
@@ -259,6 +259,29 @@ export function registerConfigRoutes(app: FastifyInstance, serverCtx: ServerCont
     }
 
     return sanitizeConfig(serverCtx.ctx.config as never);
+  });
+
+  // Test LLM config without saving — used by the setup wizard
+  const testConfigSchema = z.object({
+    provider: z.enum(["ollama", "openai", "anthropic", "google"]),
+    model: z.string().min(1),
+    baseUrl: z.string().url(),
+    apiKey: z.string().optional(),
+    embedModel: z.string().optional(),
+  });
+
+  app.post("/api/config/test", async (request) => {
+    const body = validate(testConfigSchema, request.body);
+    const testLlm = createLLMClient({
+      provider: body.provider,
+      model: body.model,
+      baseUrl: body.baseUrl,
+      apiKey: body.apiKey,
+      embedModel: body.embedModel ?? "nomic-embed-text",
+      fallbackMode: "local-first",
+    });
+    const result = await testLlm.health();
+    return { ok: result.ok, provider: result.provider };
   });
 
   // Directory browser endpoint for the UI — restricted to home directory

--- a/packages/server/src/workers.ts
+++ b/packages/server/src/workers.ts
@@ -44,21 +44,27 @@ export class WorkerLoop {
     if (this.running) return;
     this.running = true;
 
+    const isLLMConfigured = !!this.ctx.config.llm.apiKey || this.ctx.config.llm.provider === "ollama";
+
     const briefingMs = this.options?.briefingIntervalMs ?? DEFAULT_BRIEFING_INTERVAL_MS;
     const scheduleMs = this.options?.scheduleCheckIntervalMs ?? DEFAULT_SCHEDULE_CHECK_INTERVAL_MS;
     const learningMs = this.options?.learningIntervalMs ?? DEFAULT_LEARNING_INTERVAL_MS;
     const learningDelayMs = this.options?.learningInitialDelayMs ?? DEFAULT_LEARNING_INITIAL_DELAY_MS;
     const generateInitial = this.options?.generateInitialBriefing ?? true;
 
+    if (!isLLMConfigured) {
+      this.ctx.logger.info("LLM not configured — skipping background briefing and learning. Configure in Settings.");
+    }
+
     // --- Briefing generator ---
     this.briefingTimer = setInterval(() => {
-      if (this.ctx.config.workers?.briefing === false) return;
+      if (this.ctx.config.workers?.briefing === false || !isLLMConfigured) return;
       generateBriefing(this.ctx).catch((err) => {
         this.ctx.logger.warn(`Background briefing failed: ${err instanceof Error ? err.message : String(err)}`);
       });
     }, briefingMs);
 
-    if (generateInitial && this.ctx.config.workers?.briefing !== false) {
+    if (generateInitial && isLLMConfigured && this.ctx.config.workers?.briefing !== false) {
       const latest = getLatestBriefing(this.ctx.storage);
       if (!latest) {
         generateBriefing(this.ctx).catch((err) => {
@@ -74,14 +80,14 @@ export class WorkerLoop {
 
     // --- Background learning ---
     this.learningInitTimer = setTimeout(() => {
-      if (this.ctx.config.workers?.backgroundLearning === false) return;
+      if (this.ctx.config.workers?.backgroundLearning === false || !isLLMConfigured) return;
       runBackgroundLearning(this.ctx, this.abortController.signal).catch((err) => {
         this.ctx.logger.warn(`Background learning failed: ${err instanceof Error ? err.message : String(err)}`);
       });
     }, learningDelayMs);
 
     this.learningTimer = setInterval(() => {
-      if (this.ctx.config.workers?.backgroundLearning === false) return;
+      if (this.ctx.config.workers?.backgroundLearning === false || !isLLMConfigured) return;
       runBackgroundLearning(this.ctx, this.abortController.signal).catch((err) => {
         this.ctx.logger.warn(`Background learning failed: ${err instanceof Error ? err.message : String(err)}`);
       });

--- a/packages/server/test/routes.test.ts
+++ b/packages/server/test/routes.test.ts
@@ -61,6 +61,7 @@ vi.mock("@personal-ai/core", async (importOriginal) => {
     loadConfigFile: (...args: unknown[]) => mockLoadConfigFile(...args),
     getArtifact: (...args: unknown[]) => mockGetArtifact(...args),
     listArtifacts: (...args: unknown[]) => mockListArtifacts(...args),
+    createLLMClient: (...args: unknown[]) => mockCreateLLMClient(...args),
   };
 });
 
@@ -78,6 +79,9 @@ const mockGetJwtSecret = vi.fn().mockReturnValue("test-secret-key-for-jwt-testin
 // ---------------------------------------------------------------------------
 const mockWriteConfig = vi.fn();
 const mockLoadConfigFile = vi.fn().mockReturnValue({});
+const mockCreateLLMClient = vi.fn().mockReturnValue({
+  health: vi.fn().mockResolvedValue({ ok: true, provider: "openai" }),
+});
 
 // ---------------------------------------------------------------------------
 // Background jobs mock functions
@@ -1807,6 +1811,93 @@ describe("Config routes", () => {
     const body = res.json();
     expect(body.error).toMatch(/Invalid enum value/);
     // Should not write config or reinitialize on validation error
+    expect(mockWriteConfig).not.toHaveBeenCalled();
+    expect(serverCtx.reinitialize).not.toHaveBeenCalled();
+  });
+
+  // -- POST /api/config/test ------------------------------------------------
+
+  it("POST /api/config/test returns ok for valid config", async () => {
+    mockCreateLLMClient.mockReturnValue({
+      health: vi.fn().mockResolvedValue({ ok: true, provider: "openai" }),
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/config/test",
+      payload: {
+        provider: "openai",
+        model: "glm-5",
+        baseUrl: "https://ollama.com/v1",
+        apiKey: "test-key",
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.ok).toBe(true);
+    expect(body.provider).toBe("openai");
+  });
+
+  it("POST /api/config/test returns not ok for failed health check", async () => {
+    mockCreateLLMClient.mockReturnValue({
+      health: vi.fn().mockResolvedValue({ ok: false, provider: "openai" }),
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/config/test",
+      payload: {
+        provider: "openai",
+        model: "gpt-4o",
+        baseUrl: "https://api.openai.com/v1",
+        apiKey: "bad-key",
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().ok).toBe(false);
+  });
+
+  it("POST /api/config/test rejects missing required fields", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/config/test",
+      payload: { provider: "openai" },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("POST /api/config/test rejects invalid provider", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/config/test",
+      payload: {
+        provider: "invalid",
+        model: "test",
+        baseUrl: "https://example.com",
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("POST /api/config/test does not write config", async () => {
+    mockCreateLLMClient.mockReturnValue({
+      health: vi.fn().mockResolvedValue({ ok: true, provider: "ollama" }),
+    });
+
+    await app.inject({
+      method: "POST",
+      url: "/api/config/test",
+      payload: {
+        provider: "ollama",
+        model: "llama3.2",
+        baseUrl: "http://127.0.0.1:11434",
+      },
+    });
+
     expect(mockWriteConfig).not.toHaveBeenCalled();
     expect(serverCtx.reinitialize).not.toHaveBeenCalled();
   });

--- a/packages/server/test/workers.test.ts
+++ b/packages/server/test/workers.test.ts
@@ -42,7 +42,7 @@ vi.mock("@personal-ai/plugin-assistant/page-fetch", () => ({
 
 function createMockCtx(): PluginContext {
   return {
-    config: { dataDir: "/tmp", llm: {}, plugins: [], logLevel: "silent" },
+    config: { dataDir: "/tmp", llm: { provider: "ollama" }, plugins: [], logLevel: "silent" },
     storage: {
       query: vi.fn().mockReturnValue([]),
       run: vi.fn(),

--- a/packages/ui/src/api.ts
+++ b/packages/ui/src/api.ts
@@ -326,6 +326,19 @@ export function getConfig(): Promise<ConfigInfo> {
   return request<ConfigInfo>("/config");
 }
 
+export function testConfig(config: {
+  provider: string;
+  model: string;
+  baseUrl: string;
+  apiKey?: string;
+  embedModel?: string;
+}): Promise<{ ok: boolean; provider: string }> {
+  return request<{ ok: boolean; provider: string }>("/config/test", {
+    method: "POST",
+    body: JSON.stringify(config),
+  });
+}
+
 export function updateConfig(updates: {
   provider?: string;
   model?: string;

--- a/packages/ui/src/components/LLMSetupWizard.tsx
+++ b/packages/ui/src/components/LLMSetupWizard.tsx
@@ -1,0 +1,296 @@
+import { useState } from "react";
+import { testConfig, updateConfig } from "../api";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { CheckCircleIcon, XCircleIcon, LoaderIcon, ExternalLinkIcon, MonitorIcon, CloudIcon } from "lucide-react";
+
+const isCloudDeployment =
+  typeof window !== "undefined" &&
+  window.location.hostname !== "localhost" &&
+  window.location.hostname !== "127.0.0.1";
+
+type ProviderKey = "ollama-local" | "ollama-cloud" | "openai" | "anthropic" | "google";
+
+const PROVIDERS: Record<ProviderKey, {
+  label: string;
+  description: string;
+  provider: string;
+  baseUrl: string;
+  model: string;
+  embedModel: string;
+  needsKey: boolean;
+  keyUrl?: string;
+  badge?: string;
+}> = {
+  "ollama-local": {
+    label: "Ollama (local)",
+    description: "Free & private — runs on your machine",
+    provider: "ollama",
+    baseUrl: "http://127.0.0.1:11434",
+    model: "llama3.2",
+    embedModel: "nomic-embed-text",
+    needsKey: false,
+  },
+  "ollama-cloud": {
+    label: "Ollama Cloud",
+    description: "Free — GLM-5, great at tool calling",
+    provider: "openai",
+    baseUrl: "https://ollama.com/v1",
+    model: "glm-5",
+    embedModel: "nomic-embed-text",
+    needsKey: true,
+    keyUrl: "https://ollama.com",
+    badge: "Free",
+  },
+  openai: {
+    label: "OpenAI",
+    description: "GPT-4o — fast and reliable",
+    provider: "openai",
+    baseUrl: "https://api.openai.com/v1",
+    model: "gpt-4o",
+    embedModel: "text-embedding-3-small",
+    needsKey: true,
+    keyUrl: "https://platform.openai.com/api-keys",
+  },
+  anthropic: {
+    label: "Anthropic",
+    description: "Claude Sonnet — strong reasoning",
+    provider: "anthropic",
+    baseUrl: "https://api.anthropic.com",
+    model: "claude-sonnet-4-20250514",
+    embedModel: "text-embedding-3-small",
+    needsKey: true,
+    keyUrl: "https://console.anthropic.com/settings/keys",
+  },
+  google: {
+    label: "Google AI",
+    description: "Gemini 2.0 Flash — fast, free tier",
+    provider: "google",
+    baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+    model: "gemini-2.0-flash",
+    embedModel: "text-embedding-004",
+    needsKey: true,
+    keyUrl: "https://aistudio.google.com/apikey",
+    badge: "Free tier",
+  },
+};
+
+type Step = "mode" | "provider" | "apikey" | "local-guide";
+
+interface Props {
+  onComplete: () => void;
+  onSkip?: () => void;
+}
+
+export default function LLMSetupWizard({ onComplete, onSkip }: Props) {
+  const [step, setStep] = useState<Step>(isCloudDeployment ? "provider" : "mode");
+  const [selected, setSelected] = useState<ProviderKey | null>(null);
+  const [apiKey, setApiKey] = useState("");
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ ok: boolean; error?: string } | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const preset = selected ? PROVIDERS[selected] : null;
+
+  const handleSelectMode = (mode: "local" | "cloud") => {
+    if (mode === "local") {
+      setSelected("ollama-local");
+      setStep("local-guide");
+    } else {
+      setStep("provider");
+    }
+  };
+
+  const handleSelectProvider = (key: ProviderKey) => {
+    setSelected(key);
+    setTestResult(null);
+    setApiKey("");
+    if (PROVIDERS[key].needsKey) {
+      setStep("apikey");
+    } else {
+      setStep("local-guide");
+    }
+  };
+
+  const handleTest = async () => {
+    if (!preset) return;
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const result = await testConfig({
+        provider: preset.provider,
+        model: preset.model,
+        baseUrl: preset.baseUrl,
+        apiKey: apiKey || undefined,
+        embedModel: preset.embedModel,
+      });
+      setTestResult({ ok: result.ok });
+    } catch (err) {
+      setTestResult({ ok: false, error: err instanceof Error ? err.message : "Connection failed" });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!preset) return;
+    setSaving(true);
+    try {
+      await updateConfig({
+        provider: preset.provider,
+        model: preset.model,
+        baseUrl: preset.baseUrl,
+        embedModel: preset.embedModel,
+        apiKey: apiKey || undefined,
+      });
+      onComplete();
+    } catch {
+      setSaving(false);
+    }
+  };
+
+  // Mode selection: local vs cloud (only shown for local deployments)
+  if (step === "mode") {
+    return (
+      <div className="space-y-3">
+        <p className="text-center text-xs text-muted-foreground">How do you want to run your AI?</p>
+        <button type="button" onClick={() => handleSelectMode("local")} className="w-full text-left">
+          <Card className="cursor-pointer border-border/50 transition-colors hover:border-primary/50">
+            <CardContent className="flex items-start gap-3 p-4">
+              <MonitorIcon className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+              <div>
+                <div className="text-sm font-medium">Run locally</div>
+                <div className="text-xs text-muted-foreground">Free & private. Requires Ollama installed on your machine. Nothing leaves your computer.</div>
+              </div>
+            </CardContent>
+          </Card>
+        </button>
+        <button type="button" onClick={() => handleSelectMode("cloud")} className="w-full text-left">
+          <Card className="cursor-pointer border-border/50 transition-colors hover:border-primary/50">
+            <CardContent className="flex items-start gap-3 p-4">
+              <CloudIcon className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+              <div>
+                <div className="text-sm font-medium">Use a cloud provider</div>
+                <div className="text-xs text-muted-foreground">Faster, smarter models. Requires an API key.</div>
+              </div>
+            </CardContent>
+          </Card>
+        </button>
+        {onSkip && (
+          <button type="button" onClick={onSkip} className="w-full text-center text-xs text-muted-foreground hover:text-foreground">
+            Skip — configure later in Settings
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // Provider picker (cloud providers)
+  if (step === "provider") {
+    const cloudProviders: ProviderKey[] = ["ollama-cloud", "openai", "anthropic", "google"];
+    return (
+      <div className="space-y-3">
+        <p className="text-center text-xs text-muted-foreground">Pick your AI provider</p>
+        {cloudProviders.map((key) => {
+          const p = PROVIDERS[key];
+          return (
+            <button key={key} type="button" onClick={() => handleSelectProvider(key)} className="w-full text-left">
+              <Card className="cursor-pointer border-border/50 transition-colors hover:border-primary/50">
+                <CardContent className="flex items-center justify-between p-4">
+                  <div>
+                    <div className="text-sm font-medium">{p.label}</div>
+                    <div className="text-xs text-muted-foreground">{p.description}</div>
+                  </div>
+                  {p.badge && (
+                    <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">{p.badge}</span>
+                  )}
+                </CardContent>
+              </Card>
+            </button>
+          );
+        })}
+        {!isCloudDeployment && (
+          <button type="button" onClick={() => setStep("mode")} className="w-full text-center text-xs text-muted-foreground hover:text-foreground">
+            ← Back
+          </button>
+        )}
+        {onSkip && (
+          <button type="button" onClick={onSkip} className="w-full text-center text-xs text-muted-foreground hover:text-foreground">
+            Skip — configure later in Settings
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // Local Ollama guide
+  if (step === "local-guide") {
+    return (
+      <div className="space-y-4">
+        <p className="text-center text-xs text-muted-foreground">Set up Ollama on your machine</p>
+        <div className="space-y-2 rounded-md bg-muted/50 p-4 text-xs">
+          <p>1. Install Ollama from <a href="https://ollama.com/download" target="_blank" rel="noopener noreferrer" className="text-primary underline">ollama.com/download</a></p>
+          <p>2. Open a terminal and run:</p>
+          <pre className="rounded bg-background p-2 text-[11px]">ollama pull llama3.2{"\n"}ollama pull nomic-embed-text</pre>
+          <p>3. Make sure Ollama is running, then test below.</p>
+        </div>
+        <Button onClick={handleTest} disabled={testing} className="w-full" variant="outline">
+          {testing ? <><LoaderIcon className="mr-2 size-3 animate-spin" /> Testing...</> : "Test Connection"}
+        </Button>
+        {testResult && (
+          <div className={`flex items-center gap-2 rounded-md p-2 text-xs ${testResult.ok ? "bg-green-500/10 text-green-600" : "bg-destructive/10 text-destructive"}`}>
+            {testResult.ok ? <CheckCircleIcon className="size-4" /> : <XCircleIcon className="size-4" />}
+            {testResult.ok ? "Connected to Ollama!" : "Can't reach Ollama. Is it running?"}
+          </div>
+        )}
+        {testResult?.ok && (
+          <Button onClick={handleSave} disabled={saving} className="w-full">
+            {saving ? "Saving..." : "Continue"}
+          </Button>
+        )}
+        <button type="button" onClick={() => { setStep("mode"); setTestResult(null); }} className="w-full text-center text-xs text-muted-foreground hover:text-foreground">
+          ← Back
+        </button>
+      </div>
+    );
+  }
+
+  // API key entry + test
+  return (
+    <div className="space-y-4">
+      <p className="text-center text-xs text-muted-foreground">
+        Enter your {preset?.label} API key
+      </p>
+      {preset?.keyUrl && (
+        <a href={preset.keyUrl} target="_blank" rel="noopener noreferrer" className="flex items-center justify-center gap-1 text-xs text-primary hover:underline">
+          Get your key at {new URL(preset.keyUrl).hostname} <ExternalLinkIcon className="size-3" />
+        </a>
+      )}
+      <input
+        type="password"
+        value={apiKey}
+        onChange={(e) => { setApiKey(e.target.value); setTestResult(null); }}
+        placeholder="Paste your API key"
+        autoFocus
+        className="w-full rounded-md border border-border/50 bg-background px-3 py-2 text-sm text-foreground placeholder-muted-foreground/50 outline-none transition-colors focus:border-primary/50 focus:ring-1 focus:ring-primary/25"
+      />
+      <Button onClick={handleTest} disabled={testing || !apiKey.trim()} className="w-full" variant="outline">
+        {testing ? <><LoaderIcon className="mr-2 size-3 animate-spin" /> Testing...</> : "Test Connection"}
+      </Button>
+      {testResult && (
+        <div className={`flex items-center gap-2 rounded-md p-2 text-xs ${testResult.ok ? "bg-green-500/10 text-green-600" : "bg-destructive/10 text-destructive"}`}>
+          {testResult.ok ? <CheckCircleIcon className="size-4" /> : <XCircleIcon className="size-4" />}
+          {testResult.ok ? `Connected to ${preset?.label} successfully!` : (testResult.error ?? "Invalid key. Double-check and try again.")}
+        </div>
+      )}
+      {testResult?.ok && (
+        <Button onClick={handleSave} disabled={saving} className="w-full">
+          {saving ? "Saving..." : "Continue"}
+        </Button>
+      )}
+      <button type="button" onClick={() => { setStep(isCloudDeployment ? "provider" : "provider"); setTestResult(null); }} className="w-full text-center text-xs text-muted-foreground hover:text-foreground">
+        ← Back
+      </button>
+    </div>
+  );
+}

--- a/packages/ui/src/context/AuthContext.tsx
+++ b/packages/ui/src/context/AuthContext.tsx
@@ -32,6 +32,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const refresh = useCallback(async () => {
     try {
+      // If user explicitly signed out on localhost, stay signed out
+      if (localStorage.getItem("pai_signed_out")) {
+        setIsAuthenticated(false);
+        setOwner(null);
+        setNeedsSetup(false);
+        setLoading(false);
+        return;
+      }
+
       const status = await getAuthStatus();
       if (status.setup) {
         setNeedsSetup(true);
@@ -43,6 +52,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           setOwner(me);
           setIsAuthenticated(true);
           setNeedsSetup(false);
+          localStorage.removeItem("pai_signed_out");
         } catch {
           // getMe failed (e.g. token expired between status check and /me call)
           // Try refreshing the token and retry once
@@ -52,6 +62,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             setOwner(me);
             setIsAuthenticated(true);
             setNeedsSetup(false);
+            localStorage.removeItem("pai_signed_out");
           } catch {
             setIsAuthenticated(false);
             setOwner(null);
@@ -68,6 +79,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             setOwner(me);
             setIsAuthenticated(true);
             setNeedsSetup(false);
+            localStorage.removeItem("pai_signed_out");
           } else {
             setIsAuthenticated(false);
             setOwner(null);
@@ -115,6 +127,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(async () => {
     await apiLogout();
+    localStorage.setItem("pai_signed_out", "1");
     setIsAuthenticated(false);
     setOwner(null);
   }, []);

--- a/packages/ui/src/pages/Login.tsx
+++ b/packages/ui/src/pages/Login.tsx
@@ -39,6 +39,7 @@ export default function Login() {
 
     try {
       await login(email.trim(), password);
+      localStorage.removeItem("pai_signed_out");
       await refresh();
       navigate("/chat", { replace: true });
     } catch (err) {

--- a/packages/ui/src/pages/Login.tsx
+++ b/packages/ui/src/pages/Login.tsx
@@ -14,7 +14,14 @@ export default function Login() {
   const [checking, setChecking] = useState(false);
   const [showForgot, setShowForgot] = useState(false);
   const navigate = useNavigate();
-  const { refresh, isAuthenticated, loading } = useAuth();
+  const { refresh, isAuthenticated, needsSetup, loading } = useAuth();
+
+  // If no owner exists, redirect to setup
+  useEffect(() => {
+    if (!loading && needsSetup) {
+      navigate("/setup", { replace: true });
+    }
+  }, [loading, needsSetup, navigate]);
 
   // If already authenticated, redirect to chat
   useEffect(() => {

--- a/packages/ui/src/pages/Settings.tsx
+++ b/packages/ui/src/pages/Settings.tsx
@@ -20,7 +20,7 @@ const isCloudDeployment =
   window.location.hostname !== "127.0.0.1";
 
 const PROVIDER_PRESETS: Record<string, { baseUrl: string; model: string; embedModel: string }> = {
-  ollama: { baseUrl: isCloudDeployment ? "https://ollama.com" : "http://localhost:11434", model: isCloudDeployment ? "glm-5:cloud" : "llama3.2", embedModel: "nomic-embed-text" },
+  ollama: { baseUrl: isCloudDeployment ? "https://ollama.com/v1" : "http://localhost:11434", model: isCloudDeployment ? "glm-5" : "llama3.2", embedModel: "nomic-embed-text" },
   openai: { baseUrl: "https://api.openai.com/v1", model: "gpt-4o", embedModel: "text-embedding-3-small" },
   anthropic: { baseUrl: "https://api.anthropic.com", model: "claude-sonnet-4-20250514", embedModel: "" },
   google: { baseUrl: "https://generativelanguage.googleapis.com/v1beta", model: "gemini-2.0-flash", embedModel: "text-embedding-004" },

--- a/packages/ui/src/pages/Settings.tsx
+++ b/packages/ui/src/pages/Settings.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { useConfig, useUpdateConfig, useMemoryStats, useBrowseDir, useHealth, useLearningRuns } from "@/hooks";
+import { useAuth } from "../context/AuthContext";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -10,7 +12,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { InfoBubble } from "../components/InfoBubble";
-import { FolderIcon, FolderOpenIcon, ChevronUpIcon, ChevronDownIcon, BotIcon, CircleCheckIcon, CircleXIcon, LoaderIcon, CpuIcon } from "lucide-react";
+import { FolderIcon, FolderOpenIcon, ChevronUpIcon, ChevronDownIcon, BotIcon, CircleCheckIcon, CircleXIcon, LoaderIcon, CpuIcon, LogOutIcon } from "lucide-react";
 import type { LearningRun } from "@/api";
 import { formatWithTimezone, parseApiDate } from "@/lib/datetime";
 
@@ -33,6 +35,8 @@ export default function Settings() {
   const updateConfigMut = useUpdateConfig();
   const { data: health, isLoading: healthLoading } = useHealth();
   const { data: learningData } = useLearningRuns();
+  const { logout } = useAuth();
+  const navigate = useNavigate();
 
   const loading = configLoading || statsLoading;
 
@@ -783,6 +787,20 @@ export default function Settings() {
           </Card>
         )}
       </div>
+
+      {/* Sign Out */}
+      <Separator className="my-2" />
+      <Button
+        variant="ghost"
+        className="w-full justify-start gap-2 text-xs text-muted-foreground hover:text-destructive"
+        onClick={async () => {
+          await logout();
+          navigate("/login", { replace: true });
+        }}
+      >
+        <LogOutIcon className="size-3.5" />
+        Sign out
+      </Button>
 
       {/* Directory browser dialog */}
       <Dialog open={browseOpen} onOpenChange={setBrowseOpen}>

--- a/packages/ui/src/pages/Setup.tsx
+++ b/packages/ui/src/pages/Setup.tsx
@@ -1,12 +1,40 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { setupOwner } from "../api";
+import { setupOwner, remember } from "../api";
 import { useAuth } from "../context/AuthContext";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { SparklesIcon, EyeIcon, EyeOffIcon } from "lucide-react";
+import LLMSetupWizard from "../components/LLMSetupWizard";
+
+type Step = "account" | "llm" | "intro";
+
+const STEPS: Step[] = ["account", "llm", "intro"];
+
+function StepIndicator({ current }: { current: Step }) {
+  const labels = ["Account", "AI Setup", "About You"];
+  const idx = STEPS.indexOf(current);
+  return (
+    <div className="flex items-center justify-center gap-2 pb-2">
+      {labels.map((label, i) => (
+        <div key={label} className="flex items-center gap-2">
+          <div className={`flex size-6 items-center justify-center rounded-full text-[10px] font-medium ${i <= idx ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground"}`}>
+            {i + 1}
+          </div>
+          <span className={`text-[10px] ${i <= idx ? "text-foreground" : "text-muted-foreground"}`}>{label}</span>
+          {i < labels.length - 1 && <div className={`h-px w-6 ${i < idx ? "bg-primary" : "bg-border"}`} />}
+        </div>
+      ))}
+    </div>
+  );
+}
 
 export default function Setup() {
+  const [step, setStep] = useState<Step>("account");
+  const navigate = useNavigate();
+  const { refresh, isAuthenticated, needsSetup, loading } = useAuth();
+
+  // Account fields
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -14,24 +42,25 @@ export default function Setup() {
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
-  const navigate = useNavigate();
-  const { refresh, isAuthenticated, needsSetup, loading } = useAuth();
 
-  // Guard: redirect if already set up or authenticated
+  // Intro fields
+  const [work, setWork] = useState("");
+  const [preferences, setPreferences] = useState("");
+  const [introSaving, setIntroSaving] = useState(false);
+  const [introError, setIntroError] = useState("");
+
   useEffect(() => {
     if (loading) return;
-    if (isAuthenticated) {
-      navigate("/chat", { replace: true });
-    } else if (!needsSetup) {
-      // Owner exists but not authenticated → show login instead
+    if (isAuthenticated && step === "account") {
+      setStep("llm");
+    } else if (!needsSetup && !isAuthenticated) {
       navigate("/login", { replace: true });
     }
-  }, [loading, isAuthenticated, needsSetup, navigate]);
+  }, [loading, isAuthenticated, needsSetup, navigate, step]);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleAccountSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
-
     if (!name.trim() || !email.trim() || !password) {
       setError("Name, email, and password are required.");
       return;
@@ -44,64 +73,123 @@ export default function Setup() {
       setError("Passwords do not match.");
       return;
     }
-
     setSaving(true);
     try {
       await setupOwner({ email: email.trim(), password, name: name.trim() });
       await refresh();
-      navigate("/chat", { replace: true });
+      setStep("llm");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Setup failed. Please try again.");
+      setError(err instanceof Error ? err.message : "Setup failed.");
       setSaving(false);
     }
   };
 
+  const handleIntroSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIntroSaving(true);
+    setIntroError("");
+    const promises: Promise<unknown>[] = [];
+    if (name.trim()) promises.push(remember(`My name is ${name.trim()}`));
+    if (work.trim()) promises.push(remember(`I work on ${work.trim()}`));
+    if (preferences.trim()) promises.push(remember(preferences.trim()));
+    if (promises.length === 0) {
+      localStorage.setItem("pai_onboarded", "1");
+      navigate("/", { replace: true });
+      return;
+    }
+    try {
+      await Promise.all(promises);
+      localStorage.setItem("pai_onboarded", "1");
+      navigate("/", { replace: true });
+    } catch {
+      setIntroSaving(false);
+      setIntroError("Could not save — you can skip and set up later in Settings.");
+    }
+  };
+
+  const handleSkipIntro = () => {
+    localStorage.setItem("pai_onboarded", "1");
+    navigate("/", { replace: true });
+  };
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
-      <Card className="w-full max-w-sm border-border/50 bg-card/50">
+      <Card className="w-full max-w-md border-border/50 bg-card/50">
         <CardHeader className="items-center pb-2">
           <div className="mb-3 flex size-12 items-center justify-center rounded-full bg-primary/10">
             <SparklesIcon className="size-6 text-primary" />
           </div>
           <CardTitle className="text-center font-mono text-lg font-semibold">
-            Set up pai
+            {step === "account" ? "Set up pai" : step === "llm" ? "Connect your AI" : "Welcome to pai"}
           </CardTitle>
-          <p className="text-center text-xs text-muted-foreground">
-            Create your owner account to get started.
-          </p>
+          <StepIndicator current={step} />
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-3">
-            <div>
-              <label className="mb-1 block text-xs font-medium text-muted-foreground">Name</label>
-              <input type="text" value={name} onChange={(e) => setName(e.target.value)} placeholder="What should I call you?" required
-                className="w-full rounded-md border border-border/50 bg-background px-3 py-2 text-sm text-foreground placeholder-muted-foreground/50 outline-none transition-colors focus:border-primary/50 focus:ring-1 focus:ring-primary/25" />
-            </div>
-            <div>
-              <label className="mb-1 block text-xs font-medium text-muted-foreground">Email</label>
-              <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="you@example.com" autoFocus required
-                className="w-full rounded-md border border-border/50 bg-background px-3 py-2 text-sm text-foreground placeholder-muted-foreground/50 outline-none transition-colors focus:border-primary/50 focus:ring-1 focus:ring-primary/25" />
-            </div>
-            <div>
-              <label className="mb-1 block text-xs font-medium text-muted-foreground">Password</label>
-              <div className="relative">
-                <input type={showPassword ? "text" : "password"} value={password} onChange={(e) => setPassword(e.target.value)} placeholder="At least 8 characters" required
-                  className="w-full rounded-md border border-border/50 bg-background px-3 py-2 pr-9 text-sm text-foreground placeholder-muted-foreground/50 outline-none transition-colors focus:border-primary/50 focus:ring-1 focus:ring-primary/25" />
-                <button type="button" onClick={() => setShowPassword(!showPassword)} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-muted-foreground">
-                  {showPassword ? <EyeOffIcon className="size-4" /> : <EyeIcon className="size-4" />}
-                </button>
+          {step === "account" && (
+            <form onSubmit={handleAccountSubmit} className="space-y-3">
+              <div>
+                <label className="mb-1 block text-xs font-medium text-muted-foreground">Name</label>
+                <input type="text" value={name} onChange={(e) => setName(e.target.value)} placeholder="What should I call you?" required autoFocus
+                  className="w-full rounded-md border border-border/50 bg-background px-3 py-2 text-sm text-foreground placeholder-muted-foreground/50 outline-none transition-colors focus:border-primary/50 focus:ring-1 focus:ring-primary/25" />
               </div>
-            </div>
-            <div>
-              <label className="mb-1 block text-xs font-medium text-muted-foreground">Confirm Password</label>
-              <input type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} placeholder="Repeat your password" required
-                className="w-full rounded-md border border-border/50 bg-background px-3 py-2 text-sm text-foreground placeholder-muted-foreground/50 outline-none transition-colors focus:border-primary/50 focus:ring-1 focus:ring-primary/25" />
-            </div>
-            {error && <p className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">{error}</p>}
-            <Button type="submit" className="w-full" disabled={saving}>
-              {saving ? "Setting up..." : "Create Account"}
-            </Button>
-          </form>
+              <div>
+                <label className="mb-1 block text-xs font-medium text-muted-foreground">Email</label>
+                <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="you@example.com" required
+                  className="w-full rounded-md border border-border/50 bg-background px-3 py-2 text-sm text-foreground placeholder-muted-foreground/50 outline-none transition-colors focus:border-primary/50 focus:ring-1 focus:ring-primary/25" />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs font-medium text-muted-foreground">Password</label>
+                <div className="relative">
+                  <input type={showPassword ? "text" : "password"} value={password} onChange={(e) => setPassword(e.target.value)} placeholder="At least 8 characters" required
+                    className="w-full rounded-md border border-border/50 bg-background px-3 py-2 pr-9 text-sm text-foreground placeholder-muted-foreground/50 outline-none transition-colors focus:border-primary/50 focus:ring-1 focus:ring-primary/25" />
+                  <button type="button" onClick={() => setShowPassword(!showPassword)} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-muted-foreground">
+                    {showPassword ? <EyeOffIcon className="size-4" /> : <EyeIcon className="size-4" />}
+                  </button>
+                </div>
+              </div>
+              <div>
+                <label className="mb-1 block text-xs font-medium text-muted-foreground">Confirm Password</label>
+                <input type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} placeholder="Repeat your password" required
+                  className="w-full rounded-md border border-border/50 bg-background px-3 py-2 text-sm text-foreground placeholder-muted-foreground/50 outline-none transition-colors focus:border-primary/50 focus:ring-1 focus:ring-primary/25" />
+              </div>
+              {error && <p className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">{error}</p>}
+              <Button type="submit" className="w-full" disabled={saving}>
+                {saving ? "Setting up..." : "Create Account"}
+              </Button>
+            </form>
+          )}
+
+          {step === "llm" && (
+            <LLMSetupWizard onComplete={() => setStep("intro")} onSkip={() => setStep("intro")} />
+          )}
+
+          {step === "intro" && (
+            <>
+              <p className="mb-4 text-center text-xs text-muted-foreground">
+                Tell me a bit about yourself so I can be more helpful.
+              </p>
+              <form onSubmit={handleIntroSubmit} className="space-y-4">
+                <div>
+                  <label className="mb-1.5 block text-xs font-medium text-muted-foreground">What do you work on?</label>
+                  <textarea value={work} onChange={(e) => setWork(e.target.value)} placeholder="e.g. Full-stack web apps with React and Python" rows={2} autoFocus
+                    className="w-full resize-none rounded-md border border-border/50 bg-background px-3 py-2 text-sm text-foreground placeholder-muted-foreground/50 outline-none transition-colors focus:border-primary/50 focus:ring-1 focus:ring-primary/25" />
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Any preferences I should know?</label>
+                  <textarea value={preferences} onChange={(e) => setPreferences(e.target.value)} placeholder="e.g. I prefer TypeScript, dark mode, and concise answers" rows={2}
+                    className="w-full resize-none rounded-md border border-border/50 bg-background px-3 py-2 text-sm text-foreground placeholder-muted-foreground/50 outline-none transition-colors focus:border-primary/50 focus:ring-1 focus:ring-primary/25" />
+                </div>
+                {introError && <p className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">{introError}</p>}
+                <Button type="submit" className="w-full" disabled={introSaving}>
+                  {introSaving ? "Saving..." : "Get Started"}
+                </Button>
+              </form>
+              <button type="button" onClick={handleSkipIntro} disabled={introSaving}
+                className="mt-3 w-full text-center text-xs text-muted-foreground transition-colors hover:text-foreground">
+                Skip for now
+              </button>
+            </>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/packages/ui/src/pages/Setup.tsx
+++ b/packages/ui/src/pages/Setup.tsx
@@ -76,6 +76,7 @@ export default function Setup() {
     setSaving(true);
     try {
       await setupOwner({ email: email.trim(), password, name: name.trim() });
+      localStorage.removeItem("pai_signed_out");
       await refresh();
       setStep("llm");
     } catch (err) {

--- a/tests/e2e/01-setup.spec.ts
+++ b/tests/e2e/01-setup.spec.ts
@@ -6,19 +6,51 @@ test.describe("Setup wizard", () => {
     await page.goto("/");
     await expect(page).toHaveURL(/\/setup/, { timeout: 10_000 });
 
-    // Verify page title
+    // Step 1: Account creation
     await expect(page.getByText("Set up pai")).toBeVisible();
 
-    // Fill in the setup form (labels lack htmlFor — use placeholders)
     await page.getByPlaceholder("What should I call you?").fill("Test Owner");
     await page.getByPlaceholder("you@example.com").fill("test@example.com");
     await page.getByPlaceholder("At least 8 characters").fill("testpass123");
     await page.getByPlaceholder("Repeat your password").fill("testpass123");
 
-    // Submit
     await page.getByRole("button", { name: "Create Account" }).click();
 
-    // Should redirect to chat after setup completes
-    await expect(page).toHaveURL(/\/chat/, { timeout: 15_000 });
+    // Step 2: LLM setup — should show "Connect your AI"
+    await expect(page.getByText("Connect your AI")).toBeVisible({ timeout: 10_000 });
+
+    // On localhost, should show both options
+    await expect(page.getByText("Run locally")).toBeVisible();
+    await expect(page.getByText("Use a cloud provider")).toBeVisible();
+
+    // Verify cloud provider flow renders correctly
+    await page.getByText("Use a cloud provider").click();
+    await expect(page.getByText("Ollama Cloud")).toBeVisible();
+    await expect(page.getByText("OpenAI")).toBeVisible();
+    await expect(page.getByText("Anthropic")).toBeVisible();
+    await expect(page.getByText("Google AI")).toBeVisible();
+
+    // Test back navigation
+    await page.getByText("← Back").click();
+    await expect(page.getByText("Run locally")).toBeVisible();
+
+    // Verify local Ollama flow renders correctly
+    await page.getByText("Run locally").click();
+    await expect(page.getByText("Set up Ollama on your machine")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Test Connection" })).toBeVisible();
+    await page.getByText("← Back").click();
+
+    // Skip LLM setup to preserve mock config for subsequent tests
+    await page.getByText("Skip").click();
+
+    // Step 3: Personal intro
+    await expect(page.getByText("Welcome to pai")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("Tell me a bit about yourself")).toBeVisible();
+
+    // Skip intro
+    await page.getByText("Skip for now").click();
+
+    // Should redirect to inbox
+    await expect(page).toHaveURL(/\/$/, { timeout: 15_000 });
   });
 });

--- a/tests/e2e/03-settings.spec.ts
+++ b/tests/e2e/03-settings.spec.ts
@@ -101,7 +101,7 @@ test.describe("Settings", () => {
     const apiKeyInput = apiKeyRow.locator('input[type="password"]');
     await apiKeyInput.fill("sk-consecutive-test");
     await page.getByRole("button", { name: "Save" }).click();
-    await expect(page.getByText(/Configuration saved/i)).toBeVisible({
+    await expect(page.getByText(/Configuration saved/i).first()).toBeVisible({
       timeout: 5_000,
     });
 


### PR DESCRIPTION
## Summary

Replaces the bare account-creation-only setup page with a guided 3-step first-boot wizard and fixes several onboarding pain points.

## Changes

### Setup Wizard (UI)
- **New LLMSetupWizard component** with deployment-aware decision tree
  - Cloud deployments: skip straight to provider picker
  - Local deployments: choose between local Ollama or cloud provider
- **Provider cards**: Ollama Cloud (free), OpenAI, Anthropic, Google AI — each with description, direct link to get API key, auto-filled presets
- **Test Connection** button validates config via `POST /api/config/test` before proceeding
- **Skip option** on LLM step (configure later in Settings)
- **Step indicator** showing progress (Account → AI Setup → About You)
- **Personal intro** step (name, work, preferences) inlined from previously orphaned Onboarding page

### Server
- `POST /api/config/test` endpoint: validates LLM config without saving
- Workers skip briefing/learning when LLM is unconfigured (friendly log instead of 'Unauthorized')

### Bug Fixes
- Fixed Ollama Cloud base URL: `ollama.com/v1` (was `api.ollama.com`)
- Fixed Ollama Cloud model name: `glm-5` (was `glm-5:cloud`)
- Login page redirects to `/setup` when no owner exists
- Sign out works on localhost (localStorage flag for auth bypass)

### CLI
- `pai init` now includes `ollama-cloud` as a provider option

### Sign Out
- Added sign out button to Settings page (bottom, ghost style)

## Tests
- 5 server tests for `POST /api/config/test`
- 5 CLI tests for provider presets
- Updated E2E setup test for full 3-step wizard flow
- Fixed E2E settings toast flake
- All **711 unit tests** + **9 E2E tests** pass