### PR TITLE
feat: UI polish — typography, citations, resizable panel, PWA fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,8 @@ services:
       - PAI_CORS_ORIGIN=${PAI_CORS_ORIGIN:-}
       - PAI_TELEGRAM_TOKEN=${PAI_TELEGRAM_TOKEN:-}
       - PAI_SEARCH_URL=http://searxng:8080
-      - PAI_SANDBOX_URL=${PAI_SANDBOX_URL:-}
-      - PAI_BROWSER_URL=${PAI_BROWSER_URL:-}
+      - PAI_SANDBOX_URL=${PAI_SANDBOX_URL:-http://sandbox:9867}
+      - PAI_BROWSER_URL=${PAI_BROWSER_URL:-http://sandbox:9867}
       - NODE_ENV=production
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3141/api/health').then(r=>r.ok?process.exit(0):process.exit(1)).catch(()=>process.exit(1))"]
@@ -35,6 +35,8 @@ services:
   searxng:
     image: searxng/searxng:latest
     container_name: personal-ai-searxng
+    ports:
+      - "8080:8080"
     volumes:
       - ./searxng/settings.yml:/etc/searxng/settings.yml:ro
     environment:
@@ -49,8 +51,8 @@ services:
 
   sandbox:
     build:
-      context: ./sandbox
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: sandbox/Dockerfile
     container_name: personal-ai-sandbox
     profiles:
       - sandbox

--- a/packages/ui/src/components/MarkdownContent.tsx
+++ b/packages/ui/src/components/MarkdownContent.tsx
@@ -53,19 +53,19 @@ const markdownComponents: Components = {
     return <p className="mb-3 text-sm leading-relaxed text-foreground last:mb-0">{children}</p>;
   },
   h1({ children }) {
-    return <h1 className="mb-3 mt-5 text-lg font-bold text-foreground first:mt-0">{children}</h1>;
+    return <h1 className="mb-4 mt-8 text-lg font-bold text-foreground first:mt-0">{children}</h1>;
   },
   h2({ children }) {
-    return <h2 className="mb-2 mt-4 text-base font-semibold text-foreground first:mt-0">{children}</h2>;
+    return <h2 className="mb-3 mt-6 text-base font-semibold text-foreground first:mt-0">{children}</h2>;
   },
   h3({ children }) {
-    return <h3 className="mb-2 mt-3 text-sm font-semibold text-foreground first:mt-0">{children}</h3>;
+    return <h3 className="mb-2 mt-5 text-sm font-semibold text-foreground first:mt-0">{children}</h3>;
   },
   ul({ children }) {
-    return <ul className="mb-3 ml-4 list-disc space-y-1 text-sm text-foreground last:mb-0">{children}</ul>;
+    return <ul className="mb-4 ml-4 list-disc space-y-1.5 text-sm text-foreground last:mb-0">{children}</ul>;
   },
   ol({ children }) {
-    return <ol className="mb-3 ml-4 list-decimal space-y-1 text-sm text-foreground last:mb-0">{children}</ol>;
+    return <ol className="mb-4 ml-4 list-decimal space-y-1.5 text-sm text-foreground last:mb-0">{children}</ol>;
   },
   li({ children }) {
     return <li className="leading-relaxed">{children}</li>;
@@ -101,7 +101,7 @@ const markdownComponents: Components = {
     return <td className="border-t border-border/30 px-3 py-2 text-foreground/85">{children}</td>;
   },
   hr() {
-    return <hr className="my-4 border-border/40" />;
+    return <hr className="my-6 border-border/40" />;
   },
   strong({ children }) {
     return <strong className="font-semibold text-foreground">{children}</strong>;

--- a/packages/ui/src/components/assistant-ui/markdown-text.tsx
+++ b/packages/ui/src/components/assistant-ui/markdown-text.tsx
@@ -70,7 +70,7 @@ const defaultComponents = memoizeMarkdownComponents({
   h1: ({ className, ...props }) => (
     <h1
       className={cn(
-        "aui-md-h1 mb-2 scroll-m-20 font-semibold text-base first:mt-0 last:mb-0",
+        "aui-md-h1 mt-6 mb-3 scroll-m-20 font-bold text-lg first:mt-0 last:mb-0",
         className,
       )}
       {...props}
@@ -79,7 +79,7 @@ const defaultComponents = memoizeMarkdownComponents({
   h2: ({ className, ...props }) => (
     <h2
       className={cn(
-        "aui-md-h2 mt-3 mb-1.5 scroll-m-20 font-semibold text-sm first:mt-0 last:mb-0",
+        "aui-md-h2 mt-5 mb-2.5 scroll-m-20 font-semibold text-base first:mt-0 last:mb-0",
         className,
       )}
       {...props}
@@ -88,7 +88,7 @@ const defaultComponents = memoizeMarkdownComponents({
   h3: ({ className, ...props }) => (
     <h3
       className={cn(
-        "aui-md-h3 mt-2.5 mb-1 scroll-m-20 font-semibold text-sm first:mt-0 last:mb-0",
+        "aui-md-h3 mt-4 mb-2 scroll-m-20 font-semibold text-sm first:mt-0 last:mb-0",
         className,
       )}
       {...props}
@@ -97,7 +97,7 @@ const defaultComponents = memoizeMarkdownComponents({
   h4: ({ className, ...props }) => (
     <h4
       className={cn(
-        "aui-md-h4 mt-2 mb-1 scroll-m-20 font-medium text-sm first:mt-0 last:mb-0",
+        "aui-md-h4 mt-3 mb-1.5 scroll-m-20 font-medium text-sm text-foreground/90 first:mt-0 last:mb-0",
         className,
       )}
       {...props}
@@ -106,7 +106,7 @@ const defaultComponents = memoizeMarkdownComponents({
   h5: ({ className, ...props }) => (
     <h5
       className={cn(
-        "aui-md-h5 mt-2 mb-1 font-medium text-sm first:mt-0 last:mb-0",
+        "aui-md-h5 mt-3 mb-1 font-medium text-xs uppercase tracking-wide text-muted-foreground first:mt-0 last:mb-0",
         className,
       )}
       {...props}
@@ -115,7 +115,7 @@ const defaultComponents = memoizeMarkdownComponents({
   h6: ({ className, ...props }) => (
     <h6
       className={cn(
-        "aui-md-h6 mt-2 mb-1 font-medium text-sm first:mt-0 last:mb-0",
+        "aui-md-h6 mt-2 mb-1 font-medium text-xs text-muted-foreground first:mt-0 last:mb-0",
         className,
       )}
       {...props}
@@ -124,21 +124,39 @@ const defaultComponents = memoizeMarkdownComponents({
   p: ({ className, ...props }) => (
     <p
       className={cn(
-        "aui-md-p my-2.5 leading-normal first:mt-0 last:mb-0",
+        "aui-md-p my-3 leading-relaxed first:mt-0 last:mb-0",
         className,
       )}
       {...props}
     />
   ),
-  a: ({ className, ...props }) => (
-    <a
-      className={cn(
-        "aui-md-a text-primary underline underline-offset-2 hover:text-primary/80",
-        className,
-      )}
-      {...props}
-    />
-  ),
+  a: ({ className, children, ...props }) => {
+    const text = typeof children === "string" ? children : "";
+    if (/^\^?\d+$/.test(text)) {
+      return (
+        <a
+          className={cn(
+            "aui-md-citation ml-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded bg-primary/15 px-1 text-[9px] font-medium text-primary/70 no-underline hover:bg-primary/25 hover:text-primary transition-colors align-super",
+            className,
+          )}
+          {...props}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {text.replace("^", "")}
+        </a>
+      );
+    }
+    return (
+      <a
+        className={cn(
+          "aui-md-a text-primary underline underline-offset-2 hover:text-primary/80",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
   blockquote: ({ className, ...props }) => (
     <blockquote
       className={cn(
@@ -151,7 +169,7 @@ const defaultComponents = memoizeMarkdownComponents({
   ul: ({ className, ...props }) => (
     <ul
       className={cn(
-        "aui-md-ul my-2 ml-4 list-disc marker:text-muted-foreground [&>li]:mt-1",
+        "aui-md-ul my-3 ml-4 list-disc marker:text-muted-foreground [&>li]:mt-1.5",
         className,
       )}
       {...props}
@@ -160,7 +178,7 @@ const defaultComponents = memoizeMarkdownComponents({
   ol: ({ className, ...props }) => (
     <ol
       className={cn(
-        "aui-md-ol my-2 ml-4 list-decimal marker:text-muted-foreground [&>li]:mt-1",
+        "aui-md-ol my-3 ml-4 list-decimal marker:text-muted-foreground [&>li]:mt-1.5",
         className,
       )}
       {...props}
@@ -213,7 +231,7 @@ const defaultComponents = memoizeMarkdownComponents({
   ),
   sup: ({ className, ...props }) => (
     <sup
-      className={cn("aui-md-sup [&>a]:text-xs [&>a]:no-underline", className)}
+      className={cn("aui-md-sup [&>a]:text-[9px] [&>a]:no-underline [&>a]:ml-0.5 [&>a]:rounded-sm [&>a]:bg-primary/15 [&>a]:px-1 [&>a]:py-px [&>a]:text-primary/70 [&>a]:hover:bg-primary/25 [&>a]:hover:text-primary [&>a]:transition-colors", className)}
       {...props}
     />
   ),

--- a/packages/ui/src/lib/render-registry.tsx
+++ b/packages/ui/src/lib/render-registry.tsx
@@ -24,7 +24,7 @@ export const { registry, handlers, executeAction } = defineRegistry(resultCatalo
       const [open, setOpen] = useState(props.defaultOpen !== false);
       if (props.collapsible) {
         return (
-          <div className="border border-zinc-700/50 rounded-lg mb-3 overflow-hidden">
+          <div className="border border-zinc-700/50 rounded-lg mb-5 overflow-hidden">
             <button
               className="w-full flex items-center justify-between px-4 py-3 bg-zinc-800/50 hover:bg-zinc-800 text-left"
               onClick={() => setOpen(!open)}
@@ -41,14 +41,14 @@ export const { registry, handlers, executeAction } = defineRegistry(resultCatalo
                 <ChevronRight className="w-4 h-4 text-zinc-400" />
               )}
             </button>
-            {open && <div className="px-4 py-3">{children}</div>}
+            {open && <div className="px-4 py-4 space-y-3">{children}</div>}
           </div>
         );
       }
       return (
-        <div className="mb-4">
-          <h3 className="font-semibold text-zinc-100 mb-2">{props.title}</h3>
-          {props.subtitle && <p className="text-sm text-zinc-400 mb-2">{props.subtitle}</p>}
+        <div className="mb-6">
+          <h3 className="font-semibold text-zinc-100 mb-3">{props.title}</h3>
+          {props.subtitle && <p className="text-sm text-zinc-400 mb-3">{props.subtitle}</p>}
           {children}
         </div>
       );
@@ -57,7 +57,7 @@ export const { registry, handlers, executeAction } = defineRegistry(resultCatalo
     Stack: ({ props, children }) => {
       const dir = props.direction === "horizontal" ? "flex-row" : "flex-col";
       const gap =
-        props.gap === "sm" ? "gap-2" : props.gap === "lg" ? "gap-6" : "gap-4";
+        props.gap === "sm" ? "gap-3" : props.gap === "lg" ? "gap-8" : "gap-5";
       const wrap = props.wrap ? "flex-wrap" : "";
       return <div className={`flex ${dir} ${gap} ${wrap}`}>{children}</div>;
     },
@@ -65,7 +65,7 @@ export const { registry, handlers, executeAction } = defineRegistry(resultCatalo
     Grid: ({ props, children }) => {
       const cols = props.columns ?? 3;
       const gap =
-        props.gap === "sm" ? "gap-2" : props.gap === "lg" ? "gap-6" : "gap-4";
+        props.gap === "sm" ? "gap-3" : props.gap === "lg" ? "gap-8" : "gap-5";
       const colClass =
         cols <= 2
           ? "md:grid-cols-2"

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -9,7 +9,13 @@ import "./App.css";
 
 // Auto-reload when a new service worker is installed so users always get
 // the latest UI without needing a hard refresh.
-registerSW({ immediate: true });
+registerSW({
+  immediate: true,
+  onNeedRefresh() {
+    // New content available — reload immediately
+    window.location.reload();
+  },
+});
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/packages/ui/src/pages/Jobs.tsx
+++ b/packages/ui/src/pages/Jobs.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -149,6 +149,21 @@ export default function Jobs() {
   const jobs = jobsData?.jobs ?? [];
 
   const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
+
+  // Resizable sidebar
+  const [panelWidth, setPanelWidth] = useState(480);
+  const dragging = useRef(false);
+  const onDragStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    dragging.current = true;
+    const onMove = (ev: MouseEvent) => {
+      if (!dragging.current) return;
+      setPanelWidth(Math.max(380, Math.min(window.innerWidth - ev.clientX, window.innerWidth * 0.6)));
+    };
+    const onUp = () => { dragging.current = false; window.removeEventListener("mousemove", onMove); window.removeEventListener("mouseup", onUp); };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }, []);
   const { data: jobDetailData, isLoading: detailLoading } = useJobDetail(selectedJobId);
   const selectedJob = jobDetailData?.job ?? null;
   const presentation = jobDetailData?.presentation;
@@ -342,7 +357,10 @@ export default function Jobs() {
             className="fixed inset-0 z-30 bg-black/60 md:hidden"
             onClick={() => setSelectedJobId(null)}
           />
-          <div className="fixed right-0 top-0 z-40 h-full w-full overflow-y-auto border-l border-border/40 bg-[#0f0f0f] md:static md:w-[480px]">
+          <div className="flex h-full">
+            {/* Drag handle — desktop only */}
+            <div onMouseDown={onDragStart} className="hidden md:block h-full w-2 shrink-0 cursor-col-resize bg-border/20 hover:bg-primary/30 active:bg-primary/40 transition-colors" />
+            <div style={{ width: undefined }} className="fixed right-0 top-0 z-40 h-full w-full overflow-y-auto border-l border-border/40 bg-[#0f0f0f] md:static md:h-full" ref={(el) => { if (el && window.innerWidth >= 768) el.style.width = `${panelWidth}px`; }}>
             <div className="p-6">
               <div className="flex items-start justify-between gap-3">
                 <div>
@@ -689,6 +707,7 @@ export default function Jobs() {
                 </div>
               )}
             </div>
+          </div>
           </div>
         </>
       )}

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     tailwindcss(),
     VitePWA({
       registerType: "autoUpdate",
+      devOptions: { enabled: false },
       includeAssets: ["icon.svg"],
       manifest: {
         name: "pai — Personal AI",


### PR DESCRIPTION
**Chat markdown typography:**
- Proper heading hierarchy: h1 (lg) > h2 (base) > h3 (sm) — was all text-sm before
- More vertical spacing between headings, paragraphs, and list items
- Citation links `[^1](url)` render as mini pill badges (tiny square buttons) instead of text links

**Report rendering:**
- Increased spacing in collapsible sections, Stack/Grid components
- Better padding between cards in report views

**Jobs page:**
- Report sidebar is now drag-to-resize (380px to 60% of screen width)

**PWA / DX:**
- Service worker auto-reloads page when new version detected — no more manual cache clearing
- PWA disabled in Vite dev mode
- Docker compose: sandbox/browser URLs default to container names, sandbox build context uses repo root