### PR TITLE
fix(ci): ensure root typecheck has a local TypeScript binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint": "^9",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
+    "typescript": "^5.9.3",
     "vitest": "^3.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       lint-staged:
         specifier: ^16.2.7
         version: 16.2.7
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2)


### PR DESCRIPTION
### Motivation
- The CI `typecheck` step depended on a globally available `tsc`, which made `pnpm run typecheck` unreliable in clean CI environments.  

### Description
- Added `typescript` (`^5.9.3`) to the root `devDependencies` in `package.json` and updated the root importer in `pnpm-lock.yaml` so `pnpm run typecheck` uses a local `tsc` binary.  

### Testing
- Ran `pnpm run ci` (which runs `pnpm run verify` + coverage) and unit tests and coverage completed successfully; `pnpm lint` also ran without errors; `pnpm e2e` is expected to fail in this environment because Playwright Chromium browsers are not installed and requests `pnpm exec playwright install`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9c8c3a49c832f87f5fde5ce151dba)