### PR TITLE
feat: add time_range to web search for recency filtering

### DIFF
--- a/packages/plugin-assistant/src/index.ts
+++ b/packages/plugin-assistant/src/index.ts
@@ -27,6 +27,13 @@ Do NOT skip memory_recall just because you already called it earlier in the conv
 
 **knowledge_search**: After memory_recall, if you need more detail from learned web pages/docs.
 **web_search**: For current events, news, or when memory + knowledge don't have the answer.
+
+## Citations — IMPORTANT
+
+When you use web_search results in your response, ALWAYS cite sources using superscript numbered links inline.
+Format: state the fact then add a superscript citation — e.g. "OpenAI released GPT-5 [^1](https://example.com/article)".
+Number citations sequentially [^1], [^2], [^3] etc. Each number links to the source URL.
+Every claim from search results MUST have its citation inline, right next to the relevant text.
 **memory_remember**: Store facts, preferences, decisions when the user shares something worth keeping.
 
 **When a tool returns empty results:**

--- a/packages/plugin-assistant/src/tools.ts
+++ b/packages/plugin-assistant/src/tools.ts
@@ -9,7 +9,7 @@ import { createResearchJob, runResearchInBackground } from "@personal-ai/plugin-
 import { createSwarmJob, runSwarmInBackground } from "@personal-ai/plugin-swarm";
 import { addTask, listTasks, completeTask } from "@personal-ai/plugin-tasks";
 import { createSchedule, listSchedules, deleteSchedule } from "@personal-ai/plugin-schedules";
-import { webSearch, formatSearchResults, type SearchCategory } from "./web-search.js";
+import { webSearch, formatSearchResults, type SearchCategory, type TimeRange } from "./web-search.js";
 import { fetchPageAsMarkdown, discoverSubPages } from "./page-fetch.js";
 
 export async function runCrawlInBackground(storage: Storage, llm: LLMClient, rootUrl: string, subPages: string[]): Promise<void> {
@@ -140,17 +140,18 @@ export function createAgentTools(ctx: AgentContext) {
     }),
 
     web_search: tool({
-      description: "Search the web for current information, news, prices, or facts. Use this when the user asks about recent events, current data, or anything you're unsure about. Pick the best category for the query: 'general' (default), 'news' (recent events, headlines), 'it' (programming, tech docs), 'images', 'videos', 'social media', or 'files'.",
+      description: "Search the web for current information, news, prices, or facts. Use this when the user asks about recent events, current data, or anything you're unsure about. Pick the best category for the query: 'general' (default), 'news' (recent events, headlines), 'it' (programming, tech docs), 'images', 'videos', 'social media', or 'files'. Set time_range to 'day' or 'week' for recent/latest/current queries.",
       inputSchema: z.object({
         query: z.string().describe("The search query"),
         category: z.enum(["general", "news", "it", "images", "videos", "social media", "files"]).default("general").describe("Search category — pick the best fit for the query"),
+        time_range: z.enum(["", "day", "week", "month", "year"]).default("").describe("Time range filter — use 'week' for latest/recent/current queries, 'day' for today only, 'month' for this month. Empty for no filter."),
       }),
-      execute: async ({ query, category }) => {
+      execute: async ({ query, category, time_range }) => {
         if (ctx.config.webSearchEnabled === false) {
           return "Web search is disabled in settings. Answer based on your existing knowledge.";
         }
         try {
-          const results = await webSearch(query, 5, category as SearchCategory, ctx.config.searchUrl);
+          const results = await webSearch(query, 5, category as SearchCategory, ctx.config.searchUrl, time_range as TimeRange);
           if (results.length === 0) return "[empty] No web results found. Answer from your existing knowledge and conversation context.";
           const text = formatSearchResults(results);
           // Return structured JSON string — LLM reads the text field, UI card parses the full object

--- a/packages/plugin-assistant/src/web-search.ts
+++ b/packages/plugin-assistant/src/web-search.ts
@@ -34,6 +34,8 @@ export function resolveSearchUrl(configUrl?: string): string {
   return "http://localhost:8080";
 }
 
+export type TimeRange = "day" | "week" | "month" | "year" | "";
+
 /**
  * Fetches search results from a SearXNG instance.
  * Returns up to `maxResults` results (default 5).
@@ -43,6 +45,7 @@ export async function webSearch(
   maxResults = 5,
   category: SearchCategory = "general",
   configUrl?: string,
+  timeRange: TimeRange = "",
 ): Promise<SearchResult[]> {
   const baseUrl = resolveSearchUrl(configUrl);
   const params = new URLSearchParams({
@@ -50,6 +53,7 @@ export async function webSearch(
     format: "json",
     categories: category,
   });
+  if (timeRange) params.set("time_range", timeRange);
 
   const response = await fetch(`${baseUrl}/search?${params.toString()}`, {
     method: "GET",


### PR DESCRIPTION
LLM can now set `time_range` (day/week/month/year) on web searches. For queries about latest news or recent events, the LLM picks 'day' or 'week' to get fresh results instead of stale ones.

**Changes:**
- `web-search.ts` — added `timeRange` parameter, passes `time_range` to SearXNG API
- `tools.ts` — added `time_range` to web_search tool schema with description guiding the LLM to use it for recency

All tests pass.