### PR TITLE
Improve Telegram HTML report formatting for exported research reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Filesystem-backed artifacts** — Artifacts (screenshots, charts, reports) are now stored on disk at `{dataDir}/artifacts/` instead of as SQLite BLOBs. Keeps the database lean and makes cleanup trivial. Migration v2 runs automatically on server startup — no manual setup required.
 - **Artifact auto-cleanup** — Background worker deletes artifacts older than 7 days (runs every 24 hours). Also cleans up orphan files on disk that have no matching DB records.
+- **Telegram HTML report readability** — Downloaded Telegram research/swarm report documents now use richer markdown-to-HTML rendering with proper headings, paragraphs, ordered/unordered lists, blockquotes, links, and improved document styling for browser viewing.
 
 ### Added
 

--- a/packages/plugin-telegram/src/formatter.ts
+++ b/packages/plugin-telegram/src/formatter.ts
@@ -117,6 +117,141 @@ export function markdownToTelegramHTML(md: string): string {
   return result.trim();
 }
 
+/**
+ * Convert Markdown to regular HTML for downloadable report documents.
+ * This keeps structure (headings, paragraphs, lists, code blocks, blockquotes, links)
+ * so reports render clearly in browsers.
+ */
+export function markdownToReportHTML(md: string): string {
+  let source = md.replace(/\r\n/g, "\n");
+
+  const codeBlocks: string[] = [];
+  source = source.replace(/```(\w*)\n?([\s\S]*?)```/g, (_match, lang: string, code: string) => {
+    const idx = codeBlocks.length;
+    const className = lang ? ` class="language-${escapeHTML(lang)}"` : "";
+    codeBlocks.push(`<pre><code${className}>${escapeHTML(code.trimEnd())}</code></pre>`);
+    return `\x00CB${idx}\x00`;
+  });
+
+  const inlineCodes: string[] = [];
+  source = source.replace(/`([^`\n]+)`/g, (_match, code: string) => {
+    const idx = inlineCodes.length;
+    inlineCodes.push(`<code>${escapeHTML(code)}</code>`);
+    return `\x00IC${idx}\x00`;
+  });
+
+  const inline = (text: string): string => {
+    let out = escapeHTML(text);
+    out = out.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+    out = out.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+    out = out.replace(/__(.+?)__/g, "<strong>$1</strong>");
+    out = out.replace(/(?<!\w)\*([^*\n]+)\*(?!\w)/g, "<em>$1</em>");
+    out = out.replace(/(?<!\w)_([^_\n]+)_(?!\w)/g, "<em>$1</em>");
+    out = out.replace(/~~(.+?)~~/g, "<del>$1</del>");
+    out = out.replace(/\x00IC(\d+)\x00/g, (_match, idx: string) => inlineCodes[parseInt(idx, 10)] ?? "");
+    return out;
+  };
+
+  const lines = source.split("\n");
+  const html: string[] = [];
+  let inUl = false;
+  let inOl = false;
+  let inBlockquote = false;
+
+  const closeLists = () => {
+    if (inUl) {
+      html.push("</ul>");
+      inUl = false;
+    }
+    if (inOl) {
+      html.push("</ol>");
+      inOl = false;
+    }
+  };
+
+  const closeBlockquote = () => {
+    if (inBlockquote) {
+      html.push("</blockquote>");
+      inBlockquote = false;
+    }
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    if (!line.trim()) {
+      closeLists();
+      closeBlockquote();
+      continue;
+    }
+
+    const heading = line.match(/^(#{1,6})\s+(.+)$/);
+    if (heading) {
+      closeLists();
+      closeBlockquote();
+      const [, hashes = "#", title = ""] = heading;
+      const level = hashes.length;
+      html.push(`<h${level}>${inline(title)}</h${level}>`);
+      continue;
+    }
+
+    const ul = line.match(/^[-*]\s+(.+)$/);
+    if (ul) {
+      closeBlockquote();
+      if (inOl) {
+        html.push("</ol>");
+        inOl = false;
+      }
+      if (!inUl) {
+        html.push("<ul>");
+        inUl = true;
+      }
+      const [, item = ""] = ul;
+      html.push(`<li>${inline(item)}</li>`);
+      continue;
+    }
+
+    const ol = line.match(/^\d+\.\s+(.+)$/);
+    if (ol) {
+      closeBlockquote();
+      if (inUl) {
+        html.push("</ul>");
+        inUl = false;
+      }
+      if (!inOl) {
+        html.push("<ol>");
+        inOl = true;
+      }
+      const [, item = ""] = ol;
+      html.push(`<li>${inline(item)}</li>`);
+      continue;
+    }
+
+    const quote = line.match(/^>\s?(.+)$/);
+    if (quote) {
+      closeLists();
+      if (!inBlockquote) {
+        html.push("<blockquote>");
+        inBlockquote = true;
+      }
+      const [, text = ""] = quote;
+      html.push(`<p>${inline(text)}</p>`);
+      continue;
+    }
+
+    closeLists();
+    closeBlockquote();
+    html.push(`<p>${inline(line)}</p>`);
+  }
+
+  closeLists();
+  closeBlockquote();
+
+  return html
+    .join("\n")
+    .replace(/\x00CB(\d+)\x00/g, (_match, idx: string) => codeBlocks[parseInt(idx, 10)] ?? "")
+    .trim();
+}
+
 function humanizeKey(key: string): string {
   const withSpaces = key
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")

--- a/packages/plugin-telegram/src/index.ts
+++ b/packages/plugin-telegram/src/index.ts
@@ -14,7 +14,7 @@ import { startResearchPushLoop } from "./push.js";
 // Re-exports
 export { createBot } from "./bot.js";
 export { runAgentChat, createThread, deleteThread, clearThread } from "./chat.js";
-export { markdownToTelegramHTML, splitMessage, formatBriefingHTML, escapeHTML, formatTelegramResponse } from "./formatter.js";
+export { markdownToTelegramHTML, markdownToReportHTML, splitMessage, formatBriefingHTML, escapeHTML, formatTelegramResponse } from "./formatter.js";
 export { startResearchPushLoop } from "./push.js";
 
 /** Migrations for telegram_threads mapping table */

--- a/packages/plugin-telegram/src/push.ts
+++ b/packages/plugin-telegram/src/push.ts
@@ -2,7 +2,7 @@ import { InputFile } from "grammy";
 import type { Bot } from "grammy";
 import type { Storage, Logger } from "@personal-ai/core";
 import { getArtifact, listArtifacts } from "@personal-ai/core";
-import { markdownToTelegramHTML, splitMessage, escapeHTML, formatTelegramResponse } from "./formatter.js";
+import { markdownToTelegramHTML, markdownToReportHTML, splitMessage, escapeHTML, formatTelegramResponse } from "./formatter.js";
 
 function findChatIdForBriefing(storage: Storage, briefingId: string): number | null {
   let jobId: string | null = null;
@@ -76,8 +76,35 @@ async function checkAndPushResearch(storage: Storage, bot: Bot, logger: Logger):
         if (chatId) {
           // 1. Send full report as downloadable HTML file
           const fileTitle = title.replace(/[^a-zA-Z0-9 _-]/g, "").replace(/\s+/g, "_").slice(0, 60) || "report";
-          const htmlBody = markdownToTelegramHTML(formatTelegramResponse(parsed.report));
-          const htmlContent = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>${escapeHTML(title)}</title><style>body{font-family:system-ui,sans-serif;max-width:800px;margin:2rem auto;padding:0 1rem;line-height:1.6}pre{background:#f4f4f4;padding:1rem;overflow-x:auto;border-radius:4px}code{background:#f4f4f4;padding:2px 4px;border-radius:2px}</style></head><body><h1>${escapeHTML(title)}</h1>${htmlBody}</body></html>`;
+          const htmlBody = markdownToReportHTML(formattedReport);
+          const htmlContent = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>${escapeHTML(title)}</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body { font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; max-width: 920px; margin: 2rem auto; padding: 0 1rem; line-height: 1.65; }
+    article { background: color-mix(in srgb, canvas 96%, #3b82f6 4%); border: 1px solid color-mix(in srgb, canvastext 12%, transparent); border-radius: 12px; padding: 1.25rem; }
+    h1, h2, h3, h4 { line-height: 1.25; margin-top: 1.4em; margin-bottom: 0.5em; }
+    h1 { margin-top: 0.2rem; }
+    p { margin: 0.7em 0; }
+    ul, ol { padding-left: 1.35rem; margin: 0.6em 0; }
+    li { margin: 0.35em 0; }
+    pre { background: color-mix(in srgb, canvas 92%, #111827 8%); padding: 0.95rem; overflow-x: auto; border-radius: 8px; border: 1px solid color-mix(in srgb, canvastext 14%, transparent); }
+    code { background: color-mix(in srgb, canvas 92%, #111827 8%); padding: 0.1em 0.35em; border-radius: 6px; }
+    blockquote { border-left: 3px solid #60a5fa; margin: 1em 0; padding: 0.2em 0 0.2em 0.9em; color: color-mix(in srgb, canvastext 80%, transparent); }
+    a { color: #2563eb; }
+  </style>
+</head>
+<body>
+  <article>
+    <h1>${escapeHTML(title)}</h1>
+    ${htmlBody}
+  </article>
+</body>
+</html>`;
           const htmlBuffer = Buffer.from(htmlContent, "utf-8");
           try {
             await bot.api.sendDocument(chatId, new InputFile(htmlBuffer, `${fileTitle}.html`), {

--- a/packages/plugin-telegram/test/formatter.test.ts
+++ b/packages/plugin-telegram/test/formatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatBriefingHTML, escapeHTML, formatTelegramResponse } from "../src/formatter.js";
+import { formatBriefingHTML, escapeHTML, formatTelegramResponse, markdownToReportHTML } from "../src/formatter.js";
 import type { BriefingSections } from "../src/formatter.js";
 
 describe("escapeHTML", () => {
@@ -30,6 +30,43 @@ describe("escapeHTML", () => {
 });
 
 
+
+
+describe("markdownToReportHTML", () => {
+  it("renders headings, paragraphs, lists, links, blockquotes, and code", () => {
+    const md = `# Title
+
+Intro with **bold**, _italic_, ~~strike~~ and [link](https://example.com).
+
+- one
+- two
+
+1. first
+2. second
+
+> quoted line
+
+\`\`\`ts
+const x = 1;
+\`\`\``;
+
+    const html = markdownToReportHTML(md);
+    expect(html).toContain("<h1>Title</h1>");
+    expect(html).toContain("<p>Intro with <strong>bold</strong>, <em>italic</em>, <del>strike</del>");
+    expect(html).toContain('<a href="https://example.com" target="_blank" rel="noopener noreferrer">link</a>');
+    expect(html).toContain("<ul>");
+    expect(html).toContain("<ol>");
+    expect(html).toContain("<blockquote>");
+    expect(html).toContain('<pre><code class="language-ts">const x = 1;</code></pre>');
+  });
+
+  it("escapes unsafe html while preserving markdown formatting", () => {
+    const html = markdownToReportHTML("<script>alert(1)</script> and **safe**");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).toContain("<strong>safe</strong>");
+    expect(html).not.toContain("<script>");
+  });
+});
 
 describe("formatTelegramResponse", () => {
   it("formats raw JSON payloads into readable markdown sections", () => {


### PR DESCRIPTION
### Motivation
- Research and swarm reports exported via Telegram were rendering as flattened or poorly structured HTML, making browser previews hard to read and navigate.

### Description
- Added `markdownToReportHTML()` in `packages/plugin-telegram/src/formatter.ts` to convert Markdown into well-structured HTML (headings, paragraphs, lists, blockquotes, inline/fenced code, links) while escaping unsafe HTML.
- Switched the Telegram push flow in `packages/plugin-telegram/src/push.ts` to use `markdownToReportHTML()` when building the downloadable `.html` report, and retained `markdownToTelegramHTML()` for in-chat previews.
- Enhanced the exported report document styling (responsive viewport, typography, spacing, code block and blockquote styles) for improved browser readability and accessibility.
- Re-exported the new formatter from `packages/plugin-telegram/src/index.ts`, added focused unit tests in `packages/plugin-telegram/test/formatter.test.ts`, and updated `CHANGELOG.md` with the change note.

### Testing
- Ran unit tests for the formatter with `pnpm --filter @personal-ai/plugin-telegram exec vitest run test/formatter.test.ts`, and the new `markdownToReportHTML` tests passed. 
- Running the full package test set with `pnpm --filter @personal-ai/plugin-telegram test` in this environment failed due to unrelated workspace package resolution errors for `@personal-ai/core`, not due to the formatter changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a90bc2c8a0832f97820f8072b80cb5)