### PR TITLE
feat: first-visit banners on all pages

### DIFF
--- a/packages/ui/src/components/FirstVisitBanner.tsx
+++ b/packages/ui/src/components/FirstVisitBanner.tsx
@@ -1,0 +1,38 @@
+import { useState, useEffect } from "react";
+import { LightbulbIcon, XIcon } from "lucide-react";
+
+interface Props {
+  pageKey: string;
+  tip: string;
+}
+
+export function FirstVisitBanner({ pageKey, tip }: Props) {
+  const storageKey = `pai-fvb-${pageKey}`;
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!localStorage.getItem(storageKey)) setVisible(true);
+  }, [storageKey]);
+
+  if (!visible) return null;
+
+  const dismiss = () => {
+    localStorage.setItem(storageKey, "1");
+    setVisible(false);
+  };
+
+  return (
+    <div className="mx-3 mt-2 flex items-center gap-2.5 rounded-md bg-accent/50 px-3 py-2 md:mx-6">
+      <LightbulbIcon className="size-3.5 shrink-0 text-primary" />
+      <span className="flex-1 text-xs text-muted-foreground">{tip}</span>
+      <button
+        type="button"
+        onClick={dismiss}
+        className="shrink-0 rounded-sm p-0.5 text-muted-foreground/40 transition-colors hover:text-muted-foreground"
+        aria-label="Dismiss tip"
+      >
+        <XIcon className="size-3" />
+      </button>
+    </div>
+  );
+}

--- a/packages/ui/src/pages/Jobs.tsx
+++ b/packages/ui/src/pages/Jobs.tsx
@@ -35,6 +35,7 @@ import type { BackgroundJobInfo, BlackboardEntry } from "../api";
 import type { SwarmAgent, ArtifactMeta } from "../types";
 import { useJobs, useJobDetail, useJobBlackboard, useJobAgents, useJobArtifacts, useCancelJob, useClearJobs, useConfig } from "@/hooks";
 import { ResultRenderer } from "@/components/results/ResultRenderer";
