### PR TITLE
fix: reduce wasteful thread title token usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Per-instance diagnostics** — Added a local observability system that records LLM, embed, tool, HTTP, and worker spans in SQLite. New owner-facing diagnostics panel lives in Settings with Overview, Processes, Threads, Jobs, and Errors tabs for token, latency, and failure visibility.
+- **LLM traffic shaping controls** — Added instance-level queue controls in Settings for max LLM concurrency, background start gap, startup delay, and swarm agent concurrency. Jobs and diagnostics now expose queue position, wait reason, queue wait metrics, and live lane depth.
+- **Swarm-friendly traffic defaults** — Default LLM traffic shaping now allows up to 5 concurrent swarm sub-agents with one reserved interactive slot, so a single swarm can investigate in parallel without fully blocking chat responsiveness.
 
 ### Changed
 
 - **End-to-end telemetry coverage** — Chat, Telegram, background learning, briefings, research, swarm execution, memory extraction, and knowledge embeddings now emit standardized process-level telemetry. Assistant thread messages also persist compact usage summaries for diagnostics without exposing raw metrics in normal user-facing flows.
+- **Background dispatch smoothing** — Research, swarm, and daily briefing generation now enqueue into a single background dispatcher instead of starting immediately. Restarts requeue unfinished research/swarm/briefing work as `pending`, scheduled jobs dedupe by schedule, manual work is prioritized ahead of scheduled and maintenance work, and swarm agent execution is staggered to avoid bursting the LLM server.
 
 ### Security
 
@@ -54,6 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Wasteful thread title token usage** — Short chats now keep cheap heuristic titles instead of immediately invoking the full LLM title path. LLM-generated title refreshes only start on longer threads and the title call itself is capped to a tiny output budget, cutting unnecessary token burn and queue time.
+- **Hung background LLM calls** — Research, swarm, and daily briefing generation now set explicit AI SDK timeouts so a stalled provider step cannot hold the background dispatcher indefinitely and leave jobs stuck in `running`.
+- **Nested chat LLM slowdown** — Nested LLM work inside an active chat or analysis turn now reuses the parent traffic permit instead of queueing for a second slot. This keeps sub-agent delegation and in-turn follow-up LLM calls from stalling behind background work.
 - **Telegram raw JSON responses** — Bot now detects JSON-only responses and converts them into Telegram-friendly structured sections and bullet lists for readable delivery.
 - **Telegram report link sanitization** — Telegram markdown rendering now allows only `http`/`https` URLs and strips unsafe protocols (for example `javascript:`), preventing untrusted report content from turning into executable or malformed links.
 - **Swarm results not delivered** — Push loop only handled `research-*` briefing IDs, silently dropping `swarm-*` reports

