### PR TITLE
fix: Dockerfile COPY paths for Railway builds

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -53,8 +53,8 @@ ENV PINCHTAB_AUTO_LAUNCH=1
 RUN useradd -m -s /bin/bash -u 1000 sandbox
 
 WORKDIR /app
-COPY entrypoint.py /app/entrypoint.py
-COPY start.sh /app/start.sh
+COPY sandbox/entrypoint.py /app/entrypoint.py
+COPY sandbox/start.sh /app/start.sh
 RUN chmod +x /app/start.sh
 
 # Entrypoint runs as root to bind port, but code executes as sandbox user

--- a/searxng/Dockerfile
+++ b/searxng/Dockerfile
@@ -1,2 +1,2 @@
 FROM searxng/searxng:latest
-COPY settings.yml /etc/searxng/settings.yml
+COPY searxng/settings.yml /etc/searxng/settings.yml


### PR DESCRIPTION
Railway builds from the repo root, not the Dockerfile's directory. Fixes COPY paths in:

- `searxng/Dockerfile`: `COPY settings.yml` → `COPY searxng/settings.yml`
- `sandbox/Dockerfile`: `COPY entrypoint.py` → `COPY sandbox/entrypoint.py`, same for `start.sh`

Without this, Railway builds fail with file-not-found errors.