### PR TITLE
Telegram: format mixed JSON/prose research outputs into human-friendly messages

### DIFF
--- a/packages/plugin-telegram/src/formatter.ts
+++ b/packages/plugin-telegram/src/formatter.ts
@@ -178,6 +178,54 @@ function formatObjectLines(value: Record<string, unknown>): string[] {
   return lines;
 }
 
+function formatJsonPayload(parsed: unknown): string | null {
+  if (Array.isArray(parsed)) {
+    if (parsed.length === 0) return null;
+    const lines: string[] = ["**Results**"];
+    for (const item of parsed) {
+      if (isRecord(item)) {
+        const summary = Object.entries(item)
+          .filter(([, v]) => v === null || ["string", "number", "boolean"].includes(typeof v))
+          .slice(0, 6)
+          .map(([k, v]) => `**${humanizeKey(k)}:** ${formatPrimitive(v)}`)
+          .join(" | ");
+        lines.push(`- ${summary || "(complex item)"}`);
+      } else {
+        lines.push(`- ${formatPrimitive(item)}`);
+      }
+    }
+    return lines.join("\n");
+  }
+
+  if (!isRecord(parsed)) return null;
+
+  const title = [parsed.ticker, parsed.company].filter((part): part is string => typeof part === "string" && part.length > 0)
+    .join(" — ");
+  const lines = [title ? `**${title}**` : "**Analysis Summary**", ...formatObjectLines(parsed)];
+  return lines.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function extractTrailingJson(text: string): { prefix: string; parsed: unknown } | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i];
+    if (ch !== "{" && ch !== "[") continue;
+
+    const candidate = trimmed.slice(i);
+    try {
+      const parsed = JSON.parse(candidate);
+      const prefix = trimmed.slice(0, i).trimEnd();
+      return { prefix, parsed };
+    } catch {
+      // continue scanning for the actual JSON start
+    }
+  }
+
+  return null;
+}
+
 /**
  * Format a model response for Telegram.
  * If the response is raw JSON, convert it into a human-readable markdown summary.
@@ -186,43 +234,24 @@ export function formatTelegramResponse(text: string): string {
   const trimmed = text.trim();
   if (!trimmed) return text;
 
-  const looksLikeJson = (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
-    (trimmed.startsWith("[") && trimmed.endsWith("]"));
-
-  if (!looksLikeJson) return text;
-
-  try {
-    const parsed: unknown = JSON.parse(trimmed);
-
-    if (Array.isArray(parsed)) {
-      if (parsed.length === 0) return text;
-      const lines: string[] = ["**Results**"];
-      for (const item of parsed) {
-        if (isRecord(item)) {
-          // Format each object as a readable block with key-value pairs
-          const summary = Object.entries(item)
-            .filter(([, v]) => v === null || ["string", "number", "boolean"].includes(typeof v))
-            .slice(0, 6)
-            .map(([k, v]) => `**${humanizeKey(k)}:** ${formatPrimitive(v)}`)
-            .join(" | ");
-          lines.push(`- ${summary || "(complex item)"}`);
-        } else {
-          lines.push(`- ${formatPrimitive(item)}`);
-        }
-      }
-      return lines.join("\n");
+  // Convert fenced JSON blocks (```json ... ```) into readable markdown summaries.
+  let normalized = trimmed.replace(/```json\s*([\s\S]*?)```/gi, (match, payload: string) => {
+    try {
+      const formatted = formatJsonPayload(JSON.parse(payload.trim()));
+      return formatted ?? match;
+    } catch {
+      return match;
     }
+  });
 
-    if (!isRecord(parsed)) return text;
+  // Convert full JSON payloads or prose + trailing JSON payloads.
+  const extracted = extractTrailingJson(normalized);
+  if (!extracted) return normalized;
 
-    const title = [parsed.ticker, parsed.company].filter((part): part is string => typeof part === "string" && part.length > 0)
-      .join(" — ");
-    const lines = [title ? `**${title}**` : "**Analysis Summary**", ...formatObjectLines(parsed)];
+  const formatted = formatJsonPayload(extracted.parsed);
+  if (!formatted) return normalized;
 
-    return lines.join("\n").replace(/\n{3,}/g, "\n\n").trim();
-  } catch {
-    return text;
-  }
+  return extracted.prefix ? `${extracted.prefix}\n\n${formatted}` : formatted;
 }
 
 /**

--- a/packages/plugin-telegram/src/push.ts
+++ b/packages/plugin-telegram/src/push.ts
@@ -1,6 +1,6 @@
 import type { Bot } from "grammy";
 import type { Storage, Logger } from "@personal-ai/core";
-import { markdownToTelegramHTML, splitMessage, escapeHTML } from "./formatter.js";
+import { markdownToTelegramHTML, splitMessage, escapeHTML, formatTelegramResponse } from "./formatter.js";
 
 function findChatIdForBriefing(storage: Storage, briefingId: string): number | null {
   let jobId: string | null = null;
@@ -59,7 +59,8 @@ async function checkAndPushResearch(storage: Storage, bot: Bot, logger: Logger):
         const isSwarm = row.id.startsWith("swarm-");
         const emoji = isSwarm ? "\uD83D\uDC1D" : "\uD83D\uDD2C";
         const label = isSwarm ? "Swarm Report" : "Research Complete";
-        const html = `${emoji} <b>${label}: ${escapeHTML(title)}</b>\n\n${markdownToTelegramHTML(parsed.report)}`;
+        const formattedReport = formatTelegramResponse(parsed.report);
+        const html = `${emoji} <b>${label}: ${escapeHTML(title)}</b>\n\n${markdownToTelegramHTML(formattedReport)}`;
         // Send to the originating Telegram chat, not all chats
         const chatId = findChatIdForBriefing(storage, row.id);
         if (chatId) {

--- a/packages/plugin-telegram/test/formatter.test.ts
+++ b/packages/plugin-telegram/test/formatter.test.ts
@@ -65,6 +65,33 @@ describe("formatTelegramResponse", () => {
     expect(output).not.toContain('{"ticker"');
     expect(output).not.toContain('"price":');
   });
+
+
+  it("formats prose followed by raw JSON into readable markdown", () => {
+    const input = `Based on my research, here is the result.
+
+{"topic":"Breaking News","summary":"Top story summary","sources":[{"title":"BBC","url":"https://example.com"}]}`;
+    const output = formatTelegramResponse(input);
+    expect(output).toContain("Based on my research, here is the result.");
+    expect(output).toContain("**Analysis Summary**");
+    expect(output).toContain("**Topic:** Breaking News");
+    expect(output).toContain("**Sources**");
+    expect(output).not.toContain('{"topic"');
+  });
+
+  it("formats fenced json blocks in mixed responses", () => {
+    const input = `Research finished.
+
+\`\`\`json
+{"ticker":"AAPL","company":"Apple","metrics":{"price":210}}
+\`\`\``;
+    const output = formatTelegramResponse(input);
+    expect(output).toContain("Research finished.");
+    expect(output).toContain("**AAPL — Apple**");
+    expect(output).toContain("**Metrics**");
+    expect(output).not.toContain("```json");
+  });
+
 });
 describe("formatBriefingHTML", () => {
   it("formats full sections with all fields", () => {


### PR DESCRIPTION
### Motivation
- Research and swarm report outputs were occasionally sent to Telegram as raw JSON blobs or JSON fences, making messages hard to read in chat.

### Description
- Added `formatJsonPayload` and `extractTrailingJson` helpers in `packages/plugin-telegram/src/formatter.ts` to convert JSON arrays/objects and trailing JSON payloads into readable markdown summaries.
- Normalized fenced ```json``` blocks and prose+JSON responses inside `formatTelegramResponse` so mixed model outputs are converted into human-readable text before HTML conversion.
- Applied the formatting pipeline to background pushes by calling `formatTelegramResponse` in `packages/plugin-telegram/src/push.ts` so research/swarm briefings are delivered as Telegram-friendly messages.
- Added unit tests in `packages/plugin-telegram/test/formatter.test.ts` to cover prose+JSON and fenced JSON scenarios.

### Testing
- Ran `pnpm --filter @personal-ai/plugin-telegram test -- formatter.test.ts push.test.ts` and both test files passed (`27 tests` total), all green.
- Verified the updated formatter functions via the new unit tests which assert that raw JSON is not leaked into Telegram messages and fenced/trailing JSON is rendered as readable markdown.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8b33f4320832f8528205cbd3d36e8)