### PR TITLE
fix: research jobs produce empty reports when step limit exhausted

### DIFF
--- a/packages/plugin-research/src/research.ts
+++ b/packages/plugin-research/src/research.ts
@@ -1144,7 +1144,7 @@ export async function runResearchInBackground(
         ],
         tools,
         toolChoice: "auto",
-        stopWhen: stepCountIs(8),
+        stopWhen: stepCountIs(15),
         maxRetries: 1,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         providerOptions: getProviderOptions(ctx.provider ?? "ollama", budget.contextWindow) as any,
@@ -1161,7 +1161,50 @@ export async function runResearchInBackground(
       },
     );
 
-    const rawReport = result.text || "Research completed but no report was generated.";
+    let rawReport = result.text;
+
+    // If the LLM exhausted all steps on tool calls without producing a report,
+    // do a follow-up call to synthesize findings from the tool results.
+    if (!rawReport) {
+      ctx.logger.warn(`Research job ${jobId}: no report text, running synthesis pass`);
+      const toolResults = result.steps
+        .flatMap((s) => s.toolResults ?? [])
+        .map((r) => String((r as Record<string, unknown>).result ?? ""))
+        .filter((r) => r.length > 10)
+        .join("\n\n---\n\n")
+        .slice(0, 30_000);
+
+      if (toolResults) {
+        const { result: synthResult } = await instrumentedGenerateText(
+          { storage: ctx.storage, logger: ctx.logger },
+          {
+            model: ctx.llm.getModel() as LanguageModel,
+            system: systemPrompt,
+            messages: [
+              { role: "user", content: `Research this topic thoroughly: ${job.goal}` },
+              { role: "assistant", content: `I've gathered the following research data:\n\n${toolResults}` },
+              { role: "user", content: "Now synthesize all findings into the structured markdown report." },
+            ],
+            maxRetries: 1,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            providerOptions: getProviderOptions(ctx.provider ?? "ollama", budget.contextWindow) as any,
+          },
+          {
+            spanType: "llm",
+            process: "research.synthesize",
+            surface: "worker",
+            threadId: job.threadId,
+            jobId,
+            provider: ctx.provider ?? "ollama",
+            model: ctx.model ?? "",
+            requestSizeChars: toolResults.length,
+          },
+        );
+        rawReport = synthResult.text || "";
+      }
+    }
+
+    if (!rawReport) rawReport = "Research completed but no report was generated.";
     let { report, structuredResult, renderSpec } = extractPresentationBlocks(rawReport);
 
     // Generate charts for stock research via sandbox (if available)

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { OfflineBanner } from "./OfflineBanner";
 import { MobileTabBar } from "./MobileTabBar";
 import { useInboxAll } from "@/hooks/use-inbox";
+import { useJobs } from "@/hooks/use-jobs";
 
 const navItems = [
   { to: "/", label: "Inbox", icon: IconInbox },
@@ -26,6 +27,11 @@ export default function Layout() {
 
   // Shared inbox query — reuses cache with Inbox page, polls every 30 min
   const { data: inboxData } = useInboxAll();
+  const { data: jobsData } = useJobs();
+
+  const activeJobCount = jobsData?.jobs?.filter(
+    (j) => j.status === "running" || j.status === "pending" || j.status === "planning" || j.status === "synthesizing"
+  ).length ?? 0;
 
   // Track last-seen briefing ID (persisted in localStorage)
   const [seenId, setSeenId] = useState(() => localStorage.getItem(INBOX_SEEN_KEY));
@@ -76,6 +82,11 @@ export default function Layout() {
                   {item.to === "/" && hasNewBriefing && (
                     <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-primary ring-2 ring-[#0a0a0a] pointer-events-none" />
                   )}
+                  {item.to === "/jobs" && activeJobCount > 0 && (
+                    <span className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-bold text-primary-foreground ring-2 ring-[#0a0a0a] pointer-events-none">
+                      {activeJobCount}
+                    </span>
+                  )}
                 </div>
               </TooltipTrigger>
               <TooltipContent side="right" sideOffset={8}>
@@ -95,7 +106,7 @@ export default function Layout() {
       </main>
 
       {/* Mobile bottom tab bar */}
-      <MobileTabBar hasNewBriefing={hasNewBriefing} />
+      <MobileTabBar hasNewBriefing={hasNewBriefing} activeJobCount={activeJobCount} />
     </div>
   );
 }

--- a/packages/ui/src/components/MobileTabBar.tsx
+++ b/packages/ui/src/components/MobileTabBar.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 
 interface MobileTabBarProps {
   hasNewBriefing: boolean;
+  activeJobCount: number;
 }
 
 const primaryTabs = [
@@ -21,7 +22,7 @@ const moreTabs = [
   { to: "/settings", label: "Settings", icon: TabIconSettings },
 ] as const;
 
-export function MobileTabBar({ hasNewBriefing }: MobileTabBarProps) {
+export function MobileTabBar({ hasNewBriefing, activeJobCount }: MobileTabBarProps) {
   const [moreOpen, setMoreOpen] = useState(false);
   const moreRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
@@ -106,6 +107,11 @@ export function MobileTabBar({ hasNewBriefing }: MobileTabBarProps) {
                 >
                   <tab.icon />
                   <span>{tab.label}</span>
+                  {tab.to === "/jobs" && activeJobCount > 0 && (
+                    <span className="ml-auto flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-bold text-primary-foreground">
+                      {activeJobCount}
+                    </span>
+                  )}
                 </NavLink>
               ))}
             </div>


### PR DESCRIPTION
**Problem:** Research completes with 'Research completed but no report was generated.' The LLM uses all 8 tool-call steps on searches/page reads and gets cut off before writing the report.

**Root cause:** `stepCountIs(8)` counts ALL steps including tool calls. With complex research topics, 8 steps are consumed entirely by web_search + read_page, leaving no step for the final text synthesis.

**Fix:**
- Increased step limit from 8 → 15 (more room for tool calls + report)
- Added fallback synthesis pass: if `result.text` is empty after the tool loop, extracts all tool results and makes a second LLM call to synthesize them into the structured markdown report
- Tool results are truncated to 30k chars to stay within context limits