--- a/packages/core/src/threads.ts
+++ b/packages/core/src/threads.ts
@@ -145,7 +145,23 @@ export interface ListMessagesOptions {
 export interface AppendMessagesOptions {
   maxMessages?: number;
   titleCandidate?: string;
+  replaceLowSignalTitle?: boolean;
   now?: string;
+}
+
+const LOW_SIGNAL_TITLES = new Set([
+  "hi",
+  "hello",
+  "hey",
+  "ok",
+  "okay",
+  "thanks",
+  "thank you",
+]);
+
+function isLowSignalTitle(title: string): boolean {
+  const normalized = title.trim().toLowerCase().replace(/[.!?]+$/g, "");
+  return LOW_SIGNAL_TITLES.has(normalized);
 }
 
 export function getThread(storage: Storage, id: string): ThreadRow | null {
@@ -219,6 +235,14 @@ export function listMessages(storage: Storage, threadId: string, opts: ListMessa
 export function appendMessages(storage: Storage, threadId: string, messages: ThreadMessageInput[], opts: AppendMessagesOptions = {}): void {
   if (messages.length === 0) return;
   const now = opts.now ?? new Date().toISOString();
+  const currentThread = opts.titleCandidate
+    ? storage.query<{ title: string }>("SELECT title FROM threads WHERE id = ?", [threadId])[0]
+    : null;
+  const shouldReplaceTitle = !!opts.titleCandidate
+    && (
+      currentThread?.title === "New conversation"
+      || (opts.replaceLowSignalTitle === true && currentThread?.title != null && isLowSignalTitle(currentThread.title))
+    );
 
   const tx = storage.db.transaction(() => {
     const seqRow = storage.query<{ seq: number }>(
@@ -265,9 +289,9 @@ export function appendMessages(storage: Storage, threadId: string, messages: Thr
     );
     const finalCount = finalCountRow[0]?.count ?? 0;
 
-    if (opts.titleCandidate) {
+    if (opts.titleCandidate && shouldReplaceTitle) {
       storage.run(
-        "UPDATE threads SET updated_at = ?, message_count = ?, title = CASE WHEN title = 'New conversation' THEN ? ELSE title END WHERE id = ?",
+        "UPDATE threads SET updated_at = ?, message_count = ?, title = ? WHERE id = ?",
         [now, finalCount, opts.titleCandidate, threadId],
       );
     } else {

--- a/packages/core/test/threads.test.ts
+++ b/packages/core/test/threads.test.ts
@@ -339,6 +339,28 @@ describe("appendMessages", () => {
     expect(updated.title).toBe("Custom Title");
   });
 
+  it("replaces a low-signal title when replaceLowSignalTitle is enabled", () => {
+    const thread = createThread(storage, { title: "hi" });
+
+    appendMessages(storage, thread.id, [
+      { role: "user", content: "Can you summarize this document?" },
+    ], { titleCandidate: "Can you summarize this document?", replaceLowSignalTitle: true });
+
+    const updated = getThread(storage, thread.id)!;
+    expect(updated.title).toBe("Can you summarize this document?");
+  });
+
+  it("does not replace a low-signal title unless explicitly enabled", () => {
+    const thread = createThread(storage, { title: "hi" });
+
+    appendMessages(storage, thread.id, [
+      { role: "user", content: "Can you summarize this document?" },
+    ], { titleCandidate: "Can you summarize this document?" });
+
+    const updated = getThread(storage, thread.id)!;
+    expect(updated.title).toBe("hi");
+  });
+
   it("stores partsJson when provided", () => {
     const thread = createThread(storage);
     const parts = JSON.stringify([{ type: "text", text: "hello" }]);

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -36,8 +36,11 @@ import { validate } from "../validate.js";
 export { threadMigrations };
 
 const MAX_MESSAGES_PER_THREAD = 500;
-const TITLE_GENERATE_AT = 1;   // Generate LLM title after this many user turns
-const TITLE_REFRESH_EVERY = 5; // Re-check title every N user turns after that
+const TITLE_GENERATE_AT = 5;    // Use heuristic titles first; ask the LLM only for longer threads
+const TITLE_REFRESH_EVERY = 10; // Re-check title every N user turns after that
+const TITLE_CONTEXT_MESSAGES = 6;
+const TITLE_MESSAGE_PREVIEW_CHARS = 120;
+const TITLE_MAX_OUTPUT_TOKENS = 12;
 const STREAM_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const HEARTBEAT_INTERVAL_MS = 30 * 1000;  // 30 seconds
 
@@ -155,16 +158,19 @@ async function generateThreadTitle(
   messages: Array<{ role: string; content: string }>,
 ): Promise<void> {
   try {
-    const recent = messages.slice(-10);
-    const conversation = recent.map((m) => `${m.role}: ${m.content.slice(0, 200)}`).join("\n");
+    const recent = messages.slice(-TITLE_CONTEXT_MESSAGES);
+    const conversation = recent
+      .map((m) => `${m.role}: ${m.content.slice(0, TITLE_MESSAGE_PREVIEW_CHARS)}`)
+      .join("\n");
     const result = await ctx.llm.chat([
       {
         role: "system",
-        content: "Generate a short title (max 50 chars) for this conversation. Return ONLY the title, nothing else. No quotes, no prefix.",
+        content: "Write a concise thread title for this conversation in 2 to 6 words. Max 50 characters. Return only the title. No quotes or punctuation decoration.",
       },
       { role: "user", content: conversation },
     ], {
-      temperature: 0.3,
+      temperature: 0,
+      maxTokens: TITLE_MAX_OUTPUT_TOKENS,
       telemetry: {
         process: "thread.title",
         surface: "web",
@@ -172,7 +178,11 @@ async function generateThreadTitle(
         route: "/api/chat",
       },
     });
-    const title = result.text.trim().replace(/^["']|["']$/g, "").slice(0, 50);
+    const title = result.text
+      .trim()
+      .split("\n")[0]!
+      .replace(/^["']|["']$/g, "")
+      .slice(0, 50);
     if (title.length >= 3) {
       ctx.storage.run("UPDATE threads SET title = ? WHERE id = ?", [title, threadId]);
     }
@@ -569,7 +579,7 @@ export function registerAgentRoutes(app: FastifyInstance, { ctx, agents }: Serve
             ({
               result,
               traceId: telemetryTraceId,
-            } = instrumentedStreamText(
+            } = await instrumentedStreamText(
               { storage: ctx.storage, logger: ctx.logger },
               {
                 model: ctx.llm.getModel() as LanguageModel,
@@ -644,6 +654,7 @@ export function registerAgentRoutes(app: FastifyInstance, { ctx, agents }: Serve
                     appendMessages(ctx.storage, sid, toPersist, {
                       maxMessages: MAX_MESSAGES_PER_THREAD,
                       titleCandidate: autoTitle(message),
+                      replaceLowSignalTitle: true,
                     });
 
                     // afterResponse — fire and forget, but log errors
@@ -670,12 +681,15 @@ export function registerAgentRoutes(app: FastifyInstance, { ctx, agents }: Serve
                     }
 
                     // Generate/refresh thread title via LLM (awaited so UI picks up the new title on refresh)
-                    const shouldTitle = userTurnCount === TITLE_GENERATE_AT
-                      || (userTurnCount > TITLE_GENERATE_AT && (userTurnCount - TITLE_GENERATE_AT) % TITLE_REFRESH_EVERY === 0);
+                    const shouldTitle = userTurnCount >= TITLE_GENERATE_AT
+                      && (
+                        userTurnCount === TITLE_GENERATE_AT
+                        || (userTurnCount > TITLE_GENERATE_AT && (userTurnCount - TITLE_GENERATE_AT) % TITLE_REFRESH_EVERY === 0)
+                      );
                     if (shouldTitle) {
                       const allMessages = listMessages(ctx.storage, sid, { limit: 10 })
                         .map((row) => ({ role: row.role, content: row.content }));
-                      await generateThreadTitle(ctx, sid, allMessages).catch((err) => {
+                      void generateThreadTitle(ctx, sid, allMessages).catch((err) => {
                         ctx.logger.warn(`Title generation failed: ${err instanceof Error ? err.message : String(err)}`);
                       });
                     }

--- a/packages/server/test/routes.test.ts
+++ b/packages/server/test/routes.test.ts
@@ -365,6 +365,7 @@ function createMockStorage() {
         const id = params?.[0] as string;
         const t = threads.get(id);
         if (sql.includes("SELECT *")) return t ? [t] : [];
+        if (sql.includes("SELECT title")) return t ? [{ title: t.title }] : [];
         return t ? [{ id: t.id }] : [];
       }
       if (sql.includes("FROM thread_messages") && sql.includes("MAX(sequence)")) {
@@ -1120,6 +1121,65 @@ describe("agent routes", () => {
     expect(body[0].content).toBe("Hello");
     expect(body[1].role).toBe("assistant");
     expect(body[1].content).toBe("Hello from AI");
+  });
+
+  it("POST /api/chat does not invoke LLM title generation for short threads", async () => {
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/api/threads",
+      payload: { title: "Short Thread" },
+    });
+    const thread = JSON.parse(createRes.payload);
+
+    for (const message of ["hi", "can you browse", "take a screenshot", "summarize that"]) {
+      await app.inject({
+        method: "POST",
+        url: "/api/chat",
+        payload: { message, sessionId: thread.id },
+      });
+    }
+
+    expect(serverCtx.ctx.llm.chat).not.toHaveBeenCalled();
+  });
+
+  it("POST /api/chat generates a capped thread title after longer conversations", async () => {
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/api/threads",
+      payload: { title: "Long Thread" },
+    });
+    const thread = JSON.parse(createRes.payload);
+
+    for (const message of [
+      "hi",
+      "can you browse the React docs",
+      "take a screenshot of the hooks page",
+      "summarize the main sections",
+      "compare it with the API reference",
+    ]) {
+      await app.inject({
+        method: "POST",
+        url: "/api/chat",
+        payload: { message, sessionId: thread.id },
+      });
+    }
+
+    const titleCalls = vi.mocked(serverCtx.ctx.llm.chat).mock.calls.filter(([, options]) =>
+      (options as { telemetry?: { process?: string } } | undefined)?.telemetry?.process === "thread.title",
+    );
+
+    expect(titleCalls).toHaveLength(1);
+    expect(titleCalls[0]).toEqual([
+      expect.any(Array),
+      expect.objectContaining({
+        temperature: 0,
+        maxTokens: 12,
+        telemetry: expect.objectContaining({
+          process: "thread.title",
+          threadId: thread.id,
+        }),
+      }),
+    ]);
   });
 
   // -- GET /api/threads ----------------------------------------------------


### PR DESCRIPTION
## Summary
- delay LLM thread title generation until longer conversations and refresh less often
- cap thread title output tokens and shrink the prompt context for title generation
- replace low-signal heuristic titles like "hi" with the next meaningful user title without invoking the LLM

## Verification
- pnpm exec tsc --build --pretty false
- pnpm test packages/core/test/threads.test.ts packages/server/test/routes.test.ts
- pnpm run ci