+import { FirstVisitBanner } from "../components/FirstVisitBanner";
 import { parseApiDate } from "@/lib/datetime";
 
 const statusStyles: Record<string, string> = {
@@ -256,6 +257,7 @@ export default function Jobs() {
       {/* Main list */}
       <div className="flex-1 overflow-y-auto">
         <div className="mx-auto max-w-2xl space-y-6 p-6">
+          <FirstVisitBanner pageKey="jobs" tip="Deep research and swarm analyses run here. Ask me in chat to research a topic and the results will appear here." />
           {/* Header */}
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">

--- a/packages/ui/src/pages/Knowledge.tsx
+++ b/packages/ui/src/pages/Knowledge.tsx
@@ -33,6 +33,7 @@ import {
 } from "lucide-react";
 import type { KnowledgeSource, KnowledgeSearchResult } from "../types";
 import { formatWithTimezone, parseApiDate } from "@/lib/datetime";
+import { FirstVisitBanner } from "../components/FirstVisitBanner";
 
 function formatDate(dateStr: string): string {
   const d = parseApiDate(dateStr);
@@ -276,6 +277,7 @@ export default function Knowledge() {
   return (
     <div className="flex h-full">
       <div className="flex flex-1 flex-col overflow-hidden">
+        <FirstVisitBanner pageKey="knowledge" tip="Teach me web pages, docs, or articles. Paste a URL and I'll learn from it — then reference it when you ask questions." />
         <header className="space-y-2 border-b border-border/40 bg-[#0a0a0a] px-3 py-3 md:space-y-4 md:px-6 md:py-4">
           <div className="flex items-center justify-between gap-2">
             <div className="flex min-w-0 items-center gap-3">

--- a/packages/ui/src/pages/Memory.tsx
+++ b/packages/ui/src/pages/Memory.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 import { InfoBubble } from "../components/InfoBubble";
+import { FirstVisitBanner } from "../components/FirstVisitBanner";
 import { Trash2Icon, HelpCircleIcon, PencilIcon, CheckIcon, XIcon } from "lucide-react";
 import type { Belief, BeliefType } from "../types";
 import { formatWithTimezone, parseApiDate } from "@/lib/datetime";
@@ -216,6 +217,7 @@ export default function Memory() {
   return (
     <div className="flex h-full">
       <div className="flex flex-1 flex-col overflow-hidden">
+        <FirstVisitBanner pageKey="memory" tip="Everything I know about you — built automatically from our conversations. Beliefs evolve as you share more." />
         <header className="space-y-2 border-b border-border/40 bg-[#0a0a0a] px-3 py-3 md:space-y-4 md:px-6 md:py-4">
           <div className="flex items-center justify-between gap-2">
             <div className="flex min-w-0 items-center gap-3">

--- a/packages/ui/src/pages/Schedules.tsx
+++ b/packages/ui/src/pages/Schedules.tsx
@@ -22,6 +22,7 @@ import {
   ClockIcon,
   CalendarClockIcon,
 } from "lucide-react";
+import { FirstVisitBanner } from "../components/FirstVisitBanner";
 
 function formatInterval(hours: number): string {
   if (hours < 24) return `${hours}h`;
@@ -145,6 +146,7 @@ export default function Schedules() {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
+      <FirstVisitBanner pageKey="schedules" tip="Set up recurring research jobs — daily stock updates, news digests, or any topic you want tracked automatically." />
       {/* Header */}
       <div className="flex shrink-0 items-center justify-between border-b px-4 py-3 sm:px-6">
         <div className="flex items-center gap-3">

--- a/packages/ui/src/pages/Tasks.tsx
+++ b/packages/ui/src/pages/Tasks.tsx
@@ -34,6 +34,7 @@ import {
   CalendarIcon,
 } from "lucide-react";
 import type { Task, Goal } from "../types";
+import { FirstVisitBanner } from "../components/FirstVisitBanner";
 import { formatWithTimezone, parseApiDate } from "@/lib/datetime";
 
 function formatDate(dateStr: string): string {
@@ -281,6 +282,7 @@ export default function Tasks() {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
+      <FirstVisitBanner pageKey="tasks" tip="Your to-do list with goals and priorities. Ask me in chat to add tasks, or create them here directly." />
       {/* Top-level tabs */}
       <header className="space-y-2 border-b border-border/40 bg-[#0a0a0a] px-3 py-3 md:space-y-4 md:px-6 md:py-4">
         <Tabs

--- a/packages/ui/src/pages/Timeline.tsx
+++ b/packages/ui/src/pages/Timeline.tsx
@@ -6,6 +6,7 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { InfoBubble } from "../components/InfoBubble";
+import { FirstVisitBanner } from "../components/FirstVisitBanner";
 import { useBeliefs, useAppTimezone } from "@/hooks";
 import type { Belief, BeliefType } from "../types";
 import { formatWithTimezone, parseApiDate } from "@/lib/datetime";
@@ -69,6 +70,7 @@ export default function Timeline() {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
+      <FirstVisitBanner pageKey="timeline" tip="A chronological feed of everything I've learned about you — when beliefs were created or updated." />
       {/* Header */}
       <header className="space-y-4 border-b border-border/40 bg-[#0a0a0a] px-4 py-4 md:px-6">
         <h1 className="flex items-center gap-1.5 font-mono text-sm font-semibold text-foreground">


### PR DESCRIPTION
Adds a subtle, dismissible banner on first visit to each page explaining what it does.

- Compact single-line with lightbulb icon and muted accent background
- Blends with the dark theme
- Dismissed with X, stored in localStorage per page — shows once, never again
- Pages: Memory, Knowledge, Tasks, Jobs, Schedules, Timeline
- Chat skipped (has WelcomeSuggestions), Inbox skipped (has welcome state)

All tests pass.