### PR TITLE
fix: auto-detect timezone on signup and login

### DIFF
--- a/packages/ui/src/api.ts
+++ b/packages/ui/src/api.ts
@@ -364,6 +364,7 @@ export function updateConfig(updates: {
   knowledgeDefaultTtlDays?: number | null;
   knowledgeFreshnessDecayDays?: number;
   debugResearch?: boolean;
+  timezone?: string;
 }): Promise<ConfigInfo> {
   return request<ConfigInfo>("/config", {
     method: "PUT",

--- a/packages/ui/src/pages/Login.tsx
+++ b/packages/ui/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { login } from "../api";
+import { login, updateConfig } from "../api";
 import { useAuth } from "../context/AuthContext";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -40,6 +40,9 @@ export default function Login() {
     try {
       await login(email.trim(), password);
       localStorage.removeItem("pai_signed_out");
+      // Sync browser timezone to server on login
+      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      if (tz) updateConfig({ timezone: tz }).catch(() => {});
       await refresh();
       navigate("/chat", { replace: true });
     } catch (err) {

--- a/packages/ui/src/pages/Setup.tsx
+++ b/packages/ui/src/pages/Setup.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { setupOwner, remember } from "../api";
+import { setupOwner, remember, updateConfig } from "../api";
 import { useAuth } from "../context/AuthContext";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -77,6 +77,9 @@ export default function Setup() {
     try {
       await setupOwner({ email: email.trim(), password, name: name.trim() });
       localStorage.removeItem("pai_signed_out");
+      // Auto-detect and save the user's timezone
+      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      if (tz) updateConfig({ timezone: tz }).catch(() => {});
       await refresh();
       setStep("llm");
     } catch (err) {


### PR DESCRIPTION
Browser timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`) is automatically sent to the server on account creation and login via `PUT /api/config`.

Fixes briefings and timestamps showing UTC instead of the user's local time on cloud deployments (e.g. Railway).

**Changes:**
- `Setup.tsx` — saves browser timezone after account creation
- `Login.tsx` — syncs browser timezone on every login
- `api.ts` — added `timezone` to `updateConfig` type

No new dependencies. All existing tests pass.