### PR TITLE
Allow root-relative links and improve Markdown link parsing in Telegram formatter

### DIFF
--- a/packages/plugin-telegram/src/formatter.ts
+++ b/packages/plugin-telegram/src/formatter.ts
@@ -63,13 +63,66 @@ function sanitizeUrl(raw: string): string | null {
   const trimmed = raw.trim();
   if (!trimmed) return null;
 
+  // Allow root-relative links (e.g. /api/artifacts/:id) for in-app downloads.
+  if (trimmed.startsWith("/")) {
+    if (trimmed.startsWith("//")) return null;
+    return trimmed.replace(/"/g, "&quot;");
+  }
+
   try {
     const parsed = new URL(trimmed);
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
-    return parsed.toString().replace(/"/g, "&quot;");
+    let safeUrl = parsed.toString();
+    if (parsed.pathname === "/" && !parsed.search && !parsed.hash && !trimmed.endsWith("/")) {
+      safeUrl = safeUrl.replace(/\/$/, "");
+    }
+    return safeUrl.replace(/"/g, "&quot;");
   } catch {
     return null;
   }
+}
+
+function replaceMarkdownLinks(text: string, render: (label: string, rawUrl: string) => string): string {
+  let out = "";
+  let i = 0;
+
+  while (i < text.length) {
+    const openBracket = text.indexOf("[", i);
+    if (openBracket < 0) {
+      out += text.slice(i);
+      break;
+    }
+
+    out += text.slice(i, openBracket);
+
+    const closeBracket = text.indexOf("]", openBracket + 1);
+    if (closeBracket < 0 || text[closeBracket + 1] !== "(") {
+      out += text.slice(openBracket, closeBracket < 0 ? text.length : closeBracket + 1);
+      i = closeBracket < 0 ? text.length : closeBracket + 1;
+      continue;
+    }
+
+    let depth = 1;
+    let cursor = closeBracket + 2;
+    while (cursor < text.length && depth > 0) {
+      if (text[cursor] === "(") depth += 1;
+      if (text[cursor] === ")") depth -= 1;
+      cursor += 1;
+    }
+
+    if (depth !== 0) {
+      out += text.slice(openBracket, cursor);
+      i = cursor;
+      continue;
+    }
+
+    const label = text.slice(openBracket + 1, closeBracket);
+    const rawUrl = text.slice(closeBracket + 2, cursor - 1);
+    out += render(label, rawUrl);
+    i = cursor;
+  }
+
+  return out;
 }
 
 /**
@@ -113,7 +166,7 @@ export function markdownToTelegramHTML(md: string): string {
   result = result.replace(/~~(.+?)~~/g, "<s>$1</s>");
 
   // Links: [text](url)
-  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label: string, rawUrl: string) => {
+  result = replaceMarkdownLinks(result, (label: string, rawUrl: string) => {
     const safeUrl = sanitizeUrl(rawUrl);
     if (!safeUrl) return label;
     return `<a href="${safeUrl}">${label}</a>`;
@@ -159,7 +212,7 @@ export function markdownToReportHTML(md: string): string {
 
   const inline = (text: string): string => {
     let out = escapeHTML(text);
-    out = out.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label: string, rawUrl: string) => {
+    out = replaceMarkdownLinks(out, (label: string, rawUrl: string) => {
       const safeUrl = sanitizeUrl(rawUrl);
       if (!safeUrl) return label;
       return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${label}</a>`;

--- a/packages/plugin-telegram/test/formatter.test.ts
+++ b/packages/plugin-telegram/test/formatter.test.ts
@@ -53,7 +53,7 @@ const x = 1;
     const html = markdownToReportHTML(md);
     expect(html).toContain("<h1>Title</h1>");
     expect(html).toContain("<p>Intro with <strong>bold</strong>, <em>italic</em>, <del>strike</del>");
-    expect(html).toContain('<a href="https://example.com/" target="_blank" rel="noopener noreferrer">link</a>');
+    expect(html).toContain('<a href="https://example.com" target="_blank" rel="noopener noreferrer">link</a>');
     expect(html).toContain("<ul>");
     expect(html).toContain("<ol>");
     expect(html).toContain("<blockquote>");
@@ -71,6 +71,11 @@ const x = 1;
     const html = markdownToReportHTML("See [payload](javascript:alert1) now");
     expect(html).toContain("<p>See payload now</p>");
     expect(html).not.toContain("javascript:");
+  });
+
+  it("keeps root-relative artifact links", () => {
+    const html = markdownToReportHTML("Download [chart](/api/artifacts/abc123)");
+    expect(html).toContain('<a href="/api/artifacts/abc123" target="_blank" rel="noopener noreferrer">chart</a>');
   });
 });
 

--- a/packages/plugin-telegram/test/telegram.test.ts
+++ b/packages/plugin-telegram/test/telegram.test.ts
@@ -34,6 +34,11 @@ describe("markdownToTelegramHTML", () => {
     expect(markdownToTelegramHTML("[XSS](javascript:alert(1))")).toBe("XSS");
   });
 
+  it("keeps root-relative artifact links", () => {
+    expect(markdownToTelegramHTML("[artifact](/api/artifacts/abc123)"))
+      .toBe('<a href="/api/artifacts/abc123">artifact</a>');
+  });
+
   it("converts headers to bold", () => {
     expect(markdownToTelegramHTML("# Title")).toBe("<b>Title</b>");
     expect(markdownToTelegramHTML("## Subtitle")).toBe("<b>Subtitle</b>");


### PR DESCRIPTION
### Motivation

- Allow root-relative links (e.g. `/api/artifacts/:id`) so in-app download links render correctly in Telegram and report HTML.
- Make Markdown link parsing more robust to nested parentheses and edge cases that the previous regex missed.
- Normalize absolute URLs to avoid surprising trailing slashes while continuing to drop unsafe protocols.

### Description

- Add root-relative handling in `sanitizeUrl` to allow `"/…"` paths and reject protocol-relative `"//…"` links.
- Trim a trailing slash for absolute URLs when the original input did not include it to keep link hrefs consistent.
- Introduce `replaceMarkdownLinks` to correctly parse Markdown links with nested parentheses and use it in `markdownToTelegramHTML` and `markdownToReportHTML` instead of a simple regex.
- Update expectations and add tests to cover root-relative links and the normalized href behavior.

### Testing

- Ran the `plugin-telegram` unit tests including `test/formatter.test.ts` and `test/telegram.test.ts`, and all tests passed.
- Added tests `keeps root-relative artifact links` in both `formatter.test.ts` and `telegram.test.ts`, which succeeded.
- Updated an existing assertion to expect hrefs without an extra trailing slash, and the adjusted test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a91c4db668832f9c4d395e42ee3428)