### PR TITLE
feat: user sign-up guidance

### DIFF
--- a/packages/server/src/workers.ts
+++ b/packages/server/src/workers.ts
@@ -1,5 +1,5 @@
 import type { PluginContext } from "@personal-ai/core";
-import { cleanupExpiredSources, cleanupOldArtifacts } from "@personal-ai/core";
+import { cleanupExpiredSources, cleanupOldArtifacts, listBeliefs, listThreads } from "@personal-ai/core";
 import { getDueSchedules, markScheduleRun } from "@personal-ai/plugin-schedules";
 import { createResearchJob, runResearchInBackground } from "@personal-ai/plugin-research";
 import { webSearch, formatSearchResults } from "@personal-ai/plugin-assistant/web-search";
@@ -71,9 +71,15 @@ export class WorkerLoop {
     if (generateInitial && isLLMConfigured && this.ctx.config.workers?.briefing !== false) {
       const latest = getLatestBriefing(this.ctx.storage);
       if (!latest) {
-        generateBriefing(this.ctx).catch((err) => {
-          this.ctx.logger.warn(`Initial briefing failed: ${err instanceof Error ? err.message : String(err)}`);
-        });
+        // Skip if no user data exists yet — avoids a useless "no data" briefing on first boot
+        const hasData =
+          listBeliefs(this.ctx.storage, "active").length > 0 ||
+          listThreads(this.ctx.storage).length > 0;
+        if (hasData) {
+          generateBriefing(this.ctx).catch((err) => {
+            this.ctx.logger.warn(`Initial briefing failed: ${err instanceof Error ? err.message : String(err)}`);
+          });
+        }
       }
     }
 

--- a/packages/server/test/workers.test.ts
+++ b/packages/server/test/workers.test.ts
@@ -40,6 +40,17 @@ vi.mock("@personal-ai/plugin-assistant/page-fetch", () => ({
   fetchPageAsMarkdown: vi.fn(),
 }));
 
+const mockListBeliefs = vi.fn().mockReturnValue([]);
+const mockListThreads = vi.fn().mockReturnValue([]);
+vi.mock("@personal-ai/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@personal-ai/core")>();
+  return {
+    ...actual,
+    listBeliefs: (...args: unknown[]) => mockListBeliefs(...args),
+    listThreads: (...args: unknown[]) => mockListThreads(...args),
+  };
+});
+
 function createMockCtx(): PluginContext {
   return {
     config: { dataDir: "/tmp", llm: { provider: "ollama" }, plugins: [], logLevel: "silent" },
@@ -112,15 +123,30 @@ describe("WorkerLoop", () => {
     loop.stop(); // should not throw
   });
 
-  it("generates initial briefing when none exists", () => {
+  it("generates initial briefing when none exists and user has data", () => {
     const ctx = createMockCtx();
     mockGetLatestBriefing.mockReturnValue(null);
+    mockListBeliefs.mockReturnValue([{ id: "b1" }]);
 
     const loop = new WorkerLoop(ctx, { generateInitialBriefing: true });
     loop.start();
 
     expect(mockGetLatestBriefing).toHaveBeenCalled();
     expect(mockGenerateBriefing).toHaveBeenCalledTimes(1);
+
+    loop.stop();
+  });
+
+  it("skips initial briefing when no user data exists", () => {
+    const ctx = createMockCtx();
+    mockGetLatestBriefing.mockReturnValue(null);
+    mockListBeliefs.mockReturnValue([]);
+    mockListThreads.mockReturnValue([]);
+
+    const loop = new WorkerLoop(ctx, { generateInitialBriefing: true });
+    loop.start();
+
+    expect(mockGenerateBriefing).not.toHaveBeenCalled();
 
     loop.stop();
   });

--- a/packages/ui/src/api.ts
+++ b/packages/ui/src/api.ts
@@ -364,6 +364,7 @@ export function updateConfig(updates: {
   knowledgeDefaultTtlDays?: number | null;
   knowledgeFreshnessDecayDays?: number;
   debugResearch?: boolean;
+  timezone?: string;
 }): Promise<ConfigInfo> {
   return request<ConfigInfo>("/config", {
     method: "PUT",

--- a/packages/ui/src/pages/Inbox.tsx
+++ b/packages/ui/src/pages/Inbox.tsx
@@ -27,6 +27,10 @@ import {
   FileTextIcon,
   FileJsonIcon,
   PrinterIcon,
+  MessageCircleIcon,
+  BookOpenIcon,
+  ListTodoIcon,
+  InboxIcon,
 } from "lucide-react";
 
 const STORAGE_KEY = "pai-inbox-read";
@@ -500,21 +504,37 @@ function InboxFeed() {
   if (items.length === 0 && !generating) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-6 p-4 md:p-6">
-        <div className="inbox-fade-in flex flex-col items-center gap-3 text-center">
+        <div className="inbox-fade-in flex w-full max-w-md flex-col items-center gap-5 text-center">
           <SparklesIcon className="h-10 w-10 text-primary/60" />
-          <h2 className="font-mono text-lg font-semibold text-foreground">Your Inbox</h2>
-          <p className="max-w-sm text-sm text-muted-foreground">
-            Your daily briefings, research reports, and swarm analyses will appear here.
-            Try asking the assistant to research a topic or run a deep multi-agent swarm report.
-          </p>
-          <Button
-            onClick={handleRefresh}
-            disabled={generating}
-            className="mt-2 gap-2"
-          >
-            <RefreshCwIcon className="h-4 w-4" />
-            Generate Briefing
+          <div>
+            <h2 className="font-mono text-lg font-semibold text-foreground">Welcome to pai</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Start by chatting — I'll learn about you as we talk.
+            </p>
+          </div>
+          <Button onClick={() => navigate("/chat")} className="gap-2">
+            <MessageCircleIcon className="h-4 w-4" />
+            Start chatting
           </Button>
+          <Separator className="w-full" />
+          <div className="grid w-full gap-3 text-left">
+            {[
+              { icon: MessageCircleIcon, label: "Chat", desc: "Talk to me — I remember what matters" },
+              { icon: BrainIcon, label: "Memory", desc: "What I know about you, always evolving" },
+              { icon: BookOpenIcon, label: "Knowledge", desc: "Teach me web pages to reference later" },
+              { icon: ListTodoIcon, label: "Tasks", desc: "Your to-do list with AI prioritization" },
+              { icon: SearchIcon, label: "Jobs", desc: "Deep research and swarm analyses" },
+              { icon: InboxIcon, label: "Inbox", desc: "Daily briefings appear here as you use the app" },
+            ].map(({ icon: Icon, label, desc }) => (
+              <div key={label} className="flex items-start gap-3 rounded-md border border-border/30 px-3 py-2.5">
+                <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                <div>
+                  <div className="text-xs font-medium text-foreground">{label}</div>
+                  <div className="text-[11px] text-muted-foreground">{desc}</div>
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
     );

--- a/packages/ui/src/pages/Login.tsx
+++ b/packages/ui/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { login } from "../api";
+import { login, updateConfig } from "../api";
 import { useAuth } from "../context/AuthContext";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -40,6 +40,9 @@ export default function Login() {
     try {
       await login(email.trim(), password);
       localStorage.removeItem("pai_signed_out");
+      // Sync browser timezone to server on login
+      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      if (tz) updateConfig({ timezone: tz }).catch(() => {});
       await refresh();
       navigate("/chat", { replace: true });
     } catch (err) {

--- a/packages/ui/src/pages/Setup.tsx
+++ b/packages/ui/src/pages/Setup.tsx
@@ -98,13 +98,13 @@ export default function Setup() {
     if (preferences.trim()) promises.push(remember(preferences.trim()));
     if (promises.length === 0) {
       localStorage.setItem("pai_onboarded", "1");
-      navigate("/", { replace: true });
+      navigate("/chat", { replace: true });
       return;
     }
     try {
       await Promise.all(promises);
       localStorage.setItem("pai_onboarded", "1");
-      navigate("/", { replace: true });
+      navigate("/chat", { replace: true });
     } catch {
       setIntroSaving(false);
       setIntroError("Could not save — you can skip and set up later in Settings.");
@@ -113,7 +113,7 @@ export default function Setup() {
 
   const handleSkipIntro = () => {
     localStorage.setItem("pai_onboarded", "1");
-    navigate("/", { replace: true });
+    navigate("/chat", { replace: true });
   };
 
   return (

--- a/packages/ui/src/pages/Setup.tsx
+++ b/packages/ui/src/pages/Setup.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { setupOwner, remember } from "../api";
+import { setupOwner, remember, updateConfig } from "../api";
 import { useAuth } from "../context/AuthContext";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -77,6 +77,9 @@ export default function Setup() {
     try {
       await setupOwner({ email: email.trim(), password, name: name.trim() });
       localStorage.removeItem("pai_signed_out");
+      // Auto-detect and save the user's timezone
+      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      if (tz) updateConfig({ timezone: tz }).catch(() => {});
       await refresh();
       setStep("llm");
     } catch (err) {

--- a/tests/e2e/01-setup.spec.ts
+++ b/tests/e2e/01-setup.spec.ts
@@ -51,6 +51,6 @@ test.describe("Setup wizard", () => {
     await page.getByText("Skip for now").click();
 
     // Should redirect to inbox
-    await expect(page).toHaveURL(/\/$/, { timeout: 15_000 });
+    await expect(page).toHaveURL(/\/chat/, { timeout: 15_000 });
   });
 });


### PR DESCRIPTION
## Problem

New users land on an empty Inbox with a stale auto-generated briefing that says "no tasks, no goals, no memories" — unhelpful and confusing.

## Changes

### Skip initial briefing when no data
Workers now check for beliefs/threads before generating the first briefing. If both are empty (fresh account), the briefing is skipped entirely.

### Welcome state on empty Inbox
When the Inbox has no items, shows a welcome card with:
- "Start chatting" CTA button
- Feature descriptions for every sidebar item (Chat, Memory, Knowledge, Tasks, Jobs, Inbox)

### Redirect to Chat after setup
Setup wizard now sends new users to `/chat` instead of `/` (Inbox). They land on the chat page with suggested prompts, ready to start.

## Tests
- Updated worker tests: covers both "has data → generate" and "no data → skip" cases
- Updated E2E setup test for `/chat` redirect
- All **786 unit tests** + **9 E2E tests** pass