### PR TITLE
feat: add llm traffic shaping and background dispatch

### DIFF
--- a/packages/core/src/background-jobs.ts
+++ b/packages/core/src/background-jobs.ts
@@ -1,4 +1,4 @@
-import type { Storage, Migration } from "./types.js";
+import type { BackgroundJobSourceKind, BackgroundWaitingReason, Storage, Migration } from "./types.js";
 import type { ResearchResultType } from "./research-schemas.js";
 
 // ---- Types ----
@@ -7,9 +7,16 @@ export interface BackgroundJob {
   id: string;
   type: "crawl" | "research" | "swarm";
   label: string;
-  status: "running" | "done" | "error";
+  status: "pending" | "running" | "done" | "error";
   progress: string;
   startedAt: string;
+  queuedAt?: string | null;
+  attemptCount?: number;
+  lastAttemptAt?: string | null;
+  sourceKind?: BackgroundJobSourceKind;
+  sourceScheduleId?: string | null;
+  queuePosition?: number | null;
+  waitingReason?: BackgroundWaitingReason | null;
   error?: string;
   result?: string;
   resultType?: ResearchResultType;
@@ -27,6 +34,12 @@ interface BackgroundJobRow {
   result: string | null;
   result_type: string | null;
   structured_result: string | null;
+  queued_at: string | null;
+  started_at_actual: string | null;
+  attempt_count: number | null;
+  last_attempt_at: string | null;
+  source_kind: string | null;
+  source_schedule_id: string | null;
   updated_at: string;
 }
 
@@ -57,6 +70,17 @@ export const backgroundJobMigrations: Migration[] = [
       ALTER TABLE background_jobs ADD COLUMN structured_result TEXT;
     `,
   },
+  {
+    version: 3,
+    up: `
+      ALTER TABLE background_jobs ADD COLUMN queued_at TEXT;
+      ALTER TABLE background_jobs ADD COLUMN started_at_actual TEXT;
+      ALTER TABLE background_jobs ADD COLUMN attempt_count INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE background_jobs ADD COLUMN last_attempt_at TEXT;
+      ALTER TABLE background_jobs ADD COLUMN source_kind TEXT NOT NULL DEFAULT 'manual';
+      ALTER TABLE background_jobs ADD COLUMN source_schedule_id TEXT;
+    `,
+  },
 ];
 
 // ---- Helpers ----
@@ -69,6 +93,12 @@ function rowToJob(row: BackgroundJobRow): BackgroundJob {
     status: row.status as BackgroundJob["status"],
     progress: row.progress,
     startedAt: row.started_at,
+    queuedAt: row.queued_at ?? row.started_at,
+    ...(row.started_at_actual ? { startedAt: row.started_at_actual } : {}),
+    attemptCount: row.attempt_count ?? 0,
+    lastAttemptAt: row.last_attempt_at,
+    sourceKind: (row.source_kind as BackgroundJobSourceKind | null) ?? "manual",
+    sourceScheduleId: row.source_schedule_id,
     ...(row.error ? { error: row.error } : {}),
     ...(row.result ? { result: row.result } : {}),
     ...(row.result_type ? { resultType: row.result_type as BackgroundJob["resultType"] } : {}),
@@ -80,17 +110,41 @@ function rowToJob(row: BackgroundJobRow): BackgroundJob {
 
 export function upsertJob(storage: Storage, job: BackgroundJob): void {
   storage.run(
-    `INSERT INTO background_jobs (id, type, label, status, progress, started_at, error, result, result_type, structured_result, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+    `INSERT INTO background_jobs (id, type, label, status, progress, started_at, error, result, result_type, structured_result, queued_at, started_at_actual, attempt_count, last_attempt_at, source_kind, source_schedule_id, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
      ON CONFLICT(id) DO UPDATE SET
        status = excluded.status,
+       label = excluded.label,
        progress = excluded.progress,
        error = excluded.error,
        result = excluded.result,
        result_type = excluded.result_type,
        structured_result = excluded.structured_result,
+       queued_at = COALESCE(excluded.queued_at, background_jobs.queued_at),
+       started_at_actual = excluded.started_at_actual,
+       attempt_count = excluded.attempt_count,
+       last_attempt_at = excluded.last_attempt_at,
+       source_kind = excluded.source_kind,
+       source_schedule_id = excluded.source_schedule_id,
        updated_at = datetime('now')`,
-    [job.id, job.type, job.label, job.status, job.progress, job.startedAt, job.error ?? null, job.result ?? null, job.resultType ?? null, job.structuredResult ?? null],
+    [
+      job.id,
+      job.type,
+      job.label,
+      job.status,
+      job.progress,
+      job.startedAt,
+      job.error ?? null,
+      job.result ?? null,
+      job.resultType ?? null,
+      job.structuredResult ?? null,
+      job.queuedAt ?? job.startedAt,
+      job.status === "pending" ? null : (job.startedAt ?? null),
+      job.attemptCount ?? 0,
+      job.lastAttemptAt ?? null,
+      job.sourceKind ?? "manual",
+      job.sourceScheduleId ?? null,
+    ],
   );
 }
 
@@ -113,7 +167,7 @@ export function listJobs(storage: Storage): BackgroundJob[] {
 export function updateJobStatus(
   storage: Storage,
   id: string,
-  updates: Partial<Pick<BackgroundJob, "status" | "progress" | "error" | "result" | "resultType" | "structuredResult">>,
+  updates: Partial<Pick<BackgroundJob, "status" | "progress" | "error" | "result" | "resultType" | "structuredResult" | "queuedAt" | "startedAt" | "attemptCount" | "lastAttemptAt" | "sourceKind" | "sourceScheduleId">>,
 ): void {
   const fields: string[] = ["updated_at = datetime('now')"];
   const values: unknown[] = [];
@@ -142,6 +196,30 @@ export function updateJobStatus(
     fields.push("structured_result = ?");
     values.push(updates.structuredResult);
   }
+  if (updates.queuedAt !== undefined) {
+    fields.push("queued_at = ?");
+    values.push(updates.queuedAt);
+  }
+  if (updates.startedAt !== undefined) {
+    fields.push("started_at_actual = ?");
+    values.push(updates.startedAt);
+  }
+  if (updates.attemptCount !== undefined) {
+    fields.push("attempt_count = ?");
+    values.push(updates.attemptCount);
+  }
+  if (updates.lastAttemptAt !== undefined) {
+    fields.push("last_attempt_at = ?");
+    values.push(updates.lastAttemptAt);
+  }
+  if (updates.sourceKind !== undefined) {
+    fields.push("source_kind = ?");
+    values.push(updates.sourceKind);
+  }
+  if (updates.sourceScheduleId !== undefined) {
+    fields.push("source_schedule_id = ?");
+    values.push(updates.sourceScheduleId);
+  }
 
   values.push(id);
   storage.run(`UPDATE background_jobs SET ${fields.join(", ")} WHERE id = ?`, values);
@@ -149,7 +227,7 @@ export function updateJobStatus(
 
 export function cancelBackgroundJob(storage: Storage, id: string): boolean {
   const job = getJob(storage, id);
-  if (!job || job.status !== "running") return false;
+  if (!job || (job.status !== "running" && job.status !== "pending")) return false;
   storage.run(
     "UPDATE background_jobs SET status = 'error', error = 'Cancelled by user', updated_at = datetime('now') WHERE id = ?",
     [id],
@@ -166,11 +244,14 @@ export function forceDeleteBackgroundJob(storage: Storage, id: string): boolean 
 
 export function recoverStaleBackgroundJobs(storage: Storage): number {
   const count = storage.query<{ cnt: number }>(
-    "SELECT COUNT(*) as cnt FROM background_jobs WHERE status = 'running'",
+    "SELECT COUNT(*) as cnt FROM background_jobs WHERE status IN ('running', 'pending')",
   )[0]?.cnt ?? 0;
   if (count > 0) {
     storage.run(
-      "UPDATE background_jobs SET status = 'error', error = 'Server restarted — job interrupted', updated_at = datetime('now') WHERE status = 'running'",
+      "UPDATE background_jobs SET status = 'pending', error = NULL, progress = 'queued after restart', started_at_actual = NULL, updated_at = datetime('now') WHERE type IN ('research', 'swarm') AND status IN ('running', 'pending')",
+    );
+    storage.run(
+      "UPDATE background_jobs SET status = 'error', error = 'Server restarted — job interrupted', updated_at = datetime('now') WHERE type = 'crawl' AND status = 'running'",
     );
   }
   return count;
@@ -178,11 +259,11 @@ export function recoverStaleBackgroundJobs(storage: Storage): number {
 
 export function cancelAllRunningBackgroundJobs(storage: Storage): number {
   const count = storage.query<{ cnt: number }>(
-    "SELECT COUNT(*) as cnt FROM background_jobs WHERE status = 'running'",
+    "SELECT COUNT(*) as cnt FROM background_jobs WHERE status IN ('running', 'pending')",
   )[0]?.cnt ?? 0;
   if (count > 0) {
     storage.run(
-      "UPDATE background_jobs SET status = 'error', error = 'Server shutting down', updated_at = datetime('now') WHERE status = 'running'",
+      "UPDATE background_jobs SET status = 'error', error = 'Server shutting down', updated_at = datetime('now') WHERE status IN ('running', 'pending')",
     );
   }
   return count;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -3,6 +3,7 @@ import { join, dirname, resolve } from "node:path";
 import { homedir } from "node:os";
 import { createCipheriv, createDecipheriv, randomBytes, createHash } from "node:crypto";
 import type { Config } from "./types.js";
+import { getDefaultLlmTrafficConfig } from "./llm-traffic.js";
 
 const DEFAULT_HOME = join(homedir(), ".personal-ai");
 const DEFAULT_DATA_DIR = join(DEFAULT_HOME, "data");
@@ -127,6 +128,7 @@ export function resolveConfigHome(env: Record<string, string | undefined> = proc
 }
 
 export function loadConfig(env: Record<string, string | undefined> = process.env): Config {
+  const defaultTraffic = getDefaultLlmTrafficConfig();
   const fileConfig = loadConfigFile(env["PAI_HOME"]);
   const fileLlm: Partial<Config["llm"]> = fileConfig.llm ?? {};
   const fileTelegram: Partial<NonNullable<Config["telegram"]>> = fileConfig.telegram ?? {};
@@ -163,7 +165,15 @@ export function loadConfig(env: Record<string, string | undefined> = process.env
     plugins: env["PAI_PLUGINS"]?.split(",").map((s) => s.trim()) ?? fileConfig.plugins ?? ["memory", "tasks"],
     timezone: env["PAI_TIMEZONE"] ?? dataDirConfig?.timezone ?? fileConfig.timezone,
     webSearchEnabled: env["PAI_WEB_SEARCH"] === "false" ? false : (fileConfig.webSearchEnabled ?? true),
-    workers: dataDirConfig?.workers ?? fileConfig.workers,
+    workers: {
+      ...(fileConfig.workers ?? {}),
+      ...(dataDirConfig?.workers ?? {}),
+      llmTraffic: {
+        ...defaultTraffic,
+        ...(fileConfig.workers?.llmTraffic ?? {}),
+        ...(dataDirConfig?.workers?.llmTraffic ?? {}),
+      },
+    },
     knowledge: dataDirConfig?.knowledge ?? fileConfig.knowledge,
     debugResearch: dataDirConfig?.debugResearch ?? fileConfig.debugResearch,
     sandboxUrl: dataDirConfig?.sandboxUrl ?? env["PAI_SANDBOX_URL"] ?? fileConfig.sandboxUrl,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export type {
   Config, Migration, Storage, LLMClient, ChatMessage, ChatOptions, TokenUsage, ChatResult, EmbedResult, StreamEvent,
   PluginContext, Command, Plugin, AgentPlugin, AgentContext, Logger, LogLevel, LogFileOptions,
   TelemetryAttributes, TelemetryProcess, TelemetrySpanType, TelemetryStatus, TelemetrySurface, EmbedOptions,
+  LlmTrafficConfig, LlmTrafficLane, BackgroundJobSourceKind, BackgroundWaitingReason,
 } from "./types.js";
 
 // Background jobs (DB-backed)
@@ -11,6 +12,15 @@ export { loadConfig, loadConfigFile, writeConfig, findGitRoot, resolveConfigHome
 export { createStorage, backupDatabase, resolveIdPrefix } from "./storage.js";
 export { createLLMClient } from "./llm.js";
 export { createLogger } from "./logger.js";
+export {
+  acquireLlmTrafficPermit,
+  configureLlmTraffic,
+  getDefaultLlmTrafficConfig,
+  getLlmTrafficConfig,
+  getLlmTrafficSnapshot,
+  getTrafficLane,
+} from "./llm-traffic.js";
+export type { LlmTrafficPermit, LlmTrafficSnapshot } from "./llm-traffic.js";
 export {
   telemetryMigrations,
   TELEMETRY_RETENTION_DAYS,
@@ -36,6 +46,9 @@ export type {
   TelemetrySummary,
   ProcessAggregate,
   ModelAggregate,
+  QueueProcessAggregate,
+  QueueLaneSnapshot,
+  LiveQueueSnapshot,
   ObservabilityOverview,
   ObservabilityRange,
   ThreadMessageUsage,

--- a/packages/core/src/llm-traffic.ts
+++ b/packages/core/src/llm-traffic.ts
@@ -1,0 +1,274 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { LlmTrafficConfig, LlmTrafficLane } from "./types.js";
+
+export interface LlmTrafficPermit {
+  lane: LlmTrafficLane;
+  queueWaitMs: number;
+  queueDepthAtEnqueue: number;
+  queueDepthAtStart: number;
+  release(): void;
+}
+
+export interface LlmTrafficSnapshot {
+  active: Record<LlmTrafficLane, number>;
+  queued: Record<LlmTrafficLane, number>;
+  activeTotal: number;
+  queuedTotal: number;
+}
+
+interface QueueRequest {
+  lane: LlmTrafficLane;
+  enqueuedAt: number;
+  queueDepthAtEnqueue: number;
+  resolve: (permit: LlmTrafficPermit) => void;
+}
+
+interface PermitContext {
+  lane: LlmTrafficLane;
+}
+
+const LANE_ORDER: LlmTrafficLane[] = ["interactive", "deferred", "background"];
+const permitContext = new AsyncLocalStorage<PermitContext>();
+
+const DEFAULTS: Required<LlmTrafficConfig> = {
+  maxConcurrent: 6,
+  startGapMs: 1500,
+  startupDelayMs: 10000,
+  swarmAgentConcurrency: 5,
+  reservedInteractiveSlots: 1,
+};
+
+export function getDefaultLlmTrafficConfig(): Required<LlmTrafficConfig> {
+  return { ...DEFAULTS };
+}
+
+class LlmTrafficController {
+  private config = { ...DEFAULTS };
+  private queues: Record<LlmTrafficLane, QueueRequest[]> = {
+    interactive: [],
+    deferred: [],
+    background: [],
+  };
+  private active: Record<LlmTrafficLane, number> = {
+    interactive: 0,
+    deferred: 0,
+    background: 0,
+  };
+  private drainTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastBackgroundStartAt = 0;
+
+  configure(config?: LlmTrafficConfig): void {
+    const maxConcurrent = Math.max(1, config?.maxConcurrent ?? DEFAULTS.maxConcurrent);
+    this.config = {
+      ...DEFAULTS,
+      ...(config ?? {}),
+      maxConcurrent,
+      startGapMs: Math.max(0, config?.startGapMs ?? DEFAULTS.startGapMs),
+      startupDelayMs: Math.max(0, config?.startupDelayMs ?? DEFAULTS.startupDelayMs),
+      swarmAgentConcurrency: Math.max(1, config?.swarmAgentConcurrency ?? DEFAULTS.swarmAgentConcurrency),
+      reservedInteractiveSlots: Math.max(0, Math.min(
+        maxConcurrent - 1,
+        config?.reservedInteractiveSlots ?? DEFAULTS.reservedInteractiveSlots,
+      )),
+    };
+    this.scheduleDrain(0);
+  }
+
+  getConfig(): Required<LlmTrafficConfig> {
+    return { ...this.config };
+  }
+
+  snapshot(): LlmTrafficSnapshot {
+    const queued = {
+      interactive: this.queues.interactive.length,
+      deferred: this.queues.deferred.length,
+      background: this.queues.background.length,
+    };
+    const active = { ...this.active };
+    return {
+      active,
+      queued,
+      activeTotal: active.interactive + active.deferred + active.background,
+      queuedTotal: queued.interactive + queued.deferred + queued.background,
+    };
+  }
+
+  async acquire(lane: LlmTrafficLane): Promise<LlmTrafficPermit> {
+    const current = permitContext.getStore();
+    if (current) {
+      return {
+        lane,
+        queueWaitMs: 0,
+        queueDepthAtEnqueue: 0,
+        queueDepthAtStart: 0,
+        release: () => {},
+      };
+    }
+
+    return new Promise<LlmTrafficPermit>((resolve) => {
+      const snapshot = this.snapshot();
+      const request: QueueRequest = {
+        lane,
+        enqueuedAt: Date.now(),
+        queueDepthAtEnqueue: snapshot.queued[lane] + snapshot.active[lane],
+        resolve,
+      };
+      this.queues[lane].push(request);
+      this.scheduleDrain(0);
+    });
+  }
+
+  private release(lane: LlmTrafficLane): void {
+    this.active[lane] = Math.max(0, this.active[lane] - 1);
+    this.scheduleDrain(0);
+  }
+
+  private scheduleDrain(delayMs: number): void {
+    if (this.drainTimer) {
+      clearTimeout(this.drainTimer);
+      this.drainTimer = null;
+    }
+    this.drainTimer = setTimeout(() => {
+      this.drainTimer = null;
+      this.drain();
+    }, Math.max(0, delayMs));
+  }
+
+  private drain(): void {
+    while (true) {
+      const next = this.nextRequest();
+      if (!next) return;
+      if (!this.canStartLane(next.lane)) return;
+
+      const now = Date.now();
+      if (next.lane === "background" && this.config.startGapMs > 0) {
+        const gapRemaining = this.lastBackgroundStartAt + this.config.startGapMs - now;
+        if (gapRemaining > 0) {
+          this.scheduleDrain(gapRemaining);
+          return;
+        }
+      }
+
+      this.queues[next.lane].shift();
+      this.active[next.lane] += 1;
+      if (next.lane === "background") {
+        this.lastBackgroundStartAt = now;
+      }
+
+      const queueWaitMs = Math.max(0, now - next.enqueuedAt);
+      const permit: LlmTrafficPermit = {
+        lane: next.lane,
+        queueWaitMs,
+        queueDepthAtEnqueue: next.queueDepthAtEnqueue,
+        queueDepthAtStart: this.active[next.lane] + this.queues[next.lane].length - 1,
+        release: () => {
+          if ((permit as { released?: boolean }).released) return;
+          (permit as { released?: boolean }).released = true;
+          this.release(next.lane);
+        },
+      };
+      next.resolve(permit);
+    }
+  }
+
+  private canStartLane(lane: LlmTrafficLane): boolean {
+    const snapshot = this.snapshot();
+    if (lane !== "background") {
+      return snapshot.activeTotal < this.config.maxConcurrent;
+    }
+
+    const backgroundCapacity = Math.max(1, this.config.maxConcurrent - this.config.reservedInteractiveSlots);
+    return snapshot.activeTotal < backgroundCapacity;
+  }
+
+  private nextRequest(): QueueRequest | null {
+    for (const lane of LANE_ORDER) {
+      const queue = this.queues[lane];
+      if (queue.length > 0) return queue[0]!;
+    }
+    return null;
+  }
+}
+
+const controller = new LlmTrafficController();
+
+function wrapIteratorWithPermitContext<T>(iterable: AsyncIterable<T>, lane: LlmTrafficLane): AsyncIterable<T> {
+  if (permitContext.getStore()) return iterable;
+
+  return {
+    [Symbol.asyncIterator]() {
+      const iterator = iterable[Symbol.asyncIterator]();
+      return {
+        next: () => permitContext.run({ lane }, () => iterator.next()),
+        return: (value?: unknown) => iterator.return
+          ? permitContext.run({ lane }, () => iterator.return!(value as never))
+          : Promise.resolve({ done: true, value } as IteratorResult<T>),
+        throw: (error?: unknown) => iterator.throw
+          ? permitContext.run({ lane }, () => iterator.throw!(error))
+          : Promise.reject(error),
+      };
+    },
+  };
+}
+
+export function configureLlmTraffic(config?: LlmTrafficConfig): void {
+  controller.configure(config);
+}
+
+export function acquireLlmTrafficPermit(lane: LlmTrafficLane): Promise<LlmTrafficPermit> {
+  return controller.acquire(lane);
+}
+
+export function runWithLlmTrafficPermitContext<T>(permit: LlmTrafficPermit, fn: () => Promise<T>): Promise<T> {
+  if (permitContext.getStore()) return fn();
+  return permitContext.run({ lane: permit.lane }, fn);
+}
+
+export function runWithLlmTrafficPermitContextStream<T>(permit: LlmTrafficPermit, iterable: AsyncIterable<T>): AsyncIterable<T> {
+  return wrapIteratorWithPermitContext(iterable, permit.lane);
+}
+
+export function getLlmTrafficSnapshot(): LlmTrafficSnapshot {
+  return controller.snapshot();
+}
+
+export function getLlmTrafficConfig(): Required<LlmTrafficConfig> {
+  return controller.getConfig();
+}
+
+export function getTrafficLane(process: string, surface?: string | null): LlmTrafficLane {
+  if (
+    process === "chat.main" ||
+    process === "chat.subagent" ||
+    process === "telegram.chat"
+  ) {
+    return "interactive";
+  }
+
+  if (
+    process === "thread.title" ||
+    process === "memory.extract" ||
+    process === "memory.relationship" ||
+    process === "memory.summarize" ||
+    process === "telegram.passive"
+  ) {
+    return "deferred";
+  }
+
+  if (
+    process === "research.run" ||
+    process === "swarm.plan" ||
+    process === "swarm.agent" ||
+    process === "swarm.synthesize" ||
+    process === "briefing.generate" ||
+    process === "learning.extract"
+  ) {
+    return "background";
+  }
+
+  if (process === "embed.memory" || process === "embed.knowledge") {
+    return surface === "worker" ? "background" : "deferred";
+  }
+
+  return surface === "worker" ? "background" : "interactive";
+}

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -188,7 +188,7 @@ export function createLLMClient(llmConfig: Config["llm"], logger?: Logger, stora
 
     let result: ReturnType<typeof streamText>;
     try {
-      ({ result } = instrumentedStreamText(
+      ({ result } = await instrumentedStreamText(
         { storage, logger: log },
         {
           model: llmModel,

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -1,6 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { generateText, streamText } from "ai";
 import type { Logger, Migration, Storage, TelemetryAttributes, TelemetrySpanType, TelemetryStatus } from "./types.js";
+import {
+  acquireLlmTrafficPermit,
+  getTrafficLane,
+  runWithLlmTrafficPermitContext,
+  runWithLlmTrafficPermitContextStream,
+} from "./llm-traffic.js";
 
 export const TELEMETRY_RETENTION_DAYS = 30;
 
@@ -166,11 +172,35 @@ export interface TelemetrySummary {
 export interface ProcessAggregate extends TelemetrySummary {
   process: string;
   avgStepCount: number;
+  avgQueueWaitMs: number;
+  p95QueueWaitMs: number;
 }
 
 export interface ModelAggregate extends TelemetrySummary {
   provider: string | null;
   model: string | null;
+}
+
+export interface QueueProcessAggregate {
+  process: string;
+  calls: number;
+  avgQueueWaitMs: number;
+  p95QueueWaitMs: number;
+}
+
+export interface QueueLaneSnapshot {
+  active: number;
+  queued: number;
+}
+
+export interface LiveQueueSnapshot {
+  activeRequests: number;
+  queuedRequests: number;
+  lanes: Record<"interactive" | "deferred" | "background", QueueLaneSnapshot>;
+  startupDelayUntil: string | null;
+  backgroundActiveWorkId: string | null;
+  backgroundActiveKind: string | null;
+  pendingBackgroundJobs: number;
 }
 
 export interface ObservabilityOverview {
@@ -179,6 +209,12 @@ export interface ObservabilityOverview {
   totals: TelemetrySummary;
   topProcesses: ProcessAggregate[];
   topModels: ModelAggregate[];
+  queue: {
+    avgWaitMs: number;
+    p95WaitMs: number;
+    byProcess: QueueProcessAggregate[];
+  };
+  live?: LiveQueueSnapshot;
 }
 
 export interface ThreadMessageUsage {
@@ -366,6 +402,41 @@ function summarizeRows(rows: TelemetrySpanRow[]): TelemetrySummary {
 
 function summarizeAggregateRows(rows: TelemetrySpanRow[]): TelemetrySpanRow[] {
   return rows.filter((row) => row.span_type !== "tool");
+}
+
+function getQueueWaitMs(row: TelemetrySpanRow): number | null {
+  const metadata = parseMetadata(row.metadata_json);
+  const value = metadata?.queueWaitMs;
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function summarizeQueueWait(rows: TelemetrySpanRow[]): { avgQueueWaitMs: number; p95QueueWaitMs: number } {
+  const waits = rows.map(getQueueWaitMs).filter((value): value is number => value != null && value >= 0);
+  return {
+    avgQueueWaitMs: average(waits),
+    p95QueueWaitMs: percentile95(waits),
+  };
+}
+
+function listQueueBreakdown(rows: TelemetrySpanRow[]): QueueProcessAggregate[] {
+  const groups = new Map<string, TelemetrySpanRow[]>();
+  for (const row of rows) {
+    const list = groups.get(row.process) ?? [];
+    list.push(row);
+    groups.set(row.process, list);
+  }
+  return [...groups.entries()]
+    .map(([process, grouped]) => {
+      const summary = summarizeQueueWait(grouped);
+      return {
+        process,
+        calls: grouped.length,
+        avgQueueWaitMs: summary.avgQueueWaitMs,
+        p95QueueWaitMs: summary.p95QueueWaitMs,
+      };
+    })
+    .filter((group) => group.avgQueueWaitMs > 0 || group.p95QueueWaitMs > 0)
+    .sort((a, b) => b.p95QueueWaitMs - a.p95QueueWaitMs || b.avgQueueWaitMs - a.avgQueueWaitMs || b.calls - a.calls);
 }
 
 export function createChildTelemetry(
@@ -602,7 +673,18 @@ export function getObservabilityOverview(storage: Storage, range: ObservabilityR
     })
     .sort((a, b) => b.totalTokens - a.totalTokens || b.calls - a.calls)
     .slice(0, 5);
-  return { range, since, totals, topProcesses, topModels };
+  return {
+    range,
+    since,
+    totals,
+    topProcesses,
+    topModels,
+    queue: {
+      avgWaitMs: summarizeQueueWait(rows).avgQueueWaitMs,
+      p95WaitMs: summarizeQueueWait(rows).p95QueueWaitMs,
+      byProcess: listQueueBreakdown(rows).slice(0, 5),
+    },
+  };
 }
 
 export function listProcessAggregates(storage: Storage, range: ObservabilityRange = "24h"): ProcessAggregate[] {
@@ -618,6 +700,7 @@ export function listProcessAggregates(storage: Storage, range: ObservabilityRang
       process,
       ...summarizeRows(grouped),
       avgStepCount: average(grouped.map((row) => row.step_count ?? 0).filter((value) => value > 0)),
+      ...summarizeQueueWait(grouped),
     }))
     .sort((a, b) => b.totalTokens - a.totalTokens || b.calls - a.calls);
 }
@@ -685,6 +768,7 @@ function listGroupedBreakdown(rows: TelemetrySpanRow[]): ProcessAggregate[] {
       process,
       ...summarizeRows(grouped),
       avgStepCount: average(grouped.map((row) => row.step_count ?? 0).filter((value) => value > 0)),
+      ...summarizeQueueWait(grouped),
     }))
     .sort((a, b) => b.totalTokens - a.totalTokens || b.calls - a.calls);
 }
@@ -720,6 +804,8 @@ export async function instrumentedGenerateText(
   telemetry: TelemetryStartInput,
 ): Promise<{ result: Awaited<ReturnType<typeof generateText>>; traceId: string; spanId: string }> {
   const span = startSpan(runtime, telemetry);
+  const lane = getTrafficLane(telemetry.process, telemetry.surface ?? null);
+  const permit = await acquireLlmTrafficPermit(lane);
   const toolSpans = new Map<string, ActiveTelemetrySpan>();
   let stepCount = 0;
   const originalOnStepFinish = (options as { onStepFinish?: ((event: unknown) => void) | undefined }).onStepFinish;
@@ -763,7 +849,7 @@ export async function instrumentedGenerateText(
   };
 
   try {
-    const result = await generateText(wrappedOptions);
+    const result = await runWithLlmTrafficPermitContext(permit, () => generateText(wrappedOptions));
     closeToolSpans(runtime, toolSpans, "ok");
     finishSpan(runtime, span, {
       status: "ok",
@@ -772,6 +858,12 @@ export async function instrumentedGenerateText(
       totalTokens: getTotalTokens(result.usage),
       stepCount: stepCount || result.steps?.length || null,
       responseSizeChars: result.text?.length ?? null,
+      metadata: {
+        queueLane: lane,
+        queueWaitMs: permit.queueWaitMs,
+        queueDepthAtEnqueue: permit.queueDepthAtEnqueue,
+        queueDepthAtStart: permit.queueDepthAtStart,
+      },
     });
     return { result, traceId: span.traceId, spanId: span.id };
   } catch (err) {
@@ -780,92 +872,175 @@ export async function instrumentedGenerateText(
       status: "error",
       stepCount: stepCount || null,
       errorMessage: err instanceof Error ? err.message : String(err),
+      metadata: {
+        queueLane: lane,
+        queueWaitMs: permit.queueWaitMs,
+        queueDepthAtEnqueue: permit.queueDepthAtEnqueue,
+        queueDepthAtStart: permit.queueDepthAtStart,
+      },
     });
     throw err;
+  } finally {
+    permit.release();
   }
 }
 
-export function instrumentedStreamText(
+export async function instrumentedStreamText(
   runtime: TelemetryRuntime,
   options: Parameters<typeof streamText>[0],
   telemetry: TelemetryStartInput,
-): { result: ReturnType<typeof streamText>; traceId: string; spanId: string } {
+): Promise<{ result: ReturnType<typeof streamText>; traceId: string; spanId: string }> {
   const span = startSpan(runtime, telemetry);
+  const lane = getTrafficLane(telemetry.process, telemetry.surface ?? null);
+  const permit = await acquireLlmTrafficPermit(lane);
   const toolSpans = new Map<string, ActiveTelemetrySpan>();
   let finished = false;
   let stepCount = 0;
+  let fallbackText = "";
+  let fallbackUsage: { inputTokens?: number | null; outputTokens?: number | null } = {};
 
   const finishRoot = (updates: NonNullable<Parameters<typeof finishSpan>[2]>) => {
     if (finished) return;
     finished = true;
     closeToolSpans(runtime, toolSpans, updates.status === "ok" ? "ok" : "error", updates.errorMessage ?? null);
-    finishSpan(runtime, span, updates);
+    finishSpan(runtime, span, {
+      ...updates,
+      metadata: {
+        ...(updates.metadata ?? {}),
+        queueLane: lane,
+        queueWaitMs: permit.queueWaitMs,
+        queueDepthAtEnqueue: permit.queueDepthAtEnqueue,
+        queueDepthAtStart: permit.queueDepthAtStart,
+      },
+    });
+    permit.release();
   };
 
-  const wrappedOptions = {
-    ...options,
-    onStepFinish: (event: unknown) => {
-      stepCount += 1;
-      const callback = (options as { onStepFinish?: ((evt: unknown) => void) | undefined }).onStepFinish;
-      callback?.(event);
-    },
-    onFinish: (event: Record<string, unknown>) => {
-      const usage = (event.totalUsage ?? event.usage) as { inputTokens?: number; outputTokens?: number } | undefined;
-      const text = typeof event.text === "string" ? event.text : "";
-      finishRoot({
-        status: "ok",
-        inputTokens: usage?.inputTokens ?? null,
-        outputTokens: usage?.outputTokens ?? null,
-        totalTokens: getTotalTokens(usage),
-        stepCount: stepCount || (Array.isArray(event.steps) ? event.steps.length : null),
-        responseSizeChars: text.length,
-      });
-      const callback = (options as { onFinish?: ((evt: unknown) => void) | undefined }).onFinish;
-      callback?.(event);
-    },
-    onError: (event: Record<string, unknown>) => {
-      finishRoot({
-        status: "error",
-        stepCount: stepCount || null,
-        errorMessage: event.error instanceof Error ? event.error.message : String(event.error),
-      });
-      const callback = (options as { onError?: ((evt: unknown) => void) | undefined }).onError;
-      callback?.(event);
-    },
-    experimental_onToolCallStart: (event: Record<string, unknown>) => {
-      const toolCall = event.toolCall as Record<string, unknown> | undefined;
-      const toolCallId = typeof toolCall?.toolCallId === "string" ? toolCall.toolCallId : randomUUID();
-      const toolName = typeof toolCall?.toolName === "string" ? toolCall.toolName : "tool";
-      toolSpans.set(toolCallId, startSpan(runtime, {
-        ...createChildTelemetry(span, { process: telemetry.process, toolName }),
-        spanType: "tool",
-        toolName,
-        metadata: { args: event.input ?? null },
-      }));
-      const callback = (options as Record<string, unknown>).experimental_onToolCallStart as ((evt: unknown) => void) | undefined;
-      callback?.(event);
-    },
-    experimental_onToolCallFinish: (event: Record<string, unknown>) => {
-      const toolCall = event.toolCall as Record<string, unknown> | undefined;
-      const toolCallId = typeof toolCall?.toolCallId === "string" ? toolCall.toolCallId : "";
-      const activeToolSpan = toolSpans.get(toolCallId);
-      if (activeToolSpan) {
-        finishSpan(runtime, activeToolSpan, {
-          status: event.success === false || event.error ? "error" : "ok",
-          responseSizeChars: typeof event.output === "string" ? event.output.length : jsonLength(event.output),
-          errorMessage: event.error ? String(event.error) : null,
-          metadata: { durationMs: typeof event.durationMs === "number" ? event.durationMs : undefined },
+  try {
+    const wrappedOptions = {
+      ...options,
+      onStepFinish: (event: unknown) => {
+        stepCount += 1;
+        const callback = (options as { onStepFinish?: ((evt: unknown) => void) | undefined }).onStepFinish;
+        callback?.(event);
+      },
+      onFinish: (event: Record<string, unknown>) => {
+        const usage = (event.totalUsage ?? event.usage) as { inputTokens?: number; outputTokens?: number } | undefined;
+        const text = typeof event.text === "string" ? event.text : "";
+        finishRoot({
+          status: "ok",
+          inputTokens: usage?.inputTokens ?? null,
+          outputTokens: usage?.outputTokens ?? null,
+          totalTokens: getTotalTokens(usage),
+          stepCount: stepCount || (Array.isArray(event.steps) ? event.steps.length : null),
+          responseSizeChars: text.length,
         });
-        toolSpans.delete(toolCallId);
+        const callback = (options as { onFinish?: ((evt: unknown) => void) | undefined }).onFinish;
+        callback?.(event);
+      },
+      onError: (event: Record<string, unknown>) => {
+        finishRoot({
+          status: "error",
+          stepCount: stepCount || null,
+          errorMessage: event.error instanceof Error ? event.error.message : String(event.error),
+        });
+        const callback = (options as { onError?: ((evt: unknown) => void) | undefined }).onError;
+        callback?.(event);
+      },
+      experimental_onToolCallStart: (event: Record<string, unknown>) => {
+        const toolCall = event.toolCall as Record<string, unknown> | undefined;
+        const toolCallId = typeof toolCall?.toolCallId === "string" ? toolCall.toolCallId : randomUUID();
+        const toolName = typeof toolCall?.toolName === "string" ? toolCall.toolName : "tool";
+        toolSpans.set(toolCallId, startSpan(runtime, {
+          ...createChildTelemetry(span, { process: telemetry.process, toolName }),
+          spanType: "tool",
+          toolName,
+          metadata: { args: event.input ?? null },
+        }));
+        const callback = (options as Record<string, unknown>).experimental_onToolCallStart as ((evt: unknown) => void) | undefined;
+        callback?.(event);
+      },
+      experimental_onToolCallFinish: (event: Record<string, unknown>) => {
+        const toolCall = event.toolCall as Record<string, unknown> | undefined;
+        const toolCallId = typeof toolCall?.toolCallId === "string" ? toolCall.toolCallId : "";
+        const activeToolSpan = toolSpans.get(toolCallId);
+        if (activeToolSpan) {
+          finishSpan(runtime, activeToolSpan, {
+            status: event.success === false || event.error ? "error" : "ok",
+            responseSizeChars: typeof event.output === "string" ? event.output.length : jsonLength(event.output),
+            errorMessage: event.error ? String(event.error) : null,
+            metadata: { durationMs: typeof event.durationMs === "number" ? event.durationMs : undefined },
+          });
+          toolSpans.delete(toolCallId);
+        }
+        const callback = (options as Record<string, unknown>).experimental_onToolCallFinish as ((evt: unknown) => void) | undefined;
+        callback?.(event);
+      },
+    } as unknown as Parameters<typeof streamText>[0];
+
+    const streamResult = await runWithLlmTrafficPermitContext(permit, () => Promise.resolve(streamText(wrappedOptions)));
+    const wrappedFullStream = (async function* () {
+      try {
+        for await (const part of runWithLlmTrafficPermitContextStream(
+          permit,
+          streamResult.fullStream as AsyncIterable<Record<string, unknown>>,
+        )) {
+          if (part.type === "text-delta" && typeof part.text === "string") {
+            fallbackText += part.text;
+          } else if (part.type === "finish") {
+            const usage = part.totalUsage as { inputTokens?: number | null; outputTokens?: number | null } | undefined;
+            fallbackUsage = {
+              inputTokens: usage?.inputTokens ?? null,
+              outputTokens: usage?.outputTokens ?? null,
+            };
+          } else if (part.type === "error" && !finished) {
+            finishRoot({
+              status: "error",
+              stepCount: stepCount || null,
+              errorMessage: part.error instanceof Error ? part.error.message : String(part.error),
+            });
+          }
+          yield part;
+        }
+
+        if (!finished) {
+          finishRoot({
+            status: "ok",
+            inputTokens: fallbackUsage.inputTokens ?? null,
+            outputTokens: fallbackUsage.outputTokens ?? null,
+            totalTokens: getTotalTokens(fallbackUsage),
+            stepCount: stepCount || null,
+            responseSizeChars: fallbackText.length || null,
+          });
+        }
+      } catch (err) {
+        if (!finished) {
+          finishRoot({
+            status: "error",
+            stepCount: stepCount || null,
+            errorMessage: err instanceof Error ? err.message : String(err),
+          });
+        }
+        throw err;
       }
-      const callback = (options as Record<string, unknown>).experimental_onToolCallFinish as ((evt: unknown) => void) | undefined;
-      callback?.(event);
-    },
-  } as unknown as Parameters<typeof streamText>[0];
+    })();
 
-  const result = streamText(wrappedOptions);
-
-  return { result, traceId: span.traceId, spanId: span.id };
+    return {
+      result: {
+        ...streamResult,
+        fullStream: wrappedFullStream,
+      } as unknown as ReturnType<typeof streamText>,
+      traceId: span.traceId,
+      spanId: span.id,
+    };
+  } catch (err) {
+    finishRoot({
+      status: "error",
+      stepCount: stepCount || null,
+      errorMessage: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
 }
 
 export async function instrumentedEmbed<T>(
@@ -874,23 +1049,39 @@ export async function instrumentedEmbed<T>(
   execute: () => Promise<{ result: T; responseSizeChars?: number | null; inputTokens?: number | null; outputTokens?: number | null; totalTokens?: number | null; metadata?: Record<string, unknown> }>,
 ): Promise<{ result: T; traceId: string; spanId: string }> {
   const span = startSpan(runtime, telemetry);
+  const lane = getTrafficLane(telemetry.process, telemetry.surface ?? null);
+  const permit = await acquireLlmTrafficPermit(lane);
 
   try {
-    const output = await execute();
+    const output = await runWithLlmTrafficPermitContext(permit, execute);
     finishSpan(runtime, span, {
       status: "ok",
       inputTokens: output.inputTokens ?? null,
       outputTokens: output.outputTokens ?? null,
       totalTokens: output.totalTokens ?? null,
       responseSizeChars: output.responseSizeChars ?? null,
-      metadata: output.metadata,
+      metadata: {
+        ...(output.metadata ?? {}),
+        queueLane: lane,
+        queueWaitMs: permit.queueWaitMs,
+        queueDepthAtEnqueue: permit.queueDepthAtEnqueue,
+        queueDepthAtStart: permit.queueDepthAtStart,
+      },
     });
     return { result: output.result, traceId: span.traceId, spanId: span.id };
   } catch (err) {
     finishSpan(runtime, span, {
       status: "error",
       errorMessage: err instanceof Error ? err.message : String(err),
+      metadata: {
+        queueLane: lane,
+        queueWaitMs: permit.queueWaitMs,
+        queueDepthAtEnqueue: permit.queueDepthAtEnqueue,
+        queueDepthAtStart: permit.queueDepthAtStart,
+      },
     });
     throw err;
+  } finally {
+    permit.release();
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,6 +15,17 @@ export interface Logger {
   debug(msg: string, data?: Record<string, unknown>): void;
 }
 
+export const LLM_TRAFFIC_LANES = ["interactive", "deferred", "background"] as const;
+export type LlmTrafficLane = typeof LLM_TRAFFIC_LANES[number];
+
+export interface LlmTrafficConfig {
+  maxConcurrent?: number;
+  startGapMs?: number;
+  startupDelayMs?: number;
+  swarmAgentConcurrency?: number;
+  reservedInteractiveSlots?: number;
+}
+
 export const TELEMETRY_SPAN_TYPES = ["http", "worker", "llm", "tool", "embed"] as const;
 export type TelemetrySpanType = typeof TELEMETRY_SPAN_TYPES[number];
 
@@ -93,6 +104,7 @@ export interface Config {
     backgroundLearning?: boolean;  // default true
     briefing?: boolean;            // default true
     knowledgeCleanup?: boolean;    // default true
+    llmTraffic?: LlmTrafficConfig;
   };
   knowledge?: {
     defaultTtlDays?: number | null;  // null = no default expiry; config default 90
@@ -120,6 +132,15 @@ export interface Migration {
   version: number;
   up: string; // SQL statement
 }
+
+export type BackgroundJobSourceKind = "manual" | "schedule" | "maintenance";
+export type BackgroundWaitingReason =
+  | "startup_delay"
+  | "interactive_ahead"
+  | "manual_job_ahead"
+  | "scheduled_job_ahead"
+  | "maintenance_job_ahead"
+  | "llm_busy";
 
 export interface Storage {
   db: Database;
@@ -188,6 +209,11 @@ export interface PluginContext {
   json?: boolean;
   exitCode?: number;
   contextProvider?: (query: string) => Promise<string>;
+  backgroundJobs?: {
+    enqueueResearch?: (args: { goal: string; threadId: string | null; resultType?: string; sourceKind?: BackgroundJobSourceKind; sourceScheduleId?: string | null }) => Promise<string> | string;
+    enqueueSwarm?: (args: { goal: string; threadId: string | null; resultType?: string; sourceKind?: BackgroundJobSourceKind; sourceScheduleId?: string | null }) => Promise<string> | string;
+    enqueueBriefing?: (args?: { sourceKind?: BackgroundJobSourceKind; reason?: string }) => Promise<string> | string;
+  };
 }
 
 export interface Command {

--- a/packages/core/test/llm-traffic.test.ts
+++ b/packages/core/test/llm-traffic.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  acquireLlmTrafficPermit,
+  configureLlmTraffic,
+  getDefaultLlmTrafficConfig,
+  getLlmTrafficSnapshot,
+} from "../src/index.js";
+import { runWithLlmTrafficPermitContext } from "../src/llm-traffic.js";
+
+describe("LlmTrafficController", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    configureLlmTraffic(getDefaultLlmTrafficConfig());
+  });
+
+  afterEach(async () => {
+    await vi.runOnlyPendingTimersAsync();
+    vi.useRealTimers();
+    configureLlmTraffic(getDefaultLlmTrafficConfig());
+  });
+
+  it("enforces single concurrency and prioritizes interactive work over background work", async () => {
+    configureLlmTraffic({ maxConcurrent: 1, startGapMs: 0 });
+
+    const backgroundPermitPromise = acquireLlmTrafficPermit("background");
+    await vi.runAllTimersAsync();
+    const backgroundPermit = await backgroundPermitPromise;
+
+    const queuedBackgroundPromise = acquireLlmTrafficPermit("background");
+    const interactivePromise = acquireLlmTrafficPermit("interactive");
+
+    await vi.runAllTimersAsync();
+    const snapshotWhileBusy = getLlmTrafficSnapshot();
+    expect(snapshotWhileBusy.activeTotal).toBe(1);
+    expect(snapshotWhileBusy.queued.background).toBe(1);
+    expect(snapshotWhileBusy.queued.interactive).toBe(1);
+
+    backgroundPermit.release();
+    await vi.runAllTimersAsync();
+
+    const interactivePermit = await interactivePromise;
+    const snapshotAfterInteractiveStart = getLlmTrafficSnapshot();
+    expect(snapshotAfterInteractiveStart.active.interactive).toBe(1);
+    expect(snapshotAfterInteractiveStart.queued.background).toBe(1);
+
+    interactivePermit.release();
+    await vi.runAllTimersAsync();
+
+    const queuedBackgroundPermit = await queuedBackgroundPromise;
+    expect(getLlmTrafficSnapshot().active.background).toBe(1);
+    queuedBackgroundPermit.release();
+    await vi.runAllTimersAsync();
+    expect(getLlmTrafficSnapshot().activeTotal).toBe(0);
+  });
+
+  it("preserves FIFO order within a lane", async () => {
+    configureLlmTraffic({ maxConcurrent: 1, startGapMs: 0 });
+
+    const firstInteractive = await (async () => {
+      const permit = acquireLlmTrafficPermit("interactive");
+      await vi.runAllTimersAsync();
+      return permit;
+    })();
+
+    const resolutionOrder: string[] = [];
+    const backgroundOne = acquireLlmTrafficPermit("background").then((permit) => {
+      resolutionOrder.push("background-one");
+      return permit;
+    });
+    const backgroundTwo = acquireLlmTrafficPermit("background").then((permit) => {
+      resolutionOrder.push("background-two");
+      return permit;
+    });
+
+    firstInteractive.release();
+    await vi.runAllTimersAsync();
+
+    const firstBackground = await backgroundOne;
+    expect(resolutionOrder).toEqual(["background-one"]);
+
+    firstBackground.release();
+    await vi.runAllTimersAsync();
+
+    const secondBackground = await backgroundTwo;
+    expect(resolutionOrder).toEqual(["background-one", "background-two"]);
+    secondBackground.release();
+  });
+
+  it("stagger starts for background work using startGapMs", async () => {
+    configureLlmTraffic({ maxConcurrent: 1, startGapMs: 1500 });
+
+    const firstBackground = await (async () => {
+      const permit = acquireLlmTrafficPermit("background");
+      await vi.runAllTimersAsync();
+      return permit;
+    })();
+
+    let secondResolved = false;
+    const secondBackgroundPromise = acquireLlmTrafficPermit("background").then((permit) => {
+      secondResolved = true;
+      return permit;
+    });
+
+    firstBackground.release();
+    await vi.advanceTimersByTimeAsync(1499);
+    expect(secondResolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    const secondBackground = await secondBackgroundPromise;
+    expect(secondResolved).toBe(true);
+    expect(secondBackground.queueWaitMs).toBeGreaterThanOrEqual(1500);
+    secondBackground.release();
+  });
+
+  it("reserves interactive capacity from background work", async () => {
+    configureLlmTraffic({ maxConcurrent: 2, reservedInteractiveSlots: 1, startGapMs: 0 });
+
+    const firstBackground = await (async () => {
+      const permit = acquireLlmTrafficPermit("background");
+      await vi.runAllTimersAsync();
+      return permit;
+    })();
+
+    let secondBackgroundResolved = false;
+    const secondBackgroundPromise = acquireLlmTrafficPermit("background").then((permit) => {
+      secondBackgroundResolved = true;
+      return permit;
+    });
+
+    await vi.runAllTimersAsync();
+    expect(secondBackgroundResolved).toBe(false);
+
+    const interactivePromise = acquireLlmTrafficPermit("interactive");
+    await vi.runAllTimersAsync();
+    const interactivePermit = await interactivePromise;
+    expect(getLlmTrafficSnapshot().active.interactive).toBe(1);
+    expect(secondBackgroundResolved).toBe(false);
+
+    interactivePermit.release();
+    await vi.runAllTimersAsync();
+    expect(secondBackgroundResolved).toBe(false);
+
+    firstBackground.release();
+    await vi.runAllTimersAsync();
+    const secondBackground = await secondBackgroundPromise;
+    expect(secondBackgroundResolved).toBe(true);
+    secondBackground.release();
+  });
+
+  it("reuses the active permit for nested interactive work", async () => {
+    configureLlmTraffic({ maxConcurrent: 1, startGapMs: 0 });
+
+    const permit = await (async () => {
+      const pending = acquireLlmTrafficPermit("interactive");
+      await vi.runAllTimersAsync();
+      return pending;
+    })();
+
+    await runWithLlmTrafficPermitContext(permit, async () => {
+      const nested = await acquireLlmTrafficPermit("interactive");
+      expect(nested.queueWaitMs).toBe(0);
+      expect(getLlmTrafficSnapshot().activeTotal).toBe(1);
+      nested.release();
+      expect(getLlmTrafficSnapshot().activeTotal).toBe(1);
+    });
+
+    permit.release();
+    await vi.runAllTimersAsync();
+    expect(getLlmTrafficSnapshot().activeTotal).toBe(0);
+  });
+});

--- a/packages/plugin-assistant/src/tools.ts
+++ b/packages/plugin-assistant/src/tools.ts
@@ -316,36 +316,44 @@ export function createAgentTools(ctx: AgentContext) {
           const threadId = (ctx as unknown as Record<string, unknown>).threadId as string | undefined;
 
           const resultType = type;
-          const jobId = createResearchJob(ctx.storage, {
-            goal,
-            threadId: threadId ?? null,
-            resultType,
-          });
+          const jobId = ctx.backgroundJobs?.enqueueResearch
+            ? await ctx.backgroundJobs.enqueueResearch({
+              goal,
+              threadId: threadId ?? null,
+              resultType,
+              sourceKind: "manual",
+            })
+            : createResearchJob(ctx.storage, {
+              goal,
+              threadId: threadId ?? null,
+              resultType,
+            });
 
-          // Fire and forget — pass injected dependencies
-          runResearchInBackground(
-            {
-              storage: ctx.storage,
-              llm: ctx.llm,
-              logger: ctx.logger,
-              timezone: ctx.config.timezone,
-              provider: ctx.config.llm.provider,
-              model: ctx.config.llm.model,
-              contextWindow: ctx.config.llm.contextWindow,
-              sandboxUrl: ctx.config.sandboxUrl,
-              browserUrl: ctx.config.browserUrl,
-              dataDir: ctx.config.dataDir,
-              webSearch: (query: string, maxResults?: number) => webSearch(query, maxResults, "general", ctx.config.searchUrl),
-              formatSearchResults,
-              fetchPage: fetchPageAsMarkdown,
-            },
-            jobId,
-          ).catch((err) => {
-            ctx.logger.error(`Research background execution failed: ${err instanceof Error ? err.message : String(err)}`);
-          });
+          if (!ctx.backgroundJobs?.enqueueResearch) {
+            runResearchInBackground(
+              {
+                storage: ctx.storage,
+                llm: ctx.llm,
+                logger: ctx.logger,
+                timezone: ctx.config.timezone,
+                provider: ctx.config.llm.provider,
+                model: ctx.config.llm.model,
+                contextWindow: ctx.config.llm.contextWindow,
+                sandboxUrl: ctx.config.sandboxUrl,
+                browserUrl: ctx.config.browserUrl,
+                dataDir: ctx.config.dataDir,
+                webSearch: (query: string, maxResults?: number) => webSearch(query, maxResults, "general", ctx.config.searchUrl),
+                formatSearchResults,
+                fetchPage: fetchPageAsMarkdown,
+              },
+              jobId,
+            ).catch((err) => {
+              ctx.logger.error(`Research background execution failed: ${err instanceof Error ? err.message : String(err)}`);
+            });
+          }
 
           const domainLabel = resultType === "flight" ? "flight search" : resultType === "stock" ? "stock analysis" : "research";
-          return `Research started! I'm running a ${domainLabel} for "${goal.slice(0, 80)}". The report will appear in your Inbox when it's done. Use job_status to check progress.`;
+          return `Research queued! I'm preparing a ${domainLabel} for "${goal.slice(0, 80)}". The report will appear in your Inbox when it's done. Use job_status to check progress.`;
         } catch (err) {
           return `Failed to start research: ${err instanceof Error ? err.message : "unknown error"}`;
         }
@@ -362,35 +370,43 @@ export function createAgentTools(ctx: AgentContext) {
         try {
           const threadId = (ctx as unknown as Record<string, unknown>).threadId as string | undefined;
 
-          const jobId = createSwarmJob(ctx.storage, {
-            goal,
-            threadId: threadId ?? null,
-            resultType: type,
-          });
+          const jobId = ctx.backgroundJobs?.enqueueSwarm
+            ? await ctx.backgroundJobs.enqueueSwarm({
+              goal,
+              threadId: threadId ?? null,
+              resultType: type,
+              sourceKind: "manual",
+            })
+            : createSwarmJob(ctx.storage, {
+              goal,
+              threadId: threadId ?? null,
+              resultType: type,
+            });
 
-          // Fire and forget
-          runSwarmInBackground(
-            {
-              storage: ctx.storage,
-              llm: ctx.llm,
-              logger: ctx.logger,
-              timezone: ctx.config.timezone,
-              provider: ctx.config.llm.provider,
-              model: ctx.config.llm.model,
-              contextWindow: ctx.config.llm.contextWindow,
-              sandboxUrl: ctx.config.sandboxUrl,
-              browserUrl: ctx.config.browserUrl,
-              dataDir: ctx.config.dataDir,
-              webSearch: (query: string, maxResults?: number) => webSearch(query, maxResults, "general", ctx.config.searchUrl),
-              formatSearchResults,
-              fetchPage: fetchPageAsMarkdown,
-            },
-            jobId,
-          ).catch((err) => {
-            ctx.logger.error(`Swarm background execution failed: ${err instanceof Error ? err.message : String(err)}`);
-          });
+          if (!ctx.backgroundJobs?.enqueueSwarm) {
+            runSwarmInBackground(
+              {
+                storage: ctx.storage,
+                llm: ctx.llm,
+                logger: ctx.logger,
+                timezone: ctx.config.timezone,
+                provider: ctx.config.llm.provider,
+                model: ctx.config.llm.model,
+                contextWindow: ctx.config.llm.contextWindow,
+                sandboxUrl: ctx.config.sandboxUrl,
+                browserUrl: ctx.config.browserUrl,
+                dataDir: ctx.config.dataDir,
+                webSearch: (query: string, maxResults?: number) => webSearch(query, maxResults, "general", ctx.config.searchUrl),
+                formatSearchResults,
+                fetchPage: fetchPageAsMarkdown,
+              },
+              jobId,
+            ).catch((err) => {
+              ctx.logger.error(`Swarm background execution failed: ${err instanceof Error ? err.message : String(err)}`);
+            });
+          }
 
-          return `Swarm analysis started! I'm spawning multiple sub-agents for a ${type} analysis of "${goal.slice(0, 80)}" in parallel. The synthesized report will appear in your Inbox when done. Use job_status to check progress.`;
+          return `Swarm analysis queued! I'm preparing a ${type} analysis of "${goal.slice(0, 80)}". The synthesized report will appear in your Inbox when done. Use job_status to check progress.`;
         } catch (err) {
           return `Failed to start swarm: ${err instanceof Error ? err.message : "unknown error"}`;
         }

--- a/packages/plugin-research/src/index.ts
+++ b/packages/plugin-research/src/index.ts
@@ -1,6 +1,6 @@
 import type { Plugin, PluginContext, Command, Migration } from "@personal-ai/core";
 
-export { runResearchInBackground, createResearchJob, getResearchJob, listResearchJobs, cancelResearchJob, recoverStaleResearchJobs, cancelAllRunningResearchJobs, clearCompletedJobs } from "./research.js";
+export { runResearchInBackground, createResearchJob, getResearchJob, listResearchJobs, listPendingResearchJobs, cancelResearchJob, recoverStaleResearchJobs, cancelAllRunningResearchJobs, clearCompletedJobs } from "./research.js";
 export type { ResearchJob, ResearchContext } from "./research.js";
 
 export const researchMigrations: Migration[] = [
@@ -28,6 +28,17 @@ export const researchMigrations: Migration[] = [
   {
     version: 2,
     up: `ALTER TABLE research_jobs ADD COLUMN result_type TEXT DEFAULT 'general';`,
+  },
+  {
+    version: 3,
+    up: `
+      ALTER TABLE research_jobs ADD COLUMN queued_at TEXT;
+      ALTER TABLE research_jobs ADD COLUMN started_at TEXT;
+      ALTER TABLE research_jobs ADD COLUMN attempt_count INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE research_jobs ADD COLUMN last_attempt_at TEXT;
+      ALTER TABLE research_jobs ADD COLUMN source_kind TEXT NOT NULL DEFAULT 'manual';
+      ALTER TABLE research_jobs ADD COLUMN source_schedule_id TEXT;
+    `,
   },
 ];
 

--- a/packages/plugin-research/src/research.ts
+++ b/packages/plugin-research/src/research.ts
@@ -2,7 +2,7 @@ import { tool, stepCountIs } from "ai";
 import type { LanguageModel } from "ai";
 import { z } from "zod";
 import { nanoid } from "nanoid";
-import type { Storage, LLMClient, Logger, ResearchResultType } from "@personal-ai/core";
+import type { BackgroundJobSourceKind, Storage, LLMClient, Logger, ResearchResultType } from "@personal-ai/core";
 import {
   formatDateTime,
   detectResearchDomain,
@@ -15,6 +15,11 @@ import {
 } from "@personal-ai/core";
 import { upsertJob, updateJobStatus, knowledgeSearch, appendMessages, learnFromContent, createBrowserTools } from "@personal-ai/core";
 import type { BackgroundJob } from "@personal-ai/core";
+
+const RESEARCH_LLM_TIMEOUT = {
+  totalMs: 10 * 60_000,
+  stepMs: 90_000,
+} as const;
 
 // ---- Types ----
 
@@ -32,6 +37,12 @@ export interface ResearchJob {
   report: string | null;
   briefingId: string | null;
   createdAt: string;
+  queuedAt: string;
+  startedAt: string | null;
+  attemptCount: number;
+  lastAttemptAt: string | null;
+  sourceKind: BackgroundJobSourceKind;
+  sourceScheduleId: string | null;
   completedAt: string | null;
 }
 
@@ -49,6 +60,12 @@ interface ResearchJobRow {
   report: string | null;
   briefing_id: string | null;
   created_at: string;
+  queued_at: string | null;
+  started_at: string | null;
+  attempt_count: number | null;
+  last_attempt_at: string | null;
+  source_kind: string | null;
+  source_schedule_id: string | null;
   completed_at: string | null;
 }
 
@@ -82,16 +99,17 @@ export interface ResearchContext {
 
 export function createResearchJob(
   storage: Storage,
-  opts: { goal: string; threadId: string | null; maxSearches?: number; maxPages?: number; resultType?: ResearchResultType },
+  opts: { goal: string; threadId: string | null; maxSearches?: number; maxPages?: number; resultType?: ResearchResultType; sourceKind?: BackgroundJobSourceKind; sourceScheduleId?: string | null },
 ): string {
   const id = nanoid();
+  const queuedAt = new Date().toISOString();
   // Cross-validate LLM-provided type against keyword detection to prevent misclassification
   const detected = detectResearchDomain(opts.goal);
   const detectedType = detected !== "general" ? detected : (opts.resultType ?? "general");
   storage.run(
-    `INSERT INTO research_jobs (id, thread_id, goal, status, result_type, budget_max_searches, budget_max_pages, created_at)
-     VALUES (?, ?, ?, 'pending', ?, ?, ?, datetime('now'))`,
-    [id, opts.threadId, opts.goal, detectedType, opts.maxSearches ?? 5, opts.maxPages ?? 3],
+    `INSERT INTO research_jobs (id, thread_id, goal, status, result_type, budget_max_searches, budget_max_pages, created_at, queued_at, source_kind, source_schedule_id)
+     VALUES (?, ?, ?, 'pending', ?, ?, ?, datetime('now'), ?, ?, ?)`,
+    [id, opts.threadId, opts.goal, detectedType, opts.maxSearches ?? 5, opts.maxPages ?? 3, queuedAt, opts.sourceKind ?? "manual", opts.sourceScheduleId ?? null],
   );
   return id;
 }
@@ -117,6 +135,12 @@ export function getResearchJob(storage: Storage, id: string): ResearchJob | null
     report: row.report,
     briefingId: row.briefing_id,
     createdAt: row.created_at,
+    queuedAt: row.queued_at ?? row.created_at,
+    startedAt: row.started_at,
+    attemptCount: row.attempt_count ?? 0,
+    lastAttemptAt: row.last_attempt_at,
+    sourceKind: (row.source_kind as BackgroundJobSourceKind | null) ?? "manual",
+    sourceScheduleId: row.source_schedule_id,
     completedAt: row.completed_at,
   };
 }
@@ -139,6 +163,12 @@ export function listResearchJobs(storage: Storage): ResearchJob[] {
     report: row.report,
     briefingId: row.briefing_id,
     createdAt: row.created_at,
+    queuedAt: row.queued_at ?? row.created_at,
+    startedAt: row.started_at,
+    attemptCount: row.attempt_count ?? 0,
+    lastAttemptAt: row.last_attempt_at,
+    sourceKind: (row.source_kind as BackgroundJobSourceKind | null) ?? "manual",
+    sourceScheduleId: row.source_schedule_id,
     completedAt: row.completed_at,
   }));
 }
@@ -159,7 +189,18 @@ export function recoverStaleResearchJobs(storage: Storage): number {
   )[0]?.cnt ?? 0;
   if (count > 0) {
     storage.run(
-      "UPDATE research_jobs SET status = 'failed', completed_at = datetime('now') WHERE status IN ('running', 'pending')",
+      `UPDATE research_jobs
+       SET status = 'pending',
+           report = NULL,
+           briefing_id = NULL,
+           searches_used = 0,
+           pages_learned = 0,
+           steps_log = '[]',
+           started_at = NULL,
+           completed_at = NULL,
+           last_attempt_at = NULL,
+           attempt_count = attempt_count + 1
+       WHERE status IN ('running', 'pending')`,
     );
   }
   return count;
@@ -185,11 +226,40 @@ export function clearCompletedJobs(storage: Storage): number {
   return count;
 }
 
+export function listPendingResearchJobs(storage: Storage): ResearchJob[] {
+  const rows = storage.query<ResearchJobRow>(
+    "SELECT * FROM research_jobs WHERE status = 'pending' ORDER BY CASE source_kind WHEN 'manual' THEN 0 WHEN 'schedule' THEN 1 ELSE 2 END, queued_at ASC, created_at ASC",
+  );
+  return rows.map((row) => ({
+    id: row.id,
+    threadId: row.thread_id,
+    goal: row.goal,
+    status: row.status as ResearchJob["status"],
+    resultType: (row.result_type as ResearchResultType) ?? "general",
+    budgetMaxSearches: row.budget_max_searches,
+    budgetMaxPages: row.budget_max_pages,
+    searchesUsed: row.searches_used,
+    pagesLearned: row.pages_learned,
+    stepsLog: JSON.parse(row.steps_log) as string[],
+    report: row.report,
+    briefingId: row.briefing_id,
+    createdAt: row.created_at,
+    queuedAt: row.queued_at ?? row.created_at,
+    startedAt: row.started_at,
+    attemptCount: row.attempt_count ?? 0,
+    lastAttemptAt: row.last_attempt_at,
+    sourceKind: (row.source_kind as BackgroundJobSourceKind | null) ?? "manual",
+    sourceScheduleId: row.source_schedule_id,
+    completedAt: row.completed_at,
+  }));
+}
+
 // Allowlist of column names that can be updated on research_jobs
 const RESEARCH_JOB_COLUMNS = new Set([
   "status", "report", "result_type", "error",
   "searches_used", "pages_learned", "steps_log",
   "briefing_id", "completed_at",
+  "queued_at", "started_at", "attempt_count", "last_attempt_at", "source_kind", "source_schedule_id",
 ]);
 
 function updateJob(storage: Storage, id: string, fields: Record<string, unknown>): void {
@@ -1094,6 +1164,9 @@ export async function runResearchInBackground(
     return;
   }
 
+  const startedAt = new Date().toISOString();
+  const nextAttempt = (job.attemptCount ?? 0) + 1;
+
   // Register in shared tracker (DB-backed)
   const tracked: BackgroundJob = {
     id: jobId,
@@ -1101,12 +1174,25 @@ export async function runResearchInBackground(
     label: job.goal.slice(0, 100),
     status: "running",
     progress: "starting",
-    startedAt: new Date().toISOString(),
+    startedAt,
+    queuedAt: job.queuedAt,
+    attemptCount: nextAttempt,
+    lastAttemptAt: startedAt,
+    sourceKind: job.sourceKind,
+    sourceScheduleId: job.sourceScheduleId,
   };
   upsertJob(ctx.storage, tracked);
 
   // Set status to running
-  updateJob(ctx.storage, jobId, { status: "running" });
+  updateJob(ctx.storage, jobId, {
+    status: "running",
+    started_at: startedAt,
+    last_attempt_at: startedAt,
+    attempt_count: nextAttempt,
+    completed_at: null,
+    report: null,
+    briefing_id: null,
+  });
 
   try {
     const tools = createResearchTools(ctx, jobId, job);
@@ -1146,6 +1232,7 @@ export async function runResearchInBackground(
         toolChoice: "auto",
         stopWhen: stepCountIs(15),
         maxRetries: 1,
+        timeout: RESEARCH_LLM_TIMEOUT,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         providerOptions: getProviderOptions(ctx.provider ?? "ollama", budget.contextWindow) as any,
       },
@@ -1277,6 +1364,12 @@ export async function runResearchInBackground(
       result: presentation.report.slice(0, 200),
       resultType: job.resultType,
       ...(structuredResult ? { structuredResult } : {}),
+      queuedAt: job.queuedAt,
+      startedAt,
+      attemptCount: nextAttempt,
+      lastAttemptAt: startedAt,
+      sourceKind: job.sourceKind,
+      sourceScheduleId: job.sourceScheduleId,
     });
 
     // Create Inbox briefing for the report
@@ -1332,7 +1425,16 @@ export async function runResearchInBackground(
       completed_at: new Date().toISOString(),
     });
 
-    updateJobStatus(ctx.storage, jobId, { status: "error", error: errorMsg });
+    updateJobStatus(ctx.storage, jobId, {
+      status: "error",
+      error: errorMsg,
+      queuedAt: job.queuedAt,
+      startedAt,
+      attemptCount: nextAttempt,
+      lastAttemptAt: startedAt,
+      sourceKind: job.sourceKind,
+      sourceScheduleId: job.sourceScheduleId,
+    });
 
     // Post failure to thread
     if (job.threadId) {

--- a/packages/plugin-research/test/research.test.ts
+++ b/packages/plugin-research/test/research.test.ts
@@ -110,6 +110,12 @@ describe("Research jobs", () => {
       expect(job!.status).toBe("done");
       expect(job!.report).toContain("Research Report");
       expect(job!.completedAt).not.toBeNull();
+      expect(generateText).toHaveBeenCalledWith(expect.objectContaining({
+        timeout: {
+          totalMs: 10 * 60_000,
+          stepMs: 90_000,
+        },
+      }));
     });
 
     it("sets job to failed when generateText throws", async () => {

--- a/packages/plugin-swarm/src/index.ts
+++ b/packages/plugin-swarm/src/index.ts
@@ -1,4 +1,4 @@
-import type { Plugin, PluginContext, Command, Migration, Storage } from "@personal-ai/core";
+import type { BackgroundJobSourceKind, Plugin, PluginContext, Command, Migration, Storage } from "@personal-ai/core";
 import { detectResearchDomain } from "@personal-ai/core";
 import { nanoid } from "nanoid";
 
@@ -19,6 +19,12 @@ export interface SwarmJob {
   synthesis: string | null;
   briefingId: string | null;
   createdAt: string;
+  queuedAt: string;
+  startedAt: string | null;
+  attemptCount: number;
+  lastAttemptAt: string | null;
+  sourceKind: BackgroundJobSourceKind;
+  sourceScheduleId: string | null;
   completedAt: string | null;
 }
 
@@ -65,6 +71,12 @@ interface SwarmJobRow {
   synthesis: string | null;
   briefing_id: string | null;
   created_at: string;
+  queued_at: string | null;
+  started_at: string | null;
+  attempt_count: number | null;
+  last_attempt_at: string | null;
+  source_kind: string | null;
+  source_schedule_id: string | null;
   completed_at: string | null;
 }
 
@@ -142,15 +154,27 @@ export const swarmMigrations: Migration[] = [
     version: 2,
     up: `ALTER TABLE swarm_jobs ADD COLUMN result_type TEXT NOT NULL DEFAULT 'general';`,
   },
+  {
+    version: 3,
+    up: `
+      ALTER TABLE swarm_jobs ADD COLUMN queued_at TEXT;
+      ALTER TABLE swarm_jobs ADD COLUMN started_at TEXT;
+      ALTER TABLE swarm_jobs ADD COLUMN attempt_count INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE swarm_jobs ADD COLUMN last_attempt_at TEXT;
+      ALTER TABLE swarm_jobs ADD COLUMN source_kind TEXT NOT NULL DEFAULT 'manual';
+      ALTER TABLE swarm_jobs ADD COLUMN source_schedule_id TEXT;
+    `,
+  },
 ];
 
 // ---- Data Access ----
 
 export function createSwarmJob(
   storage: Storage,
-  opts: { goal: string; threadId: string | null; resultType?: string },
+  opts: { goal: string; threadId: string | null; resultType?: string; sourceKind?: BackgroundJobSourceKind; sourceScheduleId?: string | null },
 ): string {
   const id = nanoid();
+  const queuedAt = new Date().toISOString();
   // Cross-validate LLM-provided type against keyword detection to prevent misclassification
   let resultType = opts.resultType ?? "general";
   const detected = detectResearchDomain(opts.goal);
@@ -159,9 +183,9 @@ export function createSwarmJob(
     resultType = detected;
   }
   storage.run(
-    `INSERT INTO swarm_jobs (id, thread_id, goal, result_type, status, created_at)
-     VALUES (?, ?, ?, ?, 'pending', datetime('now'))`,
-    [id, opts.threadId, opts.goal, resultType],
+    `INSERT INTO swarm_jobs (id, thread_id, goal, result_type, status, created_at, queued_at, source_kind, source_schedule_id)
+     VALUES (?, ?, ?, ?, 'pending', datetime('now'), ?, ?, ?)`,
+    [id, opts.threadId, opts.goal, resultType, queuedAt, opts.sourceKind ?? "manual", opts.sourceScheduleId ?? null],
   );
   return id;
 }
@@ -179,6 +203,13 @@ export function getSwarmJob(storage: Storage, id: string): SwarmJob | null {
 export function listSwarmJobs(storage: Storage): SwarmJob[] {
   const rows = storage.query<SwarmJobRow>(
     "SELECT * FROM swarm_jobs ORDER BY created_at DESC LIMIT 50",
+  );
+  return rows.map(rowToSwarmJob);
+}
+
+export function listPendingSwarmJobs(storage: Storage): SwarmJob[] {
+  const rows = storage.query<SwarmJobRow>(
+    "SELECT * FROM swarm_jobs WHERE status = 'pending' ORDER BY CASE source_kind WHEN 'manual' THEN 0 WHEN 'schedule' THEN 1 ELSE 2 END, queued_at ASC, created_at ASC",
   );
   return rows.map(rowToSwarmJob);
 }
@@ -205,10 +236,24 @@ export function recoverStaleSwarmJobs(storage: Storage): number {
   )[0]?.cnt ?? 0;
   if (count > 0) {
     storage.run(
-      `UPDATE swarm_agents SET status = 'failed', error = 'Server restarted — job interrupted', completed_at = datetime('now') WHERE swarm_id IN (SELECT id FROM swarm_jobs WHERE status IN ${activeStatuses}) AND status IN ('pending', 'running')`,
+      `DELETE FROM swarm_blackboard WHERE swarm_id IN (SELECT id FROM swarm_jobs WHERE status IN ${activeStatuses})`,
     );
     storage.run(
-      `UPDATE swarm_jobs SET status = 'failed', completed_at = datetime('now') WHERE status IN ${activeStatuses}`,
+      `DELETE FROM swarm_agents WHERE swarm_id IN (SELECT id FROM swarm_jobs WHERE status IN ${activeStatuses})`,
+    );
+    storage.run(
+      `UPDATE swarm_jobs
+       SET status = 'pending',
+           plan = NULL,
+           agent_count = 0,
+           agents_done = 0,
+           synthesis = NULL,
+           briefing_id = NULL,
+           started_at = NULL,
+           completed_at = NULL,
+           last_attempt_at = NULL,
+           attempt_count = attempt_count + 1
+       WHERE status IN ${activeStatuses}`,
     );
   }
   return count;
@@ -250,6 +295,7 @@ const SWARM_JOB_COLUMNS = new Set([
   "status", "result_type", "error",
   "plan", "agent_count", "agents_done", "synthesis",
   "briefing_id", "completed_at",
+  "queued_at", "started_at", "attempt_count", "last_attempt_at", "source_kind", "source_schedule_id",
 ]);
 
 export function updateSwarmJob(storage: Storage, id: string, fields: Record<string, unknown>): void {
@@ -343,6 +389,12 @@ function rowToSwarmJob(row: SwarmJobRow): SwarmJob {
     synthesis: row.synthesis,
     briefingId: row.briefing_id,
     createdAt: row.created_at,
+    queuedAt: row.queued_at ?? row.created_at,
+    startedAt: row.started_at,
+    attemptCount: row.attempt_count ?? 0,
+    lastAttemptAt: row.last_attempt_at,
+    sourceKind: (row.source_kind as BackgroundJobSourceKind | null) ?? "manual",
+    sourceScheduleId: row.source_schedule_id,
     completedAt: row.completed_at,
   };
 }

--- a/packages/plugin-swarm/src/swarm.ts
+++ b/packages/plugin-swarm/src/swarm.ts
@@ -10,6 +10,7 @@ import {
   resolveSandboxUrl,
   getContextBudget,
   getProviderOptions,
+  getLlmTrafficConfig,
   createBrowserTools,
   buildReportPresentation,
   deriveReportVisuals,
@@ -39,6 +40,11 @@ import {
   getStockResearcherPrompt,
   getCryptoResearcherPrompt,
 } from "./prompts.js";
+
+const SWARM_LLM_TIMEOUT = {
+  totalMs: 10 * 60_000,
+  stepMs: 90_000,
+} as const;
 
 // ---- Types ----
 
@@ -180,6 +186,9 @@ export async function runSwarmInBackground(
     return;
   }
 
+  const startedAt = new Date().toISOString();
+  const nextAttempt = (job.attemptCount ?? 0) + 1;
+
   // Register in shared background_jobs tracker
   const tracked: BackgroundJob = {
     id: jobId,
@@ -187,14 +196,35 @@ export async function runSwarmInBackground(
     label: job.goal.slice(0, 100),
     status: "running",
     progress: "planning",
-    startedAt: new Date().toISOString(),
+    startedAt,
+    queuedAt: job.queuedAt,
+    attemptCount: nextAttempt,
+    lastAttemptAt: startedAt,
+    sourceKind: job.sourceKind,
+    sourceScheduleId: job.sourceScheduleId,
   };
   upsertJob(ctx.storage, tracked);
 
   try {
     // Phase 1: Plan — decompose goal into subtasks
-    updateSwarmJob(ctx.storage, jobId, { status: "planning" });
-    updateJobStatus(ctx.storage, jobId, { progress: "planning subtasks" });
+    updateSwarmJob(ctx.storage, jobId, {
+      status: "planning",
+      started_at: startedAt,
+      last_attempt_at: startedAt,
+      attempt_count: nextAttempt,
+      completed_at: null,
+      synthesis: null,
+      briefing_id: null,
+    });
+    updateJobStatus(ctx.storage, jobId, {
+      progress: "planning subtasks",
+      queuedAt: job.queuedAt,
+      startedAt,
+      attemptCount: nextAttempt,
+      lastAttemptAt: startedAt,
+      sourceKind: job.sourceKind,
+      sourceScheduleId: job.sourceScheduleId,
+    });
 
     const planned = await planSwarm(ctx, job.goal, job.resultType);
     const executablePlan = ensureAnalysisPlan(planned, job.goal, job.resultType);
@@ -237,6 +267,12 @@ export async function runSwarmInBackground(
       result: presentation.report.slice(0, 200),
       resultType: job.resultType || "general",
       ...(structuredResult ? { structuredResult } : {}),
+      queuedAt: job.queuedAt,
+      startedAt,
+      attemptCount: nextAttempt,
+      lastAttemptAt: startedAt,
+      sourceKind: job.sourceKind,
+      sourceScheduleId: job.sourceScheduleId,
     });
 
     // Create Inbox briefing
@@ -291,7 +327,16 @@ export async function runSwarmInBackground(
       completed_at: new Date().toISOString(),
     });
 
-    updateJobStatus(ctx.storage, jobId, { status: "error", error: errorMsg });
+    updateJobStatus(ctx.storage, jobId, {
+      status: "error",
+      error: errorMsg,
+      queuedAt: job.queuedAt,
+      startedAt,
+      attemptCount: nextAttempt,
+      lastAttemptAt: startedAt,
+      sourceKind: job.sourceKind,
+      sourceScheduleId: job.sourceScheduleId,
+    });
 
     if (job.threadId) {
       try {
@@ -324,6 +369,7 @@ async function planSwarm(ctx: SwarmContext, goal: string, resultType?: string): 
           { role: "user", content: `Decompose this goal into parallel subtasks:\n\n${goal}${domainHint}` },
         ],
         maxRetries: 1,
+        timeout: SWARM_LLM_TIMEOUT,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         providerOptions: getProviderOptions(ctx.provider ?? "ollama", budget.contextWindow) as any,
       },
@@ -377,19 +423,25 @@ async function executePlan(ctx: SwarmContext, jobId: string, plan: SwarmPlanItem
     progress: `running ${plan.length} agents`,
   });
 
-  // Execute all agents in parallel
-  const promises = plan.map((item, i) =>
-    runSubAgent(ctx, jobId, agentIds[i]!, item, resultType).catch((err) => {
+  const maxConcurrent = Math.max(1, getLlmTrafficConfig().swarmAgentConcurrency);
+  let nextIndex = 0;
+  const runNext = async (): Promise<void> => {
+    const index = nextIndex++;
+    if (index >= plan.length) return;
+    try {
+      await runSubAgent(ctx, jobId, agentIds[index]!, plan[index]!, resultType);
+    } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
-      updateSwarmAgent(ctx.storage, agentIds[i]!, {
+      updateSwarmAgent(ctx.storage, agentIds[index]!, {
         status: "failed",
         error: errorMsg,
         completed_at: new Date().toISOString(),
       });
-    }),
-  );
+    }
+    await runNext();
+  };
 
-  await Promise.allSettled(promises);
+  await Promise.all(Array.from({ length: Math.min(maxConcurrent, plan.length) }, () => runNext()));
 
   // Update agents_done count
   const agents = getSwarmAgents(ctx.storage, jobId);
@@ -429,6 +481,7 @@ async function runSubAgent(
       toolChoice: "auto",
       stopWhen: stepCountIs(AGENT_STEP_LIMIT),
       maxRetries: 1,
+      timeout: SWARM_LLM_TIMEOUT,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       providerOptions: getProviderOptions(ctx.provider ?? "ollama", agentBudget.contextWindow) as any,
     },
@@ -688,6 +741,7 @@ async function synthesize(
         },
       ],
       maxRetries: 1,
+      timeout: SWARM_LLM_TIMEOUT,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       providerOptions: getProviderOptions(ctx.provider ?? "ollama", synthBudget.contextWindow) as any,
     },

--- a/packages/plugin-swarm/test/swarm.test.ts
+++ b/packages/plugin-swarm/test/swarm.test.ts
@@ -137,7 +137,7 @@ describe("Swarm jobs", () => {
   });
 
   describe("recoverStaleSwarmJobs", () => {
-    it("marks running jobs and agents as failed", () => {
+    it("requeues running jobs and clears partial agent state", () => {
       const id1 = createSwarmJob(storage, { goal: "running job", threadId: null });
       const id2 = createSwarmJob(storage, { goal: "done job", threadId: null });
       updateSwarmJob(storage, id1, { status: "running" });
@@ -165,17 +165,14 @@ describe("Swarm jobs", () => {
       const recovered = recoverStaleSwarmJobs(storage);
       expect(recovered).toBe(1);
 
-      // Job should be failed
+      // Job should be requeued
       const job1 = getSwarmJob(storage, id1);
-      expect(job1!.status).toBe("failed");
+      expect(job1!.status).toBe("pending");
+      expect(job1!.attemptCount).toBe(1);
 
-      // Agents should be failed
+      // Partial agents should be cleared so the dispatcher can restart cleanly
       const agents = getSwarmAgents(storage, id1);
-      expect(agents).toHaveLength(2);
-      for (const a of agents) {
-        expect(a.status).toBe("failed");
-        expect(a.error).toBe("Server restarted — job interrupted");
-      }
+      expect(agents).toHaveLength(0);
 
       // Done job should be untouched
       const job2 = getSwarmJob(storage, id2);
@@ -325,6 +322,15 @@ describe("Swarm jobs", () => {
       expect(job!.synthesis).toContain("Swarm Report");
       expect(job!.completedAt).not.toBeNull();
       expect(job!.agentCount).toBe(3);
+      expect(mockInstrumentedGenerateText).toHaveBeenCalled();
+      for (const call of mockInstrumentedGenerateText.mock.calls) {
+        expect(call[1]).toEqual(expect.objectContaining({
+          timeout: {
+            totalMs: 10 * 60_000,
+            stepMs: 90_000,
+          },
+        }));
+      }
 
       // Verify agents were created
       const agents = getSwarmAgents(storage, id);

--- a/packages/plugin-telegram/src/bot.ts
+++ b/packages/plugin-telegram/src/bot.ts
@@ -240,11 +240,18 @@ export function createBot(token: string, ctx: PluginContext, agentPlugin: AgentP
 
     try {
       const threadId = getOrCreateThread(ctx, tgCtx.chat.id, tgCtx.from?.username);
-      const jobId = createResearchJob(ctx.storage, {
-        goal,
-        threadId,
-        resultType: "general",
-      });
+      const jobId = ctx.backgroundJobs?.enqueueResearch
+        ? await ctx.backgroundJobs.enqueueResearch({
+          goal,
+          threadId,
+          resultType: "general",
+          sourceKind: "manual",
+        })
+        : createResearchJob(ctx.storage, {
+          goal,
+          threadId,
+          resultType: "general",
+        });
 
       const researchCtx: ResearchContext = {
         storage: ctx.storage,
@@ -262,11 +269,13 @@ export function createBot(token: string, ctx: PluginContext, agentPlugin: AgentP
         fetchPage: fetchPageAsMarkdown,
       };
 
-      runResearchInBackground(researchCtx, jobId).catch((err) => {
-        ctx.logger.error(`Research background execution failed: ${err instanceof Error ? err.message : String(err)}`);
-      });
+      if (!ctx.backgroundJobs?.enqueueResearch) {
+        runResearchInBackground(researchCtx, jobId).catch((err) => {
+          ctx.logger.error(`Research background execution failed: ${err instanceof Error ? err.message : String(err)}`);
+        });
+      }
 
-      await tgCtx.reply(`\uD83D\uDD2C Starting research: "${goal.slice(0, 80)}"...\n\nI'll send results when done.`);
+      await tgCtx.reply(`\uD83D\uDD2C Research queued: "${goal.slice(0, 80)}"...\n\nI'll send results when done.`);
     } catch (err) {
       ctx.logger.error("Failed to start research", { error: err instanceof Error ? err.message : String(err) });
       await tgCtx.reply("Failed to start research. Please try again.");

--- a/packages/plugin-telegram/src/index.ts
+++ b/packages/plugin-telegram/src/index.ts
@@ -1,6 +1,6 @@
 import type { Plugin, PluginContext, Command, Migration } from "@personal-ai/core";
 import {
-  loadConfig, createStorage, createLLMClient, createLogger,
+  loadConfig, createStorage, createLLMClient, createLogger, configureLlmTraffic,
   memoryMigrations, telemetryMigrations, threadMigrations,
 } from "@personal-ai/core";
 import { taskMigrations } from "@personal-ai/plugin-tasks";
@@ -56,6 +56,7 @@ if (isDirectExecution) {
     process.exit(1);
   }
   const logger = createLogger(config.logLevel, { dir: config.dataDir });
+  configureLlmTraffic(config.workers?.llmTraffic);
   const storage = createStorage(config.dataDir, logger);
   const llm = createLLMClient(config.llm, logger, storage);
 

--- a/packages/server/src/background-dispatcher.ts
+++ b/packages/server/src/background-dispatcher.ts
@@ -1,0 +1,312 @@
+import type { BackgroundJobSourceKind, BackgroundWaitingReason, PluginContext } from "@personal-ai/core";
+import { getLlmTrafficConfig, getLlmTrafficSnapshot, upsertJob } from "@personal-ai/core";
+import { createResearchJob, listPendingResearchJobs, runResearchInBackground } from "@personal-ai/plugin-research";
+import { createSwarmJob, listPendingSwarmJobs, runSwarmInBackground } from "@personal-ai/plugin-swarm";
+import { formatSearchResults, webSearch } from "@personal-ai/plugin-assistant/web-search";
+import { fetchPageAsMarkdown } from "@personal-ai/plugin-assistant/page-fetch";
+import { enqueueBriefingGeneration, generateBriefing, listPendingDailyBriefings } from "./briefing.js";
+
+type PendingKind = "research" | "swarm" | "briefing";
+
+interface PendingWorkItem {
+  id: string;
+  kind: PendingKind;
+  queuedAt: string;
+  sourceKind: BackgroundJobSourceKind;
+}
+
+const SOURCE_PRIORITY: Record<BackgroundJobSourceKind, number> = {
+  manual: 0,
+  schedule: 1,
+  maintenance: 2,
+};
+
+function compareWork(a: PendingWorkItem, b: PendingWorkItem): number {
+  const aPriority = SOURCE_PRIORITY[a.sourceKind] ?? Number.MAX_SAFE_INTEGER;
+  const bPriority = SOURCE_PRIORITY[b.sourceKind] ?? Number.MAX_SAFE_INTEGER;
+  return aPriority - bPriority
+    || Date.parse(a.queuedAt) - Date.parse(b.queuedAt)
+    || a.id.localeCompare(b.id);
+}
+
+function sourceWaitingReason(sourceKind: BackgroundJobSourceKind): BackgroundWaitingReason {
+  if (sourceKind === "manual") return "manual_job_ahead";
+  if (sourceKind === "schedule") return "scheduled_job_ahead";
+  return "maintenance_job_ahead";
+}
+
+export class BackgroundDispatcher {
+  private startedAt = 0;
+  private running = false;
+  private activeWorkId: string | null = null;
+  private activeKind: PendingKind | null = null;
+  private drainTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly ctx: PluginContext) {}
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.startedAt = Date.now();
+    this.nudge();
+  }
+
+  stop(): void {
+    this.running = false;
+    this.activeWorkId = null;
+    this.activeKind = null;
+    if (this.drainTimer) {
+      clearTimeout(this.drainTimer);
+      this.drainTimer = null;
+    }
+  }
+
+  nudge(delayMs = 0): void {
+    if (!this.running) return;
+    if (this.drainTimer) {
+      clearTimeout(this.drainTimer);
+      this.drainTimer = null;
+    }
+    this.drainTimer = setTimeout(() => {
+      this.drainTimer = null;
+      void this.drain();
+    }, Math.max(0, delayMs));
+  }
+
+  async enqueueResearch(args: {
+    goal: string;
+    threadId: string | null;
+    resultType?: string;
+    sourceKind?: BackgroundJobSourceKind;
+    sourceScheduleId?: string | null;
+  }): Promise<string> {
+    const queuedAt = new Date().toISOString();
+    const sourceKind = args.sourceKind ?? "manual";
+    const jobId = createResearchJob(this.ctx.storage, {
+      goal: args.goal,
+      threadId: args.threadId,
+      resultType: args.resultType as never,
+      sourceKind,
+      sourceScheduleId: args.sourceScheduleId ?? null,
+    });
+    upsertJob(this.ctx.storage, {
+      id: jobId,
+      type: "research",
+      label: args.goal.slice(0, 100),
+      status: "pending",
+      progress: "queued",
+      startedAt: queuedAt,
+      queuedAt,
+      attemptCount: 0,
+      lastAttemptAt: null,
+      sourceKind,
+      sourceScheduleId: args.sourceScheduleId ?? null,
+      resultType: args.resultType as never,
+    });
+    this.nudge();
+    return jobId;
+  }
+
+  async enqueueSwarm(args: {
+    goal: string;
+    threadId: string | null;
+    resultType?: string;
+    sourceKind?: BackgroundJobSourceKind;
+    sourceScheduleId?: string | null;
+  }): Promise<string> {
+    const queuedAt = new Date().toISOString();
+    const sourceKind = args.sourceKind ?? "manual";
+    const jobId = createSwarmJob(this.ctx.storage, {
+      goal: args.goal,
+      threadId: args.threadId,
+      resultType: args.resultType,
+      sourceKind,
+      sourceScheduleId: args.sourceScheduleId ?? null,
+    });
+    upsertJob(this.ctx.storage, {
+      id: jobId,
+      type: "swarm",
+      label: args.goal.slice(0, 100),
+      status: "pending",
+      progress: "queued",
+      startedAt: queuedAt,
+      queuedAt,
+      attemptCount: 0,
+      lastAttemptAt: null,
+      sourceKind,
+      sourceScheduleId: args.sourceScheduleId ?? null,
+      resultType: args.resultType as never,
+    });
+    this.nudge();
+    return jobId;
+  }
+
+  enqueueBriefing(args?: { sourceKind?: BackgroundJobSourceKind; reason?: string }): string {
+    const id = enqueueBriefingGeneration(this.ctx.storage, args?.sourceKind ?? "maintenance");
+    this.nudge();
+    return id;
+  }
+
+  getWorkState(): {
+    startupDelayUntil: number | null;
+    activeWorkId: string | null;
+    activeKind: PendingKind | null;
+    pending: PendingWorkItem[];
+  } {
+    return {
+      startupDelayUntil: this.startedAt > 0 ? this.startedAt + getLlmTrafficConfig().startupDelayMs : null,
+      activeWorkId: this.activeWorkId,
+      activeKind: this.activeKind,
+      pending: this.getPendingWork(),
+    };
+  }
+
+  getJobQueueMetadata(jobId: string): { queuePosition: number | null; waitingReason: BackgroundWaitingReason | null } {
+    const state = this.getWorkState();
+    const pending = state.pending;
+    const index = pending.findIndex((item) => item.id === jobId);
+    if (index === -1) return { queuePosition: null, waitingReason: null };
+    if (state.startupDelayUntil && Date.now() < state.startupDelayUntil) {
+      return { queuePosition: index + 1, waitingReason: "startup_delay" };
+    }
+
+    const traffic = getLlmTrafficSnapshot();
+    if ((traffic.active.interactive + traffic.queued.interactive + traffic.active.deferred + traffic.queued.deferred) > 0) {
+      return { queuePosition: index + 1, waitingReason: "interactive_ahead" };
+    }
+
+    if (index > 0) {
+      return { queuePosition: index + 1, waitingReason: sourceWaitingReason(pending[index - 1]!.sourceKind) };
+    }
+
+    if (this.activeWorkId || traffic.active.background > 0) {
+      return { queuePosition: 1, waitingReason: "llm_busy" };
+    }
+
+    return { queuePosition: 1, waitingReason: null };
+  }
+
+  private getPendingWork(): PendingWorkItem[] {
+    const research = listPendingResearchJobs(this.ctx.storage).map((job) => ({
+      id: job.id,
+      kind: "research" as const,
+      queuedAt: job.queuedAt,
+      sourceKind: job.sourceKind,
+    }));
+    const swarm = listPendingSwarmJobs(this.ctx.storage).map((job) => ({
+      id: job.id,
+      kind: "swarm" as const,
+      queuedAt: job.queuedAt,
+      sourceKind: job.sourceKind,
+    }));
+    const briefings = listPendingDailyBriefings(this.ctx.storage).map((briefing) => ({
+      id: briefing.id,
+      kind: "briefing" as const,
+      queuedAt: briefing.queuedAt,
+      sourceKind: briefing.sourceKind,
+    }));
+    return [...research, ...swarm, ...briefings].sort(compareWork);
+  }
+
+  private hasInteractivePressure(): boolean {
+    const traffic = getLlmTrafficSnapshot();
+    return (traffic.active.interactive + traffic.queued.interactive + traffic.active.deferred + traffic.queued.deferred) > 0;
+  }
+
+  private async drain(): Promise<void> {
+    if (!this.running || this.activeWorkId) return;
+
+    const startupDelayUntil = this.startedAt + getLlmTrafficConfig().startupDelayMs;
+    if (Date.now() < startupDelayUntil) {
+      this.nudge(startupDelayUntil - Date.now());
+      return;
+    }
+
+    if (this.hasInteractivePressure()) {
+      this.nudge(500);
+      return;
+    }
+
+    if (getLlmTrafficSnapshot().active.background > 0) {
+      this.nudge(500);
+      return;
+    }
+
+    const next = this.getPendingWork()[0];
+    if (!next) return;
+
+    this.activeWorkId = next.id;
+    this.activeKind = next.kind;
+
+    try {
+      if (next.kind === "research") {
+        await runResearchInBackground(this.buildResearchContext(), next.id);
+      } else if (next.kind === "swarm") {
+        await runSwarmInBackground(this.buildSwarmContext(), next.id);
+      } else {
+        await generateBriefing(this.ctx, undefined, next.id);
+      }
+    } catch (err) {
+      this.ctx.logger.error("Background dispatch failed", {
+        kind: next.kind,
+        id: next.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      this.activeWorkId = null;
+      this.activeKind = null;
+      this.nudge(250);
+    }
+  }
+
+  private buildResearchContext() {
+    return {
+      storage: this.ctx.storage,
+      llm: this.ctx.llm,
+      logger: this.ctx.logger,
+      timezone: this.ctx.config.timezone,
+      provider: this.ctx.config.llm.provider,
+      model: this.ctx.config.llm.model,
+      contextWindow: this.ctx.config.llm.contextWindow,
+      sandboxUrl: this.ctx.config.sandboxUrl,
+      browserUrl: this.ctx.config.browserUrl,
+      dataDir: this.ctx.config.dataDir,
+      webSearch: (query: string, maxResults?: number) => webSearch(query, maxResults, "general", this.ctx.config.searchUrl),
+      formatSearchResults,
+      fetchPage: fetchPageAsMarkdown,
+    };
+  }
+
+  private buildSwarmContext() {
+    return {
+      storage: this.ctx.storage,
+      llm: this.ctx.llm,
+      logger: this.ctx.logger,
+      timezone: this.ctx.config.timezone,
+      provider: this.ctx.config.llm.provider,
+      model: this.ctx.config.llm.model,
+      contextWindow: this.ctx.config.llm.contextWindow,
+      sandboxUrl: this.ctx.config.sandboxUrl,
+      browserUrl: this.ctx.config.browserUrl,
+      dataDir: this.ctx.config.dataDir,
+      webSearch: (query: string, maxResults?: number) => webSearch(query, maxResults, "general", this.ctx.config.searchUrl),
+      formatSearchResults,
+      fetchPage: fetchPageAsMarkdown,
+    };
+  }
+}
+
+export function attachBackgroundDispatch(ctx: PluginContext, dispatcher: BackgroundDispatcher): void {
+  ctx.backgroundJobs = {
+    enqueueResearch: (args) => dispatcher.enqueueResearch(args),
+    enqueueSwarm: (args) => dispatcher.enqueueSwarm(args),
+    enqueueBriefing: (args) => dispatcher.enqueueBriefing(args),
+  };
+}
+
+export function buildQueueMetadata(
+  dispatcher: BackgroundDispatcher,
+  jobId: string,
+): { queuePosition: number | null; waitingReason: BackgroundWaitingReason | null } {
+  return dispatcher.getJobQueueMetadata(jobId);
+}

--- a/packages/server/src/briefing.ts
+++ b/packages/server/src/briefing.ts
@@ -1,7 +1,12 @@
 import type { LanguageModel } from "ai";
-import type { Migration, PluginContext, TelemetryAttributes } from "@personal-ai/core";
+import type { BackgroundJobSourceKind, Migration, PluginContext, TelemetryAttributes } from "@personal-ai/core";
 import { listBeliefs, memoryStats, listSources, formatDateTime, getContextBudget, getProviderOptions, instrumentedGenerateText } from "@personal-ai/core";
 import { listTasks, listGoals } from "@personal-ai/plugin-tasks";
+
+const BRIEFING_LLM_TIMEOUT = {
+  totalMs: 2 * 60_000,
+  stepMs: 60_000,
+} as const;
 
 // --- Types ---
 
@@ -30,6 +35,11 @@ export interface BriefingRow {
   raw_context: string | null;
   status: string;
   type: string;
+  queued_at: string | null;
+  started_at: string | null;
+  attempt_count: number | null;
+  last_attempt_at: string | null;
+  source_kind: string | null;
 }
 
 export interface Briefing {
@@ -38,6 +48,11 @@ export interface Briefing {
   sections: BriefingSection;
   status: string;
   type: string;
+  queuedAt?: string | null;
+  startedAt?: string | null;
+  attemptCount?: number;
+  lastAttemptAt?: string | null;
+  sourceKind?: BackgroundJobSourceKind;
 }
 
 // --- Migration ---
@@ -64,6 +79,16 @@ export const briefingMigrations: Migration[] = [
     version: 3,
     up: `ALTER TABLE briefings ADD COLUMN telegram_sent_at TEXT;`,
   },
+  {
+    version: 4,
+    up: `
+      ALTER TABLE briefings ADD COLUMN queued_at TEXT;
+      ALTER TABLE briefings ADD COLUMN started_at TEXT;
+      ALTER TABLE briefings ADD COLUMN attempt_count INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE briefings ADD COLUMN last_attempt_at TEXT;
+      ALTER TABLE briefings ADD COLUMN source_kind TEXT NOT NULL DEFAULT 'maintenance';
+    `,
+  },
 ];
 
 // --- Data Access ---
@@ -81,6 +106,11 @@ export function getLatestBriefing(storage: PluginContext["storage"]): Briefing |
     sections: JSON.parse(row.sections),
     status: row.status,
     type: row.type,
+    queuedAt: row.queued_at,
+    startedAt: row.started_at,
+    attemptCount: row.attempt_count ?? 0,
+    lastAttemptAt: row.last_attempt_at,
+    sourceKind: (row.source_kind as BackgroundJobSourceKind | null) ?? "maintenance",
   };
 }
 
@@ -97,6 +127,11 @@ export function getBriefingById(storage: PluginContext["storage"], id: string): 
     sections: JSON.parse(row.sections),
     status: row.status,
     type: row.type,
+    queuedAt: row.queued_at,
+    startedAt: row.started_at,
+    attemptCount: row.attempt_count ?? 0,
+    lastAttemptAt: row.last_attempt_at,
+    sourceKind: (row.source_kind as BackgroundJobSourceKind | null) ?? "maintenance",
   };
 }
 
@@ -114,11 +149,16 @@ export function listAllBriefings(storage: PluginContext["storage"]): Briefing[] 
   );
   return rows.map((row) => ({
     id: row.id,
-    generatedAt: row.generated_at,
-    sections: JSON.parse(row.sections),
-    status: row.status,
-    type: row.type,
-  }));
+      generatedAt: row.generated_at,
+      sections: JSON.parse(row.sections),
+      status: row.status,
+      type: row.type,
+      queuedAt: row.queued_at,
+      startedAt: row.started_at,
+      attemptCount: row.attempt_count ?? 0,
+      lastAttemptAt: row.last_attempt_at,
+      sourceKind: (row.source_kind as BackgroundJobSourceKind | null) ?? "maintenance",
+    }));
 }
 
 export function clearAllBriefings(storage: PluginContext["storage"]): number {
@@ -153,6 +193,73 @@ export function createResearchBriefing(
   );
 }
 
+export function getDailyBriefingState(storage: PluginContext["storage"]): { pending: boolean; generating: boolean; activeId: string | null } {
+  const rows = storage.query<{ id: string; status: string }>(
+    "SELECT id, status FROM briefings WHERE type = 'daily' AND status IN ('pending', 'generating') ORDER BY generated_at DESC LIMIT 1",
+  );
+  const row = rows[0];
+  return {
+    pending: row?.status === "pending",
+    generating: row?.status === "generating",
+    activeId: row?.id ?? null,
+  };
+}
+
+export function enqueueBriefingGeneration(
+  storage: PluginContext["storage"],
+  sourceKind: BackgroundJobSourceKind = "maintenance",
+): string {
+  const existing = storage.query<{ id: string; status: string; source_kind: string | null }>(
+    "SELECT id, status, source_kind FROM briefings WHERE type = 'daily' AND status IN ('pending', 'generating') ORDER BY generated_at DESC LIMIT 1",
+  )[0];
+  if (existing) {
+    if (existing.status === "pending" && sourceKind === "manual" && existing.source_kind !== "manual") {
+      storage.run(
+        "UPDATE briefings SET source_kind = 'manual' WHERE id = ?",
+        [existing.id],
+      );
+    }
+    return existing.id;
+  }
+
+  const id = crypto.randomUUID();
+  const queuedAt = new Date().toISOString();
+  storage.run(
+    "INSERT INTO briefings (id, generated_at, sections, raw_context, status, type, queued_at, source_kind) VALUES (?, datetime('now'), '{}', null, 'pending', 'daily', ?, ?)",
+    [id, queuedAt, sourceKind],
+  );
+  return id;
+}
+
+export function recoverStaleBriefings(storage: PluginContext["storage"]): number {
+  const count = storage.query<{ cnt: number }>(
+    "SELECT COUNT(*) as cnt FROM briefings WHERE type = 'daily' AND status IN ('pending', 'generating')",
+  )[0]?.cnt ?? 0;
+  if (count > 0) {
+    storage.run(
+      `UPDATE briefings
+       SET status = 'pending',
+           started_at = NULL,
+           last_attempt_at = NULL,
+           raw_context = NULL,
+           sections = '{}',
+           attempt_count = CASE WHEN status = 'generating' THEN attempt_count + 1 ELSE attempt_count END
+       WHERE type = 'daily' AND status IN ('pending', 'generating')`,
+    );
+  }
+  return count;
+}
+
+export function listPendingDailyBriefings(storage: PluginContext["storage"]): Array<{ id: string; queuedAt: string; sourceKind: BackgroundJobSourceKind }> {
+  return storage.query<{ id: string; queued_at: string | null; generated_at: string; source_kind: string | null }>(
+    "SELECT id, queued_at, generated_at, source_kind FROM briefings WHERE type = 'daily' AND status = 'pending' ORDER BY CASE source_kind WHEN 'manual' THEN 0 WHEN 'schedule' THEN 1 ELSE 2 END, queued_at ASC, generated_at ASC",
+  ).map((row) => ({
+    id: row.id,
+    queuedAt: row.queued_at ?? row.generated_at,
+    sourceKind: (row.source_kind as BackgroundJobSourceKind | null) ?? "maintenance",
+  }));
+}
+
 function pruneOldBriefings(storage: PluginContext["storage"]): void {
   storage.run(
     "DELETE FROM briefings WHERE generated_at < datetime('now', '-30 days')",
@@ -165,6 +272,7 @@ function pruneOldBriefings(storage: PluginContext["storage"]): void {
 export async function generateBriefing(
   ctx: PluginContext,
   telemetry?: Pick<TelemetryAttributes, "traceId" | "runId">,
+  briefingId?: string,
 ): Promise<Briefing | null> {
   try {
     const health = await ctx.llm.health();
@@ -313,11 +421,27 @@ Respond ONLY with a valid JSON object matching this exact shape (no markdown, no
   "suggestions": [{ "title": "string", "reason": "string", "action": "recall|task|learn (optional)", "actionTarget": "string (optional)" }]
 }`;
 
-  const id = crypto.randomUUID();
-  ctx.storage.run(
-    "INSERT INTO briefings (id, generated_at, sections, raw_context, status) VALUES (?, datetime('now'), '{}', ?, 'generating')",
-    [id, JSON.stringify(rawContext)],
-  );
+  const id = briefingId ?? crypto.randomUUID();
+  const hasExisting = briefingId
+    ? ctx.storage.query<{ id: string }>("SELECT id FROM briefings WHERE id = ?", [briefingId]).length > 0
+    : false;
+  if (hasExisting) {
+    ctx.storage.run(
+      `UPDATE briefings
+       SET status = 'generating',
+           raw_context = ?,
+           started_at = ?,
+           last_attempt_at = ?,
+           attempt_count = attempt_count + 1
+       WHERE id = ?`,
+      [JSON.stringify(rawContext), new Date().toISOString(), new Date().toISOString(), id],
+    );
+  } else {
+    ctx.storage.run(
+      "INSERT INTO briefings (id, generated_at, sections, raw_context, status, type, queued_at, started_at, last_attempt_at, attempt_count, source_kind) VALUES (?, datetime('now'), '{}', ?, 'generating', 'daily', ?, ?, ?, 1, 'maintenance')",
+      [id, JSON.stringify(rawContext), new Date().toISOString(), new Date().toISOString(), new Date().toISOString()],
+    );
+  }
 
   try {
     const budget = getContextBudget(ctx.config.llm.provider, ctx.config.llm.model, ctx.config.llm.contextWindow);
@@ -328,6 +452,7 @@ Respond ONLY with a valid JSON object matching this exact shape (no markdown, no
         prompt,
         temperature: 0.8,
         maxRetries: 1,
+        timeout: BRIEFING_LLM_TIMEOUT,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         providerOptions: getProviderOptions(ctx.config.llm.provider, budget.contextWindow) as any,
       },
@@ -364,6 +489,11 @@ Respond ONLY with a valid JSON object matching this exact shape (no markdown, no
       sections: parsed,
       status: "ready",
       type: "daily",
+      queuedAt: null,
+      startedAt: new Date().toISOString(),
+      attemptCount: 1,
+      lastAttemptAt: new Date().toISOString(),
+      sourceKind: "maintenance",
     };
   } catch (err) {
     console.error("Briefing generation failed:", err instanceof Error ? err.message : String(err));

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,7 +9,7 @@ import { existsSync, writeFileSync, unlinkSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import jwt from "jsonwebtoken";
-import { loadConfig, writeConfig, createStorage, createLLMClient, createLogger, hasOwner, getJwtSecret, resetOwnerPassword, recoverStaleBackgroundJobs, cancelAllRunningBackgroundJobs, startSpan, finishSpan } from "@personal-ai/core";
+import { loadConfig, writeConfig, createStorage, createLLMClient, createLogger, hasOwner, getJwtSecret, resetOwnerPassword, recoverStaleBackgroundJobs, cancelAllRunningBackgroundJobs, startSpan, finishSpan, configureLlmTraffic } from "@personal-ai/core";
 import type { AgentPlugin, PluginContext, ActiveTelemetrySpan } from "@personal-ai/core";
 import { assistantPlugin } from "@personal-ai/plugin-assistant";
 import { curatorPlugin } from "@personal-ai/plugin-curator";
@@ -33,10 +33,13 @@ import { registerObservabilityRoutes } from "./routes/observability.js";
 import { runAllMigrations } from "./migrations.js";
 import { WorkerLoop } from "./workers.js";
 import { recoverStaleLearningRuns } from "./learning.js";
+import { BackgroundDispatcher, attachBackgroundDispatch } from "./background-dispatcher.js";
+import { recoverStaleBriefings } from "./briefing.js";
 
 export interface ServerContext {
   ctx: PluginContext;
   agents: AgentPlugin[];
+  backgroundDispatcher: BackgroundDispatcher;
   /** Reinitialize storage and LLM after config change */
   reinitialize(): void;
   /** Telegram bot lifecycle */
@@ -54,6 +57,7 @@ interface TelemetryRequest {
 
 export async function createServer(options?: { port?: number; host?: string }) {
   const config = loadConfig();
+  configureLlmTraffic(config.workers?.llmTraffic);
   const logger = createLogger(config.logLevel, { dir: config.dataDir });
 
   // On PaaS (Railway, etc.) volumes may mount after the container starts.
@@ -112,7 +116,7 @@ export async function createServer(options?: { port?: number; host?: string }) {
   runAllMigrations(storage);
 
   // Recover stale jobs from previous crash/kill
-  const staleCount = recoverStaleBackgroundJobs(storage) + recoverStaleResearchJobs(storage) + recoverStaleSwarmJobs(storage) + recoverStaleLearningRuns(storage);
+  const staleCount = recoverStaleBackgroundJobs(storage) + recoverStaleResearchJobs(storage) + recoverStaleSwarmJobs(storage) + recoverStaleLearningRuns(storage) + recoverStaleBriefings(storage);
   if (staleCount > 0) logger.warn(`Recovered ${staleCount} stale jobs from previous run`);
 
   // Password reset via environment variable
@@ -131,6 +135,8 @@ export async function createServer(options?: { port?: number; host?: string }) {
   }
 
   const ctx: PluginContext = { config, storage, llm, logger };
+  const backgroundDispatcher = new BackgroundDispatcher(ctx);
+  attachBackgroundDispatch(ctx, backgroundDispatcher);
   const agents: AgentPlugin[] = [assistantPlugin, curatorPlugin];
 
   // Telegram bot state — use ReturnType to avoid importing grammy types
@@ -212,6 +218,7 @@ export async function createServer(options?: { port?: number; host?: string }) {
 
     // Reload config and recreate connections
     const newConfig = loadConfig();
+    configureLlmTraffic(newConfig.workers?.llmTraffic);
     const newLogger = createLogger(newConfig.logLevel, { dir: newConfig.dataDir });
     const newStorage = createStorage(newConfig.dataDir, newLogger);
     const newLlm = createLLMClient(newConfig.llm, newLogger, newStorage);
@@ -225,6 +232,7 @@ export async function createServer(options?: { port?: number; host?: string }) {
       llm: newLlm,
       logger: newLogger,
     });
+    attachBackgroundDispatch(ctx, backgroundDispatcher);
 
     // Close old storage after a delay to let in-flight requests drain
     pendingCloseStorage = oldStorage;
@@ -371,7 +379,7 @@ export async function createServer(options?: { port?: number; host?: string }) {
   }
 
   const serverCtx: ServerContext = {
-    ctx, agents, reinitialize,
+    ctx, agents, backgroundDispatcher, reinitialize,
     get telegramBot() { return telegramBot; },
     telegramStatus,
     startTelegramBot,
@@ -562,6 +570,7 @@ export async function createServer(options?: { port?: number; host?: string }) {
 
   // --- Background workers (briefing, schedules, learning) ---
   const workerLoop = new WorkerLoop(ctx);
+  backgroundDispatcher.start();
   workerLoop.start();
 
   // Write PID file for process management
@@ -576,6 +585,7 @@ export async function createServer(options?: { port?: number; host?: string }) {
     try { unlinkSync(pidFile); } catch { /* ignore */ }
     stopTelegramBot();
     workerLoop.stop();
+    backgroundDispatcher.stop();
     // Cancel any pending storage close from reinitialize
     if (pendingCloseTimer) {
       clearTimeout(pendingCloseTimer);

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -45,6 +45,13 @@ function sanitizeConfig(config: { llm: Record<string, unknown>; telegram?: Recor
       backgroundLearning: (workers as Record<string, unknown> | undefined)?.backgroundLearning !== false,
       briefing: (workers as Record<string, unknown> | undefined)?.briefing !== false,
       knowledgeCleanup: (workers as Record<string, unknown> | undefined)?.knowledgeCleanup !== false,
+      llmTraffic: {
+        maxConcurrent: ((workers as Record<string, unknown> | undefined)?.llmTraffic as Record<string, unknown> | undefined)?.maxConcurrent ?? 6,
+        startGapMs: ((workers as Record<string, unknown> | undefined)?.llmTraffic as Record<string, unknown> | undefined)?.startGapMs ?? 1500,
+        startupDelayMs: ((workers as Record<string, unknown> | undefined)?.llmTraffic as Record<string, unknown> | undefined)?.startupDelayMs ?? 10000,
+        swarmAgentConcurrency: ((workers as Record<string, unknown> | undefined)?.llmTraffic as Record<string, unknown> | undefined)?.swarmAgentConcurrency ?? 5,
+        reservedInteractiveSlots: ((workers as Record<string, unknown> | undefined)?.llmTraffic as Record<string, unknown> | undefined)?.reservedInteractiveSlots ?? 1,
+      },
     },
     knowledge: config.knowledge ?? {},
     debugResearch: !!config.debugResearch,
@@ -98,6 +105,11 @@ const updateConfigSchema = z.object({
   backgroundLearning: z.boolean().optional(),
   briefingEnabled: z.boolean().optional(),
   knowledgeCleanup: z.boolean().optional(),
+  llmTrafficMaxConcurrent: z.number().int().positive().optional(),
+  llmTrafficStartGapMs: z.number().int().min(0).optional(),
+  llmTrafficStartupDelayMs: z.number().int().min(0).optional(),
+  llmTrafficSwarmAgentConcurrency: z.number().int().positive().optional(),
+  llmTrafficReservedInteractiveSlots: z.number().int().min(0).optional(),
   knowledgeDefaultTtlDays: z.number().int().positive().nullable().optional(),
   knowledgeFreshnessDecayDays: z.number().int().positive().optional(),
   debugResearch: z.boolean().optional(),
@@ -188,12 +200,29 @@ export function registerConfigRoutes(app: FastifyInstance, serverCtx: ServerCont
     }
 
     // Worker settings
-    if (body.backgroundLearning !== undefined || body.briefingEnabled !== undefined || body.knowledgeCleanup !== undefined) {
+    if (
+      body.backgroundLearning !== undefined ||
+      body.briefingEnabled !== undefined ||
+      body.knowledgeCleanup !== undefined ||
+      body.llmTrafficMaxConcurrent !== undefined ||
+      body.llmTrafficStartGapMs !== undefined ||
+      body.llmTrafficStartupDelayMs !== undefined ||
+      body.llmTrafficSwarmAgentConcurrency !== undefined ||
+      body.llmTrafficReservedInteractiveSlots !== undefined
+    ) {
       const existingWorkers = ctx.config.workers ?? {};
       const workersUpdate: Record<string, unknown> = { ...existingWorkers };
       if (body.backgroundLearning !== undefined) workersUpdate.backgroundLearning = body.backgroundLearning;
       if (body.briefingEnabled !== undefined) workersUpdate.briefing = body.briefingEnabled;
       if (body.knowledgeCleanup !== undefined) workersUpdate.knowledgeCleanup = body.knowledgeCleanup;
+      const existingTraffic = (existingWorkers.llmTraffic as Record<string, unknown> | undefined) ?? {};
+      const llmTrafficUpdate: Record<string, unknown> = { ...existingTraffic };
+      if (body.llmTrafficMaxConcurrent !== undefined) llmTrafficUpdate.maxConcurrent = body.llmTrafficMaxConcurrent;
+      if (body.llmTrafficStartGapMs !== undefined) llmTrafficUpdate.startGapMs = body.llmTrafficStartGapMs;
+      if (body.llmTrafficStartupDelayMs !== undefined) llmTrafficUpdate.startupDelayMs = body.llmTrafficStartupDelayMs;
+      if (body.llmTrafficSwarmAgentConcurrency !== undefined) llmTrafficUpdate.swarmAgentConcurrency = body.llmTrafficSwarmAgentConcurrency;
+      if (body.llmTrafficReservedInteractiveSlots !== undefined) llmTrafficUpdate.reservedInteractiveSlots = body.llmTrafficReservedInteractiveSlots;
+      workersUpdate.llmTraffic = llmTrafficUpdate;
       update.workers = workersUpdate;
     }
 

--- a/packages/server/src/routes/inbox.ts
+++ b/packages/server/src/routes/inbox.ts
@@ -1,13 +1,9 @@
 import type { FastifyInstance } from "fastify";
 import type { ServerContext } from "../index.js";
-import { getLatestBriefing, getBriefingById, listBriefings, listAllBriefings, generateBriefing, clearAllBriefings, getResearchBriefings } from "../briefing.js";
-import { createResearchJob, runResearchInBackground } from "@personal-ai/plugin-research";
-import { createSwarmJob, runSwarmInBackground } from "@personal-ai/plugin-swarm";
-import { webSearch, formatSearchResults } from "@personal-ai/plugin-assistant/web-search";
-import { fetchPageAsMarkdown } from "@personal-ai/plugin-assistant/page-fetch";
+import { getLatestBriefing, getBriefingById, listBriefings, listAllBriefings, clearAllBriefings, getResearchBriefings, getDailyBriefingState } from "../briefing.js";
 import type { ResearchResultType } from "@personal-ai/core";
 
-export function registerInboxRoutes(app: FastifyInstance, { ctx }: ServerContext): void {
+export function registerInboxRoutes(app: FastifyInstance, { ctx, backgroundDispatcher }: ServerContext): void {
   app.get("/api/inbox", async () => {
     const briefing = getLatestBriefing(ctx.storage);
     if (!briefing) return { briefing: null };
@@ -15,12 +11,8 @@ export function registerInboxRoutes(app: FastifyInstance, { ctx }: ServerContext
   });
 
   app.post("/api/inbox/refresh", async () => {
-    generateBriefing(ctx).catch((err) => {
-      ctx.logger.error("Briefing refresh failed", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-    });
-    return { ok: true, message: "Briefing generation started" };
+    const briefingId = backgroundDispatcher.enqueueBriefing({ sourceKind: "manual", reason: "inbox-refresh" });
+    return { ok: true, briefingId, message: "Briefing queued" };
   });
 
   app.get("/api/inbox/history", async () => {
@@ -36,11 +28,8 @@ export function registerInboxRoutes(app: FastifyInstance, { ctx }: ServerContext
   // Unified feed — all briefing types in chronological order
   app.get("/api/inbox/all", async () => {
     const briefings = listAllBriefings(ctx.storage);
-    // Check if a briefing is currently being generated
-    const generating = ctx.storage.query<{ id: string }>(
-      "SELECT id FROM briefings WHERE status = 'generating' LIMIT 1",
-    );
-    return { briefings, generating: generating.length > 0 };
+    const state = getDailyBriefingState(ctx.storage);
+    return { briefings, generating: state.generating, pending: state.pending };
   });
 
   app.get("/api/inbox/research", async () => {
@@ -80,57 +69,18 @@ export function registerInboxRoutes(app: FastifyInstance, { ctx }: ServerContext
 
     let jobId: string;
     if (execution === "analysis") {
-      jobId = createSwarmJob(ctx.storage, {
+      jobId = await backgroundDispatcher.enqueueSwarm({
         goal,
         threadId: null,
         resultType,
-      });
-      runSwarmInBackground(
-        {
-          storage: ctx.storage,
-          llm: ctx.llm,
-          logger: ctx.logger,
-          timezone: ctx.config.timezone,
-          provider: ctx.config.llm.provider,
-          model: ctx.config.llm.model,
-          contextWindow: ctx.config.llm.contextWindow,
-          sandboxUrl: ctx.config.sandboxUrl,
-          browserUrl: ctx.config.browserUrl,
-          dataDir: ctx.config.dataDir,
-          webSearch,
-          formatSearchResults,
-          fetchPage: fetchPageAsMarkdown,
-        },
-        jobId,
-      ).catch((err) => {
-        ctx.logger.error(`Rerun analysis failed: ${err instanceof Error ? err.message : String(err)}`);
+        sourceKind: "manual",
       });
     } else {
-      jobId = createResearchJob(ctx.storage, {
+      jobId = await backgroundDispatcher.enqueueResearch({
         goal,
         threadId: null,
         resultType: resultType as ResearchResultType,
-      });
-
-      runResearchInBackground(
-        {
-          storage: ctx.storage,
-          llm: ctx.llm,
-          logger: ctx.logger,
-          timezone: ctx.config.timezone,
-          provider: ctx.config.llm.provider,
-          model: ctx.config.llm.model,
-          contextWindow: ctx.config.llm.contextWindow,
-          sandboxUrl: ctx.config.sandboxUrl,
-          browserUrl: ctx.config.browserUrl,
-          dataDir: ctx.config.dataDir,
-          webSearch,
-          formatSearchResults,
-          fetchPage: fetchPageAsMarkdown,
-        },
-        jobId,
-      ).catch((err) => {
-        ctx.logger.error(`Rerun research failed: ${err instanceof Error ? err.message : String(err)}`);
+        sourceKind: "manual",
       });
     }
 

--- a/packages/server/src/routes/jobs.ts
+++ b/packages/server/src/routes/jobs.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import type { ServerContext } from "../index.js";
 import {
   listJobs,
+  getJob,
   cancelBackgroundJob,
   forceDeleteBackgroundJob,
   clearCompletedBackgroundJobs,
@@ -60,6 +61,14 @@ function getStoredPresentation(
 }
 
 export function registerJobRoutes(app: FastifyInstance, serverCtx: ServerContext): void {
+  const { backgroundDispatcher } = serverCtx;
+
+  function queueState(id: string, status: string) {
+    return status === "pending"
+      ? backgroundDispatcher.getJobQueueMetadata(id)
+      : { queuePosition: null, waitingReason: null };
+  }
+
   // List all background jobs — DB-backed active + persisted research jobs
   app.get("/api/jobs", async () => {
     // Background jobs from DB (crawl + research status/progress)
@@ -70,38 +79,62 @@ export function registerJobRoutes(app: FastifyInstance, serverCtx: ServerContext
       status: j.status,
       progress: j.progress,
       startedAt: j.startedAt,
+      queuedAt: j.queuedAt ?? j.startedAt,
+      attemptCount: j.attemptCount ?? 0,
+      lastAttemptAt: j.lastAttemptAt ?? null,
+      sourceKind: j.sourceKind ?? "manual",
+      sourceScheduleId: j.sourceScheduleId ?? null,
+      ...queueState(j.id, j.status),
       error: j.error ?? null,
       result: j.result ?? null,
       resultType: j.resultType ?? null,
     }));
 
     // Persisted research jobs from DB (with extra detail fields)
-    const research = listResearchJobs(serverCtx.ctx.storage).map((j) => ({
-      id: j.id,
-      type: "research" as const,
-      label: j.goal,
-      status: j.status,
-      progress: `${j.searchesUsed}/${j.budgetMaxSearches} searches, ${j.pagesLearned}/${j.budgetMaxPages} pages`,
-      startedAt: j.createdAt,
-      completedAt: j.completedAt,
-      error: null,
-      result: j.report ? j.report.slice(0, 300) : null,
-      resultType: j.resultType ?? null,
-    }));
+    const research = listResearchJobs(serverCtx.ctx.storage).map((j) => {
+      const tracked = getJob(serverCtx.ctx.storage, j.id);
+      return {
+        id: j.id,
+        type: "research" as const,
+        label: j.goal,
+        status: j.status,
+        progress: tracked?.progress ?? `${j.searchesUsed}/${j.budgetMaxSearches} searches, ${j.pagesLearned}/${j.budgetMaxPages} pages`,
+        startedAt: j.startedAt ?? j.createdAt,
+        queuedAt: j.queuedAt,
+        completedAt: j.completedAt,
+        attemptCount: j.attemptCount,
+        lastAttemptAt: j.lastAttemptAt,
+        sourceKind: j.sourceKind,
+        sourceScheduleId: j.sourceScheduleId,
+        ...queueState(j.id, j.status),
+        error: tracked?.error ?? null,
+        result: j.report ? j.report.slice(0, 300) : tracked?.result ?? null,
+        resultType: j.resultType ?? null,
+      };
+    });
 
     // Persisted swarm jobs from DB
-    const swarm = listSwarmJobs(serverCtx.ctx.storage).map((j) => ({
-      id: j.id,
-      type: "swarm" as const,
-      label: j.goal,
-      status: j.status,
-      progress: `${j.agentsDone}/${j.agentCount} agents`,
-      startedAt: j.createdAt,
-      completedAt: j.completedAt,
-      error: null,
-      result: j.synthesis ? j.synthesis.slice(0, 300) : null,
-      resultType: j.resultType ?? null,
-    }));
+    const swarm = listSwarmJobs(serverCtx.ctx.storage).map((j) => {
+      const tracked = getJob(serverCtx.ctx.storage, j.id);
+      return {
+        id: j.id,
+        type: "swarm" as const,
+        label: j.goal,
+        status: j.status,
+        progress: tracked?.progress ?? `${j.agentsDone}/${j.agentCount} agents`,
+        startedAt: j.startedAt ?? j.createdAt,
+        queuedAt: j.queuedAt,
+        completedAt: j.completedAt,
+        attemptCount: j.attemptCount,
+        lastAttemptAt: j.lastAttemptAt,
+        sourceKind: j.sourceKind,
+        sourceScheduleId: j.sourceScheduleId,
+        ...queueState(j.id, j.status),
+        error: tracked?.error ?? null,
+        result: j.synthesis ? j.synthesis.slice(0, 300) : tracked?.result ?? null,
+        resultType: j.resultType ?? null,
+      };
+    });
 
     // Merge: active jobs first, then persisted (dedup by id)
     const activeIds = new Set(active.map((j) => j.id));
@@ -119,7 +152,10 @@ export function registerJobRoutes(app: FastifyInstance, serverCtx: ServerContext
     const researchJob = getResearchJob(serverCtx.ctx.storage, request.params.id);
     if (researchJob) {
       return {
-        job: researchJob,
+        job: {
+          ...researchJob,
+          ...queueState(researchJob.id, researchJob.status),
+        },
         presentation: getStoredPresentation(
           serverCtx,
           researchJob.id,
@@ -134,7 +170,10 @@ export function registerJobRoutes(app: FastifyInstance, serverCtx: ServerContext
     const swarmJob = getSwarmJob(serverCtx.ctx.storage, request.params.id);
     if (swarmJob) {
       return {
-        job: swarmJob,
+        job: {
+          ...swarmJob,
+          ...queueState(swarmJob.id, swarmJob.status),
+        },
         presentation: getStoredPresentation(
           serverCtx,
           swarmJob.id,

--- a/packages/server/src/routes/observability.ts
+++ b/packages/server/src/routes/observability.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import {
   getJobDiagnostics,
+  getLlmTrafficSnapshot,
   getObservabilityOverview,
   getThreadDiagnostics,
   getTraceSpans,
@@ -16,10 +17,39 @@ const rangeSchema = z.object({
   range: z.enum(["24h", "7d", "30d"]).optional(),
 });
 
-export function registerObservabilityRoutes(app: FastifyInstance, { ctx }: ServerContext): void {
+export function registerObservabilityRoutes(app: FastifyInstance, serverCtx: ServerContext): void {
+  const { ctx, backgroundDispatcher } = serverCtx;
+
   app.get<{ Querystring: { range?: "24h" | "7d" | "30d" } }>("/api/observability/overview", async (request) => {
     const { range } = validate(rangeSchema, request.query ?? {});
-    return getObservabilityOverview(ctx.storage, range ?? "24h");
+    const overview = getObservabilityOverview(ctx.storage, range ?? "24h");
+    const traffic = getLlmTrafficSnapshot();
+    const dispatcherState = backgroundDispatcher.getWorkState();
+    return {
+      ...overview,
+      live: {
+        activeRequests: traffic.activeTotal,
+        queuedRequests: traffic.queuedTotal,
+        lanes: {
+          interactive: {
+            active: traffic.active.interactive,
+            queued: traffic.queued.interactive,
+          },
+          deferred: {
+            active: traffic.active.deferred,
+            queued: traffic.queued.deferred,
+          },
+        background: {
+          active: traffic.active.background,
+          queued: traffic.queued.background,
+        },
+      },
+      startupDelayUntil: dispatcherState.startupDelayUntil ? new Date(dispatcherState.startupDelayUntil).toISOString() : null,
+      backgroundActiveWorkId: dispatcherState.activeWorkId,
+      backgroundActiveKind: dispatcherState.activeKind,
+      pendingBackgroundJobs: dispatcherState.pending.length,
+      },
+    };
   });
 
   app.get<{ Querystring: { range?: "24h" | "7d" | "30d" } }>("/api/observability/processes", async (request) => {

--- a/packages/server/src/worker.ts
+++ b/packages/server/src/worker.ts
@@ -1,8 +1,10 @@
-import { loadConfig, createStorage, createLLMClient, createLogger } from "@personal-ai/core";
+import { loadConfig, createStorage, createLLMClient, createLogger, configureLlmTraffic } from "@personal-ai/core";
 import { runAllMigrations } from "./migrations.js";
 import { WorkerLoop } from "./workers.js";
+import { BackgroundDispatcher, attachBackgroundDispatch } from "./background-dispatcher.js";
 
 const config = loadConfig();
+configureLlmTraffic(config.workers?.llmTraffic);
 const logger = createLogger(config.logLevel, { dir: config.dataDir });
 const storage = createStorage(config.dataDir, logger);
 const llm = createLLMClient(config.llm, logger, storage);
@@ -10,7 +12,10 @@ const llm = createLLMClient(config.llm, logger, storage);
 runAllMigrations(storage);
 
 const ctx = { config, storage, llm, logger };
+const backgroundDispatcher = new BackgroundDispatcher(ctx);
+attachBackgroundDispatch(ctx, backgroundDispatcher);
 const workerLoop = new WorkerLoop(ctx);
+backgroundDispatcher.start();
 workerLoop.start();
 
 console.log("pai worker running (Ctrl+C to stop)");
@@ -18,6 +23,7 @@ console.log("pai worker running (Ctrl+C to stop)");
 const shutdown = () => {
   console.log("Shutting down workers...");
   workerLoop.stop();
+  backgroundDispatcher.stop();
   storage.close();
   process.exit(0);
 };

--- a/packages/server/src/workers.ts
+++ b/packages/server/src/workers.ts
@@ -2,11 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { PluginContext } from "@personal-ai/core";
 import { cleanupExpiredSources, cleanupOldArtifacts, listBeliefs, listThreads, cleanupOldTelemetrySpans, startSpan, finishSpan } from "@personal-ai/core";
 import { getDueSchedules, markScheduleRun } from "@personal-ai/plugin-schedules";
-import { createResearchJob, runResearchInBackground } from "@personal-ai/plugin-research";
-import { createSwarmJob, runSwarmInBackground } from "@personal-ai/plugin-swarm";
-import { webSearch, formatSearchResults } from "@personal-ai/plugin-assistant/web-search";
-import { fetchPageAsMarkdown } from "@personal-ai/plugin-assistant/page-fetch";
-import { generateBriefing, getLatestBriefing } from "./briefing.js";
+import { getLatestBriefing } from "./briefing.js";
 import { runBackgroundLearning } from "./learning.js";
 
 export interface WorkerOptions {
@@ -67,10 +63,10 @@ export class WorkerLoop {
     // --- Briefing generator ---
     this.briefingTimer = setInterval(() => {
       if (this.ctx.config.workers?.briefing === false || !isLLMConfigured) return;
-      this.runWorkerTask("worker.briefing", async (telemetry) => {
-        await generateBriefing(this.ctx, telemetry);
+      this.runWorkerTask("worker.briefing", async () => {
+        this.ctx.backgroundJobs?.enqueueBriefing?.({ sourceKind: "maintenance", reason: "interval" });
       }).catch((err) => {
-        this.ctx.logger.warn(`Background briefing failed: ${err instanceof Error ? err.message : String(err)}`);
+        this.ctx.logger.warn(`Background briefing queueing failed: ${err instanceof Error ? err.message : String(err)}`);
       });
     }, briefingMs);
 
@@ -82,10 +78,10 @@ export class WorkerLoop {
           listBeliefs(this.ctx.storage, "active").length > 0 ||
           listThreads(this.ctx.storage).length > 0;
         if (hasData) {
-          this.runWorkerTask("worker.briefing", async (telemetry) => {
-            await generateBriefing(this.ctx, telemetry);
+          this.runWorkerTask("worker.briefing", async () => {
+            this.ctx.backgroundJobs?.enqueueBriefing?.({ sourceKind: "maintenance", reason: "startup" });
           }).catch((err) => {
-            this.ctx.logger.warn(`Initial briefing failed: ${err instanceof Error ? err.message : String(err)}`);
+            this.ctx.logger.warn(`Initial briefing queueing failed: ${err instanceof Error ? err.message : String(err)}`);
           });
         }
       }
@@ -170,64 +166,47 @@ export class WorkerLoop {
     Object.assign(this.ctx, newCtx);
   }
 
+  private hasQueuedOrRunningSchedule(scheduleId: string, type: "research" | "analysis"): boolean {
+    if (type === "research") {
+      const rows = this.ctx.storage.query<{ count: number }>(
+        "SELECT COUNT(*) as count FROM research_jobs WHERE source_schedule_id = ? AND status IN ('pending', 'running')",
+        [scheduleId],
+      );
+      return (rows[0]?.count ?? 0) > 0;
+    }
+
+    const rows = this.ctx.storage.query<{ count: number }>(
+      "SELECT COUNT(*) as count FROM swarm_jobs WHERE source_schedule_id = ? AND status IN ('pending', 'planning', 'running', 'synthesizing')",
+      [scheduleId],
+    );
+    return (rows[0]?.count ?? 0) > 0;
+  }
+
   private async runDueSchedules(): Promise<void> {
     try {
       const due = getDueSchedules(this.ctx.storage);
       for (const schedule of due) {
+        if (this.hasQueuedOrRunningSchedule(schedule.id, schedule.type)) {
+          continue;
+        }
         this.ctx.logger.info("Running scheduled job", { id: schedule.id, label: schedule.label });
         markScheduleRun(this.ctx.storage, schedule.id);
 
         if (schedule.type === "research") {
-          const jobId = createResearchJob(this.ctx.storage, {
+          await this.ctx.backgroundJobs?.enqueueResearch?.({
             goal: schedule.goal,
             threadId: schedule.threadId,
-          });
-          runResearchInBackground(
-            {
-              storage: this.ctx.storage,
-              llm: this.ctx.llm,
-              logger: this.ctx.logger,
-              timezone: this.ctx.config.timezone,
-              provider: this.ctx.config.llm.provider,
-              model: this.ctx.config.llm.model,
-              contextWindow: this.ctx.config.llm.contextWindow,
-              sandboxUrl: this.ctx.config.sandboxUrl,
-              browserUrl: this.ctx.config.browserUrl,
-              dataDir: this.ctx.config.dataDir,
-              webSearch,
-              formatSearchResults,
-              fetchPage: fetchPageAsMarkdown,
-            },
-            jobId,
-          ).catch((err) => {
-            this.ctx.logger.error(`Scheduled research failed: ${err instanceof Error ? err.message : String(err)}`);
+            sourceKind: "schedule",
+            sourceScheduleId: schedule.id,
           });
           continue;
         }
 
-        const jobId = createSwarmJob(this.ctx.storage, {
+        await this.ctx.backgroundJobs?.enqueueSwarm?.({
           goal: schedule.goal,
           threadId: schedule.threadId,
-        });
-        runSwarmInBackground(
-          {
-            storage: this.ctx.storage,
-            llm: this.ctx.llm,
-            logger: this.ctx.logger,
-            timezone: this.ctx.config.timezone,
-            provider: this.ctx.config.llm.provider,
-            model: this.ctx.config.llm.model,
-            contextWindow: this.ctx.config.llm.contextWindow,
-            sandboxUrl: this.ctx.config.sandboxUrl,
-            browserUrl: this.ctx.config.browserUrl,
-            dataDir: this.ctx.config.dataDir,
-            webSearch,
-            formatSearchResults,
-            fetchPage: fetchPageAsMarkdown,
-          },
-          jobId,
-        ).catch((err) => {
-          this.ctx.logger.error(`Scheduled analysis failed: ${err instanceof Error ? err.message : String(err)}`);
+          sourceKind: "schedule",
+          sourceScheduleId: schedule.id,
         });
       }
     } catch (err) {

--- a/packages/server/test/background-dispatcher.test.ts
+++ b/packages/server/test/background-dispatcher.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginContext } from "@personal-ai/core";
+
+const mockGetLlmTrafficConfig = vi.fn();
+const mockGetLlmTrafficSnapshot = vi.fn();
+const mockUpsertJob = vi.fn();
+
+const mockCreateResearchJob = vi.fn();
+const mockListPendingResearchJobs = vi.fn();
+const mockRunResearchInBackground = vi.fn();
+
+const mockCreateSwarmJob = vi.fn();
+const mockListPendingSwarmJobs = vi.fn();
+const mockRunSwarmInBackground = vi.fn();
+
+const mockEnqueueBriefingGeneration = vi.fn();
+const mockGenerateBriefing = vi.fn();
+const mockListPendingDailyBriefings = vi.fn();
+
+vi.mock("@personal-ai/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@personal-ai/core")>();
+  return {
+    ...actual,
+    getLlmTrafficConfig: (...args: unknown[]) => mockGetLlmTrafficConfig(...args),
+    getLlmTrafficSnapshot: (...args: unknown[]) => mockGetLlmTrafficSnapshot(...args),
+    upsertJob: (...args: unknown[]) => mockUpsertJob(...args),
+  };
+});
+
+vi.mock("@personal-ai/plugin-research", () => ({
+  createResearchJob: (...args: unknown[]) => mockCreateResearchJob(...args),
+  listPendingResearchJobs: (...args: unknown[]) => mockListPendingResearchJobs(...args),
+  runResearchInBackground: (...args: unknown[]) => mockRunResearchInBackground(...args),
+}));
+
+vi.mock("@personal-ai/plugin-swarm", () => ({
+  createSwarmJob: (...args: unknown[]) => mockCreateSwarmJob(...args),
+  listPendingSwarmJobs: (...args: unknown[]) => mockListPendingSwarmJobs(...args),
+  runSwarmInBackground: (...args: unknown[]) => mockRunSwarmInBackground(...args),
+}));
+
+vi.mock("../src/briefing.js", () => ({
+  enqueueBriefingGeneration: (...args: unknown[]) => mockEnqueueBriefingGeneration(...args),
+  generateBriefing: (...args: unknown[]) => mockGenerateBriefing(...args),
+  listPendingDailyBriefings: (...args: unknown[]) => mockListPendingDailyBriefings(...args),
+}));
+
+vi.mock("@personal-ai/plugin-assistant/web-search", () => ({
+  webSearch: vi.fn(),
+  formatSearchResults: vi.fn(),
+}));
+
+vi.mock("@personal-ai/plugin-assistant/page-fetch", () => ({
+  fetchPageAsMarkdown: vi.fn(),
+}));
+
+import { BackgroundDispatcher } from "../src/background-dispatcher.js";
+
+function makeCtx(): PluginContext {
+  return {
+    config: {
+      dataDir: "/tmp/test",
+      logLevel: "silent",
+      llm: {
+        provider: "ollama",
+        model: "llama3.2",
+        baseUrl: "http://127.0.0.1:11434",
+      },
+      plugins: [],
+    },
+    storage: {
+      query: vi.fn().mockReturnValue([]),
+      run: vi.fn(),
+      migrate: vi.fn(),
+      close: vi.fn(),
+    } as unknown as PluginContext["storage"],
+    llm: {
+      getModel: vi.fn(),
+      health: vi.fn().mockResolvedValue({ ok: true }),
+      embed: vi.fn(),
+    } as unknown as PluginContext["llm"],
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  } as PluginContext;
+}
+
+describe("BackgroundDispatcher", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockGetLlmTrafficConfig.mockReturnValue({
+      maxConcurrent: 1,
+      startGapMs: 0,
+      startupDelayMs: 0,
+      swarmAgentConcurrency: 1,
+    });
+    mockGetLlmTrafficSnapshot.mockReturnValue({
+      active: { interactive: 0, deferred: 0, background: 0 },
+      queued: { interactive: 0, deferred: 0, background: 0 },
+      activeTotal: 0,
+      queuedTotal: 0,
+    });
+    mockListPendingResearchJobs.mockReturnValue([]);
+    mockListPendingSwarmJobs.mockReturnValue([]);
+    mockListPendingDailyBriefings.mockReturnValue([]);
+  });
+
+  afterEach(async () => {
+    await vi.runOnlyPendingTimersAsync();
+    vi.useRealTimers();
+  });
+
+  it("orders pending work by manual, then schedule, then maintenance", () => {
+    mockListPendingResearchJobs.mockReturnValue([
+      { id: "research-schedule", queuedAt: "2026-03-05T10:00:00.000Z", sourceKind: "schedule" },
+      { id: "research-manual", queuedAt: "2026-03-05T11:00:00.000Z", sourceKind: "manual" },
+    ]);
+    mockListPendingSwarmJobs.mockReturnValue([
+      { id: "swarm-maintenance", queuedAt: "2026-03-05T09:00:00.000Z", sourceKind: "maintenance" },
+    ]);
+
+    const dispatcher = new BackgroundDispatcher(makeCtx());
+    const state = dispatcher.getWorkState();
+
+    expect(state.pending.map((item) => item.id)).toEqual([
+      "research-manual",
+      "research-schedule",
+      "swarm-maintenance",
+    ]);
+  });
+
+  it("dispatches only one background job at a time", async () => {
+    let releaseRun: (() => void) | null = null;
+    mockListPendingResearchJobs.mockReturnValue([
+      { id: "job-1", queuedAt: "2026-03-05T10:00:00.000Z", sourceKind: "manual" },
+    ]);
+    mockRunResearchInBackground.mockImplementation(() => new Promise<void>((resolve) => {
+      releaseRun = resolve;
+    }));
+
+    const dispatcher = new BackgroundDispatcher(makeCtx());
+    dispatcher.start();
+
+    await vi.runAllTimersAsync();
+    expect(mockRunResearchInBackground).toHaveBeenCalledTimes(1);
+
+    dispatcher.nudge();
+    await vi.runAllTimersAsync();
+    expect(mockRunResearchInBackground).toHaveBeenCalledTimes(1);
+
+    releaseRun?.();
+    await vi.runAllTimersAsync();
+    dispatcher.stop();
+  });
+});

--- a/packages/server/test/briefing.test.ts
+++ b/packages/server/test/briefing.test.ts
@@ -365,6 +365,10 @@ describe("generateBriefing", () => {
       expect.objectContaining({
         model: "mock-model",
         maxRetries: 1,
+        timeout: {
+          totalMs: 2 * 60_000,
+          stepMs: 60_000,
+        },
       }),
     );
   });

--- a/packages/server/test/routes.test.ts
+++ b/packages/server/test/routes.test.ts
@@ -158,6 +158,7 @@ const mockGenerateBriefing = vi.fn();
 const mockClearAllBriefings = vi.fn();
 const mockListAllBriefings = vi.fn();
 const mockGetResearchBriefings = vi.fn();
+const mockGetDailyBriefingState = vi.fn().mockReturnValue({ generating: false, pending: false });
 
 vi.mock("../src/briefing.js", () => ({
   getLatestBriefing: (...args: unknown[]) => mockGetLatestBriefing(...args),
@@ -167,6 +168,7 @@ vi.mock("../src/briefing.js", () => ({
   clearAllBriefings: (...args: unknown[]) => mockClearAllBriefings(...args),
   listAllBriefings: (...args: unknown[]) => mockListAllBriefings(...args),
   getResearchBriefings: (...args: unknown[]) => mockGetResearchBriefings(...args),
+  getDailyBriefingState: (...args: unknown[]) => mockGetDailyBriefingState(...args),
   briefingMigrations: [],
 }));
 
@@ -261,6 +263,7 @@ function setupDefaultAIMocks(responseText = "Hello from AI"): void {
   mockCreateUIMessageStream.mockImplementation(
     ({ execute, onError }: { execute: (ctx: { writer: { write: unknown; merge: unknown } }) => Promise<void>; onError?: (e: unknown) => string }) => {
       const chunks: string[] = [];
+      const merged: Promise<void>[] = [];
       const mockWriter = {
         write: vi.fn().mockImplementation((part: unknown) => {
           chunks.push(`data: ${JSON.stringify(part)}\n\n`);
@@ -274,32 +277,26 @@ function setupDefaultAIMocks(responseText = "Hello from AI"): void {
               chunks.push(typeof value === "string" ? value : new TextDecoder().decode(value));
               return pump();
             });
-          pump().catch(() => {});
+          const promise = pump();
+          merged.push(promise);
+          return promise.catch(() => {});
         }),
       };
-
-      // Execute the callback (async but we handle errors)
-      try {
-        const result = execute({ writer: mockWriter });
-        if (result && typeof result.then === "function") {
-          result.catch((e: unknown) => {
-            if (onError) onError(e);
-          });
-        }
-      } catch (e) {
-        if (onError) onError(e);
-      }
 
       // Return a simple ReadableStream with the collected text
       const encoder = new TextEncoder();
       return new ReadableStream({
-        start(controller) {
-          // Use a microtask to let the execute callback's async merge run
-          queueMicrotask(() => {
+        async start(controller) {
+          try {
+            await execute({ writer: mockWriter });
+            await Promise.allSettled(merged);
             const body = chunks.length > 0 ? chunks.join("") : `0:${JSON.stringify(responseText)}\n`;
             controller.enqueue(encoder.encode(body));
             controller.close();
-          });
+          } catch (e) {
+            if (onError) onError(e);
+            controller.close();
+          }
         },
       });
     },
@@ -473,6 +470,18 @@ function createMockStorage() {
 
 function createMockServerCtx(): ServerContext {
   const storage = createMockStorage();
+  const backgroundDispatcher = {
+    enqueueResearch: vi.fn().mockResolvedValue("job-research-1"),
+    enqueueSwarm: vi.fn().mockResolvedValue("job-swarm-1"),
+    enqueueBriefing: vi.fn().mockReturnValue("briefing-queued-1"),
+    getJobQueueMetadata: vi.fn().mockReturnValue({ queuePosition: null, waitingReason: null }),
+    getWorkState: vi.fn().mockReturnValue({
+      startupDelayUntil: null,
+      activeWorkId: null,
+      activeKind: null,
+      pending: [],
+    }),
+  };
   return {
     ctx: {
       config: {
@@ -522,6 +531,7 @@ function createMockServerCtx(): ServerContext {
         },
       },
     ],
+    backgroundDispatcher: backgroundDispatcher as ServerContext["backgroundDispatcher"],
     reinitialize: vi.fn(),
     telegramBot: null,
     telegramStatus: { running: false },
@@ -2148,10 +2158,10 @@ describe("Inbox routes", () => {
   });
 
   it("POST /api/inbox/refresh triggers generation", async () => {
-    mockGenerateBriefing.mockResolvedValue(null);
     const res = await app.inject({ method: "POST", url: "/api/inbox/refresh", payload: {} });
     expect(res.statusCode).toBe(200);
     expect(res.json().ok).toBe(true);
+    expect(serverCtx.backgroundDispatcher.enqueueBriefing).toHaveBeenCalledWith({ sourceKind: "manual", reason: "inbox-refresh" });
   });
 
   it("GET /api/inbox/history returns list", async () => {
@@ -2204,6 +2214,7 @@ describe("Inbox routes", () => {
     const body = res.json();
     expect(body.briefings).toHaveLength(2);
     expect(body.generating).toBe(false);
+    expect(body.pending).toBe(false);
   });
 
   it("GET /api/inbox/research returns research briefings", async () => {
@@ -2254,24 +2265,19 @@ describe("Inbox routes", () => {
       sections: JSON.stringify({ goal: "Research AI trends", resultType: "news" }),
       status: "ready",
     });
-    mockCreateResearchJob.mockReturnValue("new_job_123");
-    mockRunResearchInBackground.mockResolvedValue(undefined);
+    vi.mocked(serverCtx.backgroundDispatcher.enqueueResearch).mockResolvedValue("new_job_123");
 
     const res = await app.inject({ method: "POST", url: "/api/inbox/brief_rerun/rerun", payload: {} });
     expect(res.statusCode).toBe(200);
     const body = res.json();
     expect(body.ok).toBe(true);
     expect(body.jobId).toBe("new_job_123");
-    expect(mockCreateResearchJob).toHaveBeenCalledOnce();
-    expect(mockRunResearchInBackground).toHaveBeenCalledOnce();
-    expect(mockRunResearchInBackground).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sandboxUrl: "http://sandbox",
-        browserUrl: "http://browser",
-        dataDir: "/tmp/test",
-      }),
-      "new_job_123",
-    );
+    expect(serverCtx.backgroundDispatcher.enqueueResearch).toHaveBeenCalledWith({
+      goal: "Research AI trends",
+      threadId: null,
+      resultType: "news",
+      sourceKind: "manual",
+    });
   });
 
   it("POST /api/inbox/:id/rerun defaults resultType to general when missing", async () => {
@@ -2280,17 +2286,17 @@ describe("Inbox routes", () => {
       sections: JSON.stringify({ goal: "Research something" }),
       status: "ready",
     });
-    mockCreateResearchJob.mockReturnValue("job_gen");
-    mockRunResearchInBackground.mockResolvedValue(undefined);
+    vi.mocked(serverCtx.backgroundDispatcher.enqueueResearch).mockResolvedValue("job_gen");
 
     const res = await app.inject({ method: "POST", url: "/api/inbox/brief_notype/rerun", payload: {} });
     expect(res.statusCode).toBe(200);
     expect(res.json().ok).toBe(true);
-    // Verify resultType defaults to "general"
-    expect(mockCreateResearchJob).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ resultType: "general" }),
-    );
+    expect(serverCtx.backgroundDispatcher.enqueueResearch).toHaveBeenCalledWith({
+      goal: "Research something",
+      threadId: null,
+      resultType: "general",
+      sourceKind: "manual",
+    });
   });
 
   it("POST /api/inbox/:id/rerun handles already-parsed sections object", async () => {
@@ -2299,16 +2305,17 @@ describe("Inbox routes", () => {
       sections: { goal: "Research parsed", resultType: "stock" },
       status: "ready",
     });
-    mockCreateResearchJob.mockReturnValue("job_obj");
-    mockRunResearchInBackground.mockResolvedValue(undefined);
+    vi.mocked(serverCtx.backgroundDispatcher.enqueueResearch).mockResolvedValue("job_obj");
 
     const res = await app.inject({ method: "POST", url: "/api/inbox/brief_obj/rerun", payload: {} });
     expect(res.statusCode).toBe(200);
     expect(res.json().ok).toBe(true);
-    expect(mockCreateResearchJob).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ goal: "Research parsed", resultType: "stock" }),
-    );
+    expect(serverCtx.backgroundDispatcher.enqueueResearch).toHaveBeenCalledWith({
+      goal: "Research parsed",
+      threadId: null,
+      resultType: "stock",
+      sourceKind: "manual",
+    });
   });
 
   it("POST /api/inbox/:id/rerun preserves analysis execution mode", async () => {
@@ -2321,24 +2328,17 @@ describe("Inbox routes", () => {
       }),
       status: "ready",
     });
-    mockCreateSwarmJob.mockReturnValue("swarm_job_1");
-    mockRunSwarmInBackground.mockResolvedValue(undefined);
+    vi.mocked(serverCtx.backgroundDispatcher.enqueueSwarm).mockResolvedValue("swarm_job_1");
 
     const res = await app.inject({ method: "POST", url: "/api/inbox/swarm-brief_analysis/rerun", payload: {} });
     expect(res.statusCode).toBe(200);
     expect(res.json().jobId).toBe("swarm_job_1");
-    expect(mockCreateSwarmJob).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ goal: "Compare AI model pricing trends", resultType: "comparison" }),
-    );
-    expect(mockRunSwarmInBackground).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sandboxUrl: "http://sandbox",
-        browserUrl: "http://browser",
-        dataDir: "/tmp/test",
-      }),
-      "swarm_job_1",
-    );
+    expect(serverCtx.backgroundDispatcher.enqueueSwarm).toHaveBeenCalledWith({
+      goal: "Compare AI model pricing trends",
+      threadId: null,
+      resultType: "comparison",
+      sourceKind: "manual",
+    });
   });
 });
 
@@ -2952,6 +2952,11 @@ describe("observability routes", () => {
       totals: { calls: 4, errors: 1, inputTokens: 10, outputTokens: 5, totalTokens: 15, avgDurationMs: 120, p95DurationMs: 180 },
       topProcesses: [],
       topModels: [],
+      queue: {
+        avgWaitMs: 0,
+        p95WaitMs: 0,
+        byProcess: [],
+      },
     });
 
     const res = await app.inject({ method: "GET", url: "/api/observability/overview?range=24h" });

--- a/packages/server/test/workers.test.ts
+++ b/packages/server/test/workers.test.ts
@@ -5,10 +5,8 @@ import type { PluginContext } from "@personal-ai/core";
 // ---------------------------------------------------------------------------
 // Mock all external dependencies so we test WorkerLoop in isolation
 // ---------------------------------------------------------------------------
-const mockGenerateBriefing = vi.fn().mockResolvedValue(undefined);
 const mockGetLatestBriefing = vi.fn().mockReturnValue(null);
 vi.mock("../src/briefing.js", () => ({
-  generateBriefing: (...args: unknown[]) => mockGenerateBriefing(...args),
   getLatestBriefing: (...args: unknown[]) => mockGetLatestBriefing(...args),
 }));
 
@@ -85,6 +83,11 @@ function createMockCtx(): PluginContext {
       warn: vi.fn(),
       error: vi.fn(),
     },
+    backgroundJobs: {
+      enqueueResearch: vi.fn().mockResolvedValue("job-1"),
+      enqueueSwarm: vi.fn().mockResolvedValue("swarm-1"),
+      enqueueBriefing: vi.fn().mockResolvedValue("briefing-1"),
+    },
   } as unknown as PluginContext;
 }
 
@@ -146,7 +149,7 @@ describe("WorkerLoop", () => {
     loop.start();
 
     expect(mockGetLatestBriefing).toHaveBeenCalled();
-    expect(mockGenerateBriefing).toHaveBeenCalledTimes(1);
+    expect(ctx.backgroundJobs?.enqueueBriefing).toHaveBeenCalledTimes(1);
 
     loop.stop();
   });
@@ -160,7 +163,7 @@ describe("WorkerLoop", () => {
     const loop = new WorkerLoop(ctx, { generateInitialBriefing: true });
     loop.start();
 
-    expect(mockGenerateBriefing).not.toHaveBeenCalled();
+    expect(ctx.backgroundJobs?.enqueueBriefing).not.toHaveBeenCalled();
 
     loop.stop();
   });
@@ -173,7 +176,7 @@ describe("WorkerLoop", () => {
     loop.start();
 
     expect(mockGetLatestBriefing).toHaveBeenCalled();
-    expect(mockGenerateBriefing).not.toHaveBeenCalled();
+    expect(ctx.backgroundJobs?.enqueueBriefing).not.toHaveBeenCalled();
 
     loop.stop();
   });
@@ -185,13 +188,13 @@ describe("WorkerLoop", () => {
     const loop = new WorkerLoop(ctx, { briefingIntervalMs: 5000, generateInitialBriefing: true });
     loop.start();
 
-    expect(mockGenerateBriefing).not.toHaveBeenCalled();
+    expect(ctx.backgroundJobs?.enqueueBriefing).not.toHaveBeenCalled();
 
     vi.advanceTimersByTime(5000);
-    expect(mockGenerateBriefing).toHaveBeenCalledTimes(1);
+    expect(ctx.backgroundJobs?.enqueueBriefing).toHaveBeenCalledTimes(1);
 
     vi.advanceTimersByTime(5000);
-    expect(mockGenerateBriefing).toHaveBeenCalledTimes(2);
+    expect(ctx.backgroundJobs?.enqueueBriefing).toHaveBeenCalledTimes(2);
 
     loop.stop();
   });
@@ -279,20 +282,12 @@ describe("WorkerLoop", () => {
     vi.advanceTimersByTime(1000);
 
     expect(mockMarkScheduleRun).toHaveBeenCalledWith(ctx.storage, "s1");
-    expect(mockCreateResearchJob).toHaveBeenCalledWith(ctx.storage, {
+    expect(ctx.backgroundJobs?.enqueueResearch).toHaveBeenCalledWith({
       goal: "Check news",
       threadId: "t1",
+      sourceKind: "schedule",
+      sourceScheduleId: "s1",
     });
-    expect(mockRunResearchInBackground).toHaveBeenCalledTimes(1);
-    expect(mockRunResearchInBackground).toHaveBeenCalledWith(
-      expect.objectContaining({
-        storage: ctx.storage,
-        sandboxUrl: "http://sandbox",
-        browserUrl: "http://browser",
-        dataDir: "/tmp",
-      }),
-      "job-1",
-    );
 
     loop.stop();
   });
@@ -312,19 +307,12 @@ describe("WorkerLoop", () => {
     vi.advanceTimersByTime(1000);
 
     expect(mockMarkScheduleRun).toHaveBeenCalledWith(ctx.storage, "s2");
-    expect(mockCreateSwarmJob).toHaveBeenCalledWith(ctx.storage, {
+    expect(ctx.backgroundJobs?.enqueueSwarm).toHaveBeenCalledWith({
       goal: "Compare revenue trends",
       threadId: "t2",
+      sourceKind: "schedule",
+      sourceScheduleId: "s2",
     });
-    expect(mockRunSwarmInBackground).toHaveBeenCalledWith(
-      expect.objectContaining({
-        storage: ctx.storage,
-        sandboxUrl: "http://sandbox",
-        browserUrl: "http://browser",
-        dataDir: "/tmp",
-      }),
-      "swarm-1",
-    );
 
     loop.stop();
   });

--- a/packages/ui/src/api.ts
+++ b/packages/ui/src/api.ts
@@ -393,12 +393,22 @@ export function updateConfig(updates: {
   embedProvider?: string;
   apiKey?: string;
   dataDir?: string;
+  backgroundLearning?: boolean;
+  briefingEnabled?: boolean;
   telegramToken?: string;
   telegramEnabled?: boolean;
   knowledgeCleanup?: boolean;
+  llmTrafficMaxConcurrent?: number;
+  llmTrafficStartGapMs?: number;
+  llmTrafficStartupDelayMs?: number;
+  llmTrafficSwarmAgentConcurrency?: number;
+  llmTrafficReservedInteractiveSlots?: number;
   knowledgeDefaultTtlDays?: number | null;
   knowledgeFreshnessDecayDays?: number;
   debugResearch?: boolean;
+  sandboxUrl?: string;
+  searchUrl?: string;
+  browserUrl?: string;
   timezone?: string;
 }): Promise<ConfigInfo> {
   return request<ConfigInfo>("/config", {
@@ -494,7 +504,7 @@ export function deleteGoal(id: string): Promise<{ ok: boolean }> {
 
 // ---- Inbox ----
 
-export function refreshInbox(): Promise<{ ok: boolean }> {
+export function refreshInbox(): Promise<{ ok: boolean; briefingId?: string; message?: string }> {
   return request("/inbox/refresh", { method: "POST", body: "{}" });
 }
 
@@ -502,7 +512,7 @@ export function getInboxBriefing(id: string): Promise<{ briefing: Briefing }> {
   return request<{ briefing: Briefing }>(`/inbox/${id}`);
 }
 
-export function getInboxAll(): Promise<{ briefings: Array<{ id: string; generatedAt: string; sections: Record<string, unknown>; status: string; type: string }>; generating: boolean }> {
+export function getInboxAll(): Promise<{ briefings: Array<{ id: string; generatedAt: string; sections: Record<string, unknown>; status: string; type: string }>; generating: boolean; pending?: boolean }> {
   return request("/inbox/all");
 }
 
@@ -523,7 +533,14 @@ export interface BackgroundJobInfo {
   status: "pending" | "running" | "done" | "error" | "failed" | "planning" | "synthesizing";
   progress: string;
   startedAt: string;
+  queuedAt?: string | null;
   completedAt?: string | null;
+  attemptCount?: number;
+  lastAttemptAt?: string | null;
+  sourceKind?: "manual" | "schedule" | "maintenance";
+  sourceScheduleId?: string | null;
+  queuePosition?: number | null;
+  waitingReason?: "startup_delay" | "interactive_ahead" | "manual_job_ahead" | "scheduled_job_ahead" | "maintenance_job_ahead" | "llm_busy" | null;
   error?: string | null;
   result?: string | null;
   resultType?: ResearchResultType | null;
@@ -540,7 +557,15 @@ export interface ResearchJobDetail {
   pagesLearned: number;
   report: string | null;
   createdAt: string;
+  queuedAt?: string | null;
+  startedAt?: string | null;
   completedAt: string | null;
+  attemptCount?: number;
+  lastAttemptAt?: string | null;
+  sourceKind?: "manual" | "schedule" | "maintenance";
+  sourceScheduleId?: string | null;
+  queuePosition?: number | null;
+  waitingReason?: "startup_delay" | "interactive_ahead" | "manual_job_ahead" | "scheduled_job_ahead" | "maintenance_job_ahead" | "llm_busy" | null;
   resultType?: ResearchResultType;
   briefingId?: string | null;
   // Swarm-specific fields (present when job is a swarm)

--- a/packages/ui/src/components/settings/DiagnosticsPanel.tsx
+++ b/packages/ui/src/components/settings/DiagnosticsPanel.tsx
@@ -39,6 +39,11 @@ function formatDate(value: string, timezone?: string): string {
   }, timezone);
 }
 
+function getQueueWait(span: TelemetrySpan): number | null {
+  const value = span.metadata?.queueWaitMs;
+  return typeof value === "number" ? value : null;
+}
+
 function getTraceDepth(spans: TelemetrySpan[], span: TelemetrySpan): number {
   let depth = 0;
   let current = span;
@@ -101,6 +106,7 @@ function TraceViewer({ traceId, timezone }: { traceId: string | null; timezone?:
             </div>
             <div className="mt-1 text-[11px] text-muted-foreground">
               {formatDate(span.startedAt, timezone)}
+              {getQueueWait(span) != null ? ` • queue ${formatDuration(getQueueWait(span))}` : ""}
               {span.errorMessage ? ` • ${span.errorMessage}` : ""}
             </div>
           </div>
@@ -258,6 +264,45 @@ export function DiagnosticsPanel({ timezone }: { timezone?: string }) {
                       <StatCard label="Avg Time" value={formatDuration(overview.totals.avgDurationMs)} />
                       <StatCard label="P95 Time" value={formatDuration(overview.totals.p95DurationMs)} />
                     </div>
+                    <div className="grid gap-3 sm:grid-cols-4">
+                      <StatCard label="Active LLM" value={formatNumber(overview.live?.activeRequests ?? 0)} />
+                      <StatCard label="Queued LLM" value={formatNumber(overview.live?.queuedRequests ?? 0)} />
+                      <StatCard label="Avg Queue" value={formatDuration(overview.queue.avgWaitMs)} />
+                      <StatCard label="P95 Queue" value={formatDuration(overview.queue.p95WaitMs)} />
+                    </div>
+                    <div className="grid gap-3 lg:grid-cols-3">
+                      {(["interactive", "deferred", "background"] as const).map((lane) => (
+                        <div key={lane} className="rounded-lg border border-border/40 bg-background/40 px-4 py-3">
+                          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">{lane}</div>
+                          <div className="mt-2 flex items-center justify-between text-xs">
+                            <span className="text-muted-foreground">active</span>
+                            <span className="font-medium text-foreground">{formatNumber(overview.live?.lanes[lane].active ?? 0)}</span>
+                          </div>
+                          <div className="mt-1 flex items-center justify-between text-xs">
+                            <span className="text-muted-foreground">queued</span>
+                            <span className="font-medium text-foreground">{formatNumber(overview.live?.lanes[lane].queued ?? 0)}</span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                    <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+                      <span>pending background jobs {formatNumber(overview.live?.pendingBackgroundJobs ?? 0)}</span>
+                      {overview.live?.backgroundActiveKind ? <span>active background {overview.live.backgroundActiveKind}</span> : null}
+                      {overview.live?.startupDelayUntil ? <span>startup delay until {formatDate(overview.live.startupDelayUntil, timezone)}</span> : null}
+                    </div>
+                    <div className="rounded-lg border border-border/40">
+                      <div className="border-b border-border/30 px-4 py-3 text-xs font-medium text-foreground">Queue Wait By Process</div>
+                      {overview.queue.byProcess.length > 0 ? overview.queue.byProcess.map((process) => (
+                        <div key={process.process} className="grid grid-cols-[minmax(0,1.8fr)_repeat(3,minmax(0,1fr))] items-center gap-3 border-t border-border/30 px-4 py-3 text-xs first:border-t-0">
+                          <span className="truncate font-medium text-foreground">{process.process}</span>
+                          <span className="text-muted-foreground">{formatDuration(process.avgQueueWaitMs)}</span>
+                          <span className="text-muted-foreground">{formatDuration(process.p95QueueWaitMs)}</span>
+                          <span className="text-muted-foreground">{formatNumber(process.calls)}</span>
+                        </div>
+                      )) : (
+                        <div className="px-4 py-3 text-xs text-muted-foreground">No queue waits recorded in this range.</div>
+                      )}
+                    </div>
                     <div className="grid gap-4 lg:grid-cols-2">
                       <div className="rounded-lg border border-border/40">
                         <div className="border-b border-border/30 px-4 py-3 text-xs font-medium text-foreground">Top Processes</div>
@@ -291,11 +336,13 @@ export function DiagnosticsPanel({ timezone }: { timezone?: string }) {
               <TabsContent value="processes" className="space-y-3">
                 <div className="rounded-lg border border-border/40">
                   {(processes?.processes ?? []).map((process) => (
-                    <div key={process.process} className="grid grid-cols-[minmax(0,1.8fr)_repeat(4,minmax(0,1fr))] items-center gap-3 border-t border-border/30 px-4 py-3 text-xs first:border-t-0">
+                    <div key={process.process} className="grid grid-cols-[minmax(0,1.8fr)_repeat(7,minmax(0,1fr))] items-center gap-3 border-t border-border/30 px-4 py-3 text-xs first:border-t-0">
                       <span className="truncate font-medium text-foreground">{process.process}</span>
                       <span className="text-muted-foreground">{formatNumber(process.totalTokens)}</span>
                       <span className="text-muted-foreground">{formatDuration(process.avgDurationMs)}</span>
                       <span className="text-muted-foreground">{formatDuration(process.p95DurationMs)}</span>
+                      <span className="text-muted-foreground">{formatDuration(process.avgQueueWaitMs)}</span>
+                      <span className="text-muted-foreground">{formatDuration(process.p95QueueWaitMs)}</span>
                       <span className="text-muted-foreground">{formatNumber(process.calls)}</span>
                       <span className="text-muted-foreground">{formatNumber(process.errors)}</span>
                     </div>

--- a/packages/ui/src/hooks/use-config.ts
+++ b/packages/ui/src/hooks/use-config.ts
@@ -40,7 +40,15 @@ export function useUpdateConfig() {
       backgroundLearning?: boolean;
       briefingEnabled?: boolean;
       knowledgeCleanup?: boolean;
+      llmTrafficMaxConcurrent?: number;
+      llmTrafficStartGapMs?: number;
+      llmTrafficStartupDelayMs?: number;
+      llmTrafficSwarmAgentConcurrency?: number;
+      llmTrafficReservedInteractiveSlots?: number;
       debugResearch?: boolean;
+      sandboxUrl?: string;
+      searchUrl?: string;
+      browserUrl?: string;
     }) => updateConfig(updates),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: configKeys.all });

--- a/packages/ui/src/hooks/use-inbox.ts
+++ b/packages/ui/src/hooks/use-inbox.ts
@@ -15,11 +15,19 @@ export const inboxKeys = {
   research: () => ["inbox", "research"] as const,
 };
 
-export function useInboxAll(options?: { refetchInterval?: number | false }) {
+export function useInboxAll(options?: { refetchInterval?: number | false | ((data: Awaited<ReturnType<typeof getInboxAll>> | undefined) => number | false) }) {
   return useQuery({
     queryKey: inboxKeys.list(),
     queryFn: () => getInboxAll(),
-    refetchInterval: options?.refetchInterval,
+    refetchInterval: options?.refetchInterval
+      ? (query) => {
+          const value = options.refetchInterval;
+          if (typeof value === "function") {
+            return value(query.state.data as Awaited<ReturnType<typeof getInboxAll>> | undefined);
+          }
+          return value;
+        }
+      : false,
   });
 }
 

--- a/packages/ui/src/pages/Inbox.tsx
+++ b/packages/ui/src/pages/Inbox.tsx
@@ -21,6 +21,7 @@ import {
   SparklesIcon,
   Trash2Icon,
   SearchIcon,
+  ClockIcon,
   ChevronDownIcon,
   ChevronUpIcon,
   LoaderIcon,
@@ -308,7 +309,7 @@ function InboxDetail({ id }: { id: string }) {
                   size="sm"
                   onClick={() => {
                     rerunMutation.mutate(id, {
-                      onSuccess: () => toast.success("Research rerun started"),
+                      onSuccess: () => toast.success("Research rerun queued"),
                       onError: () => toast.error("Failed to rerun research"),
                     });
                   }}
@@ -465,27 +466,29 @@ function DailyBriefingDetail({ sections: raw, navigate }: { sections: Record<str
 // ---- Feed View ----
 
 function InboxFeed() {
-  const [generating, setGenerating] = useState(false);
   const navigate = useNavigate();
   const prevGeneratingRef = useRef(false);
+  const prevPendingRef = useRef(false);
   const { readIds, markRead } = useContext(ReadContext);
+  const refreshInboxMut = useRefreshInbox();
+  const clearInboxMut = useClearInbox();
 
   const { data: inboxData, isLoading: loading } = useInboxAll({
-    refetchInterval: generating ? 3000 : false,
+    refetchInterval: (data) => data?.generating || data?.pending ? 3000 : false,
   });
   const items: InboxItem[] = inboxData?.briefings ?? [];
+  const generating = !!inboxData?.generating;
+  const pending = !!inboxData?.pending;
+  const busy = generating || pending || refreshInboxMut.isPending;
 
   // Track generating state transitions via query data
   useEffect(() => {
-    if (inboxData?.generating && !generating) {
-      setGenerating(true);
-    }
-    if (prevGeneratingRef.current && !inboxData?.generating) {
-      setGenerating(false);
+    if ((prevGeneratingRef.current || prevPendingRef.current) && !inboxData?.generating && !inboxData?.pending) {
       toast.success("Briefing updated!");
     }
     prevGeneratingRef.current = !!inboxData?.generating;
-  }, [inboxData?.generating]); // eslint-disable-line react-hooks/exhaustive-deps
+    prevPendingRef.current = !!inboxData?.pending;
+  }, [inboxData?.generating, inboxData?.pending]);
 
   // Store last seen briefing ID
   useEffect(() => {
@@ -507,16 +510,11 @@ function InboxFeed() {
     [markRead, navigate],
   );
 
-  const refreshInboxMut = useRefreshInbox();
-  const clearInboxMut = useClearInbox();
-
   const handleRefresh = async () => {
-    setGenerating(true);
     try {
-      await refreshInboxMut.mutateAsync();
-      toast.success("Generating new briefing...");
+      const result = await refreshInboxMut.mutateAsync();
+      toast.success(result.message ?? "Briefing queued");
     } catch {
-      setGenerating(false);
       toast.error("Failed to start briefing refresh");
     }
   };
@@ -533,7 +531,7 @@ function InboxFeed() {
 
   if (loading) return <InboxSkeleton />;
 
-  if (items.length === 0 && !generating) {
+  if (items.length === 0 && !busy) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-6 p-4 md:p-6">
         <div className="inbox-fade-in flex w-full max-w-md flex-col items-center gap-5 text-center">
@@ -592,10 +590,10 @@ function InboxFeed() {
               variant="ghost"
               size="icon"
               onClick={handleRefresh}
-              disabled={generating}
+              disabled={busy}
               className="text-muted-foreground hover:text-foreground"
             >
-              <RefreshCwIcon className={`h-4 w-4 ${generating ? "animate-spin" : ""}`} />
+              <RefreshCwIcon className={`h-4 w-4 ${busy ? "animate-spin" : ""}`} />
             </Button>
             <Button
               variant="ghost"
@@ -607,6 +605,13 @@ function InboxFeed() {
             </Button>
           </div>
         </div>
+
+        {pending && !generating && (
+          <div className="inbox-fade-in flex items-center gap-2 rounded-lg border border-yellow-500/20 bg-yellow-500/5 px-4 py-3">
+            <ClockIcon className="h-4 w-4 text-yellow-400" />
+            <span className="text-sm text-yellow-300">Briefing queued. Waiting for background slot...</span>
+          </div>
+        )}
 
         {generating && (
           <div className="inbox-fade-in flex items-center gap-2 rounded-lg border border-primary/20 bg-primary/5 px-4 py-3">

--- a/packages/ui/src/pages/Jobs.tsx
+++ b/packages/ui/src/pages/Jobs.tsx
@@ -64,6 +64,21 @@ const resultTypeBadges: Record<string, string> = {
   comparison: "\u2696 comparison",
 };
 
+const waitingReasonLabels: Record<NonNullable<BackgroundJobInfo["waitingReason"]>, string> = {
+  startup_delay: "startup delay",
+  interactive_ahead: "interactive work ahead",
+  manual_job_ahead: "manual job ahead",
+  scheduled_job_ahead: "scheduled job ahead",
+  maintenance_job_ahead: "maintenance job ahead",
+  llm_busy: "llm busy",
+};
+
+const sourceKindLabels: Record<NonNullable<BackgroundJobInfo["sourceKind"]>, string> = {
+  manual: "manual",
+  schedule: "schedule",
+  maintenance: "maintenance",
+};
+
 const roleStyles: Record<string, string> = {
   researcher: "bg-blue-500/15 text-blue-400 border-blue-500/20",
   flight_researcher: "bg-blue-500/15 text-blue-400 border-blue-500/20",
@@ -97,6 +112,21 @@ function formatDuration(start: string, end: string | null): string {
   const mins = Math.floor(secs / 60);
   const remainSecs = secs % 60;
   return `${mins}m ${remainSecs}s`;
+}
+
+function statusTimestamp(job: BackgroundJobInfo): string {
+  const timestamp = job.status === "pending"
+    ? (job.queuedAt ?? job.startedAt)
+    : job.startedAt;
+  return timeAgo(timestamp);
+}
+
+function queueSummary(job: BackgroundJobInfo): string | null {
+  if (job.status !== "pending") return null;
+  const parts: string[] = [];
+  if (job.queuePosition) parts.push(`queue #${job.queuePosition}`);
+  if (job.waitingReason) parts.push(waitingReasonLabels[job.waitingReason]);
+  return parts.length > 0 ? parts.join(" · ") : "queued";
 }
 
 const blackboardTypeIcons: Record<string, typeof LightbulbIcon> = {
@@ -206,7 +236,9 @@ export default function Jobs() {
 
   if (isLoading) return <JobsSkeleton />;
 
-  const runningCount = jobs.filter((j) => j.status === "running" || j.status === "pending").length;
+  const activeCount = jobs.filter((j) =>
+    j.status === "pending" || j.status === "running" || j.status === "planning" || j.status === "synthesizing",
+  ).length;
 
   return (
     <div className="flex h-full overflow-hidden">
@@ -218,9 +250,9 @@ export default function Jobs() {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <h1 className="font-mono text-lg font-semibold text-foreground">Background Jobs</h1>
-              {runningCount > 0 && (
+              {activeCount > 0 && (
                 <Badge variant="outline" className="text-[10px] border-blue-500/20 bg-blue-500/10 text-blue-400 animate-pulse">
-                  {runningCount} running
+                  {activeCount} active
                 </Badge>
               )}
               {jobs.length > 0 && (
@@ -317,7 +349,20 @@ export default function Jobs() {
                             </Badge>
                           )}
                           <span className="text-[10px] text-muted-foreground">{job.progress}</span>
-                          <span className="text-[10px] text-muted-foreground/60">{timeAgo(job.startedAt)}</span>
+                          <span className="text-[10px] text-muted-foreground/60">{statusTimestamp(job)}</span>
+                          {job.status === "pending" && job.queuePosition ? (
+                            <Badge variant="outline" className="text-[9px] px-1.5 py-0 border-yellow-500/20 bg-yellow-500/10 text-yellow-300">
+                              #{job.queuePosition}
+                            </Badge>
+                          ) : null}
+                        </div>
+                        {queueSummary(job) ? (
+                          <p className="mt-1 text-xs text-yellow-300/80">{queueSummary(job)}</p>
+                        ) : null}
+                        <div className="mt-1 flex flex-wrap items-center gap-2 text-[10px] text-muted-foreground/70">
+                          <span>source {sourceKindLabels[job.sourceKind ?? "manual"]}</span>
+                          <span>attempt {job.attemptCount ?? 0}</span>
+                          {job.lastAttemptAt ? <span>last attempt {timeAgo(job.lastAttemptAt)}</span> : null}
                         </div>
                         {job.error && (
                           <p className="mt-1 text-xs text-red-400">{job.error}</p>
@@ -398,6 +443,10 @@ export default function Jobs() {
                   <span>Agents: {selectedJob.agentsDone ?? 0}/{selectedJob.agentCount}</span>
                 )}
                 <span>Status: {selectedJob.status}</span>
+                {selectedJob.queuePosition ? <span>Queue: #{selectedJob.queuePosition}</span> : null}
+                {selectedJob.waitingReason ? <span>Waiting: {waitingReasonLabels[selectedJob.waitingReason]}</span> : null}
+                {selectedJob.sourceKind ? <span>Source: {sourceKindLabels[selectedJob.sourceKind]}</span> : null}
+                {selectedJob.attemptCount != null ? <span>Attempts: {selectedJob.attemptCount}</span> : null}
               </div>
 
               {/* Agents section for swarm jobs */}

--- a/packages/ui/src/pages/Settings.tsx
+++ b/packages/ui/src/pages/Settings.tsx
@@ -24,6 +24,14 @@ const PROVIDER_PRESETS: Record<string, { baseUrl: string; model: string; embedMo
   google: { baseUrl: "https://generativelanguage.googleapis.com/v1beta", model: "gemini-2.0-flash", embedModel: "text-embedding-004" },
 };
 
+const DEFAULT_LLM_TRAFFIC = {
+  maxConcurrent: 6,
+  startGapMs: 1500,
+  startupDelayMs: 10000,
+  swarmAgentConcurrency: 5,
+  reservedInteractiveSlots: 1,
+};
+
 export default function Settings() {
   // --- TanStack Query hooks ---
   const { data: config, isLoading: configLoading } = useConfig();
@@ -57,6 +65,11 @@ export default function Settings() {
   const [bgLearningEnabled, setBgLearningEnabled] = useState(true);
   const [briefingEnabled, setBriefingEnabled] = useState(true);
   const [knowledgeCleanupEnabled, setKnowledgeCleanupEnabled] = useState(true);
+  const [llmTrafficMaxConcurrent, setLlmTrafficMaxConcurrent] = useState(DEFAULT_LLM_TRAFFIC.maxConcurrent);
+  const [llmTrafficStartGapMs, setLlmTrafficStartGapMs] = useState(DEFAULT_LLM_TRAFFIC.startGapMs);
+  const [llmTrafficStartupDelayMs, setLlmTrafficStartupDelayMs] = useState(DEFAULT_LLM_TRAFFIC.startupDelayMs);
+  const [llmTrafficSwarmAgentConcurrency, setLlmTrafficSwarmAgentConcurrency] = useState(DEFAULT_LLM_TRAFFIC.swarmAgentConcurrency);
+  const [llmTrafficReservedInteractiveSlots, setLlmTrafficReservedInteractiveSlots] = useState(DEFAULT_LLM_TRAFFIC.reservedInteractiveSlots);
 
   // Sidecar URLs
   const [sandboxUrl, setSandboxUrl] = useState("");
@@ -92,6 +105,7 @@ export default function Settings() {
 
     // Only sync form fields when not editing
     if (!editing) {
+      const llmTraffic = config.workers?.llmTraffic ?? {};
       setProvider(config.llm.provider);
       setModel(config.llm.model);
       setBaseUrl(config.llm.baseUrl ?? "");
@@ -102,6 +116,11 @@ export default function Settings() {
       setBgLearningEnabled(config.workers?.backgroundLearning !== false);
       setBriefingEnabled(config.workers?.briefing !== false);
       setKnowledgeCleanupEnabled(config.workers?.knowledgeCleanup !== false);
+      setLlmTrafficMaxConcurrent(llmTraffic.maxConcurrent ?? DEFAULT_LLM_TRAFFIC.maxConcurrent);
+      setLlmTrafficStartGapMs(llmTraffic.startGapMs ?? DEFAULT_LLM_TRAFFIC.startGapMs);
+      setLlmTrafficStartupDelayMs(llmTraffic.startupDelayMs ?? DEFAULT_LLM_TRAFFIC.startupDelayMs);
+      setLlmTrafficSwarmAgentConcurrency(llmTraffic.swarmAgentConcurrency ?? DEFAULT_LLM_TRAFFIC.swarmAgentConcurrency);
+      setLlmTrafficReservedInteractiveSlots(llmTraffic.reservedInteractiveSlots ?? DEFAULT_LLM_TRAFFIC.reservedInteractiveSlots);
       setSandboxUrl(config.sandboxUrl ?? "");
       setSearchUrl(config.searchUrl ?? "");
       setBrowserUrl(config.browserUrl ?? "");
@@ -111,7 +130,7 @@ export default function Settings() {
   const handleSave = useCallback(async () => {
     if (!config) return;
     try {
-      const updates: Record<string, string | boolean> = {};
+      const updates: Record<string, string | boolean | number | null> = {};
       if (provider !== config.llm.provider) updates.provider = provider;
       if (model !== config.llm.model) updates.model = model;
       if (baseUrl !== (config.llm.baseUrl ?? "")) updates.baseUrl = baseUrl;
@@ -125,6 +144,21 @@ export default function Settings() {
       if (bgLearningEnabled !== (config.workers?.backgroundLearning !== false)) updates.backgroundLearning = bgLearningEnabled;
       if (briefingEnabled !== (config.workers?.briefing !== false)) updates.briefingEnabled = briefingEnabled;
       if (knowledgeCleanupEnabled !== (config.workers?.knowledgeCleanup !== false)) updates.knowledgeCleanup = knowledgeCleanupEnabled;
+      if (llmTrafficMaxConcurrent !== (config.workers?.llmTraffic?.maxConcurrent ?? DEFAULT_LLM_TRAFFIC.maxConcurrent)) {
+        updates.llmTrafficMaxConcurrent = llmTrafficMaxConcurrent;
+      }
+      if (llmTrafficStartGapMs !== (config.workers?.llmTraffic?.startGapMs ?? DEFAULT_LLM_TRAFFIC.startGapMs)) {
+        updates.llmTrafficStartGapMs = llmTrafficStartGapMs;
+      }
+      if (llmTrafficStartupDelayMs !== (config.workers?.llmTraffic?.startupDelayMs ?? DEFAULT_LLM_TRAFFIC.startupDelayMs)) {
+        updates.llmTrafficStartupDelayMs = llmTrafficStartupDelayMs;
+      }
+      if (llmTrafficSwarmAgentConcurrency !== (config.workers?.llmTraffic?.swarmAgentConcurrency ?? DEFAULT_LLM_TRAFFIC.swarmAgentConcurrency)) {
+        updates.llmTrafficSwarmAgentConcurrency = llmTrafficSwarmAgentConcurrency;
+      }
+      if (llmTrafficReservedInteractiveSlots !== (config.workers?.llmTraffic?.reservedInteractiveSlots ?? DEFAULT_LLM_TRAFFIC.reservedInteractiveSlots)) {
+        updates.llmTrafficReservedInteractiveSlots = llmTrafficReservedInteractiveSlots;
+      }
       if (sandboxUrl !== (config.sandboxUrl ?? "")) updates.sandboxUrl = sandboxUrl;
       if (searchUrl !== (config.searchUrl ?? "")) updates.searchUrl = searchUrl;
       if (browserUrl !== (config.browserUrl ?? "")) updates.browserUrl = browserUrl;
@@ -142,7 +176,7 @@ export default function Settings() {
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to save configuration");
     }
-  }, [provider, model, baseUrl, embedModel, embedProvider, apiKey, dataDir, timezone, telegramToken, telegramEnabled, bgLearningEnabled, briefingEnabled, knowledgeCleanupEnabled, sandboxUrl, searchUrl, browserUrl, config, updateConfigMut]);
+  }, [provider, model, baseUrl, embedModel, embedProvider, apiKey, dataDir, timezone, telegramToken, telegramEnabled, bgLearningEnabled, briefingEnabled, knowledgeCleanupEnabled, llmTrafficMaxConcurrent, llmTrafficStartGapMs, llmTrafficStartupDelayMs, llmTrafficSwarmAgentConcurrency, llmTrafficReservedInteractiveSlots, sandboxUrl, searchUrl, browserUrl, config, updateConfigMut]);
 
   const handleCancel = useCallback(() => {
     if (config) {
@@ -160,6 +194,11 @@ export default function Settings() {
     setBgLearningEnabled(config?.workers?.backgroundLearning !== false);
     setBriefingEnabled(config?.workers?.briefing !== false);
     setKnowledgeCleanupEnabled(config?.workers?.knowledgeCleanup !== false);
+    setLlmTrafficMaxConcurrent(config?.workers?.llmTraffic?.maxConcurrent ?? DEFAULT_LLM_TRAFFIC.maxConcurrent);
+    setLlmTrafficStartGapMs(config?.workers?.llmTraffic?.startGapMs ?? DEFAULT_LLM_TRAFFIC.startGapMs);
+    setLlmTrafficStartupDelayMs(config?.workers?.llmTraffic?.startupDelayMs ?? DEFAULT_LLM_TRAFFIC.startupDelayMs);
+    setLlmTrafficSwarmAgentConcurrency(config?.workers?.llmTraffic?.swarmAgentConcurrency ?? DEFAULT_LLM_TRAFFIC.swarmAgentConcurrency);
+    setLlmTrafficReservedInteractiveSlots(config?.workers?.llmTraffic?.reservedInteractiveSlots ?? DEFAULT_LLM_TRAFFIC.reservedInteractiveSlots);
     setDebugResearch(config?.debugResearch ?? false);
     setSandboxUrl(config?.sandboxUrl ?? "");
     setSearchUrl(config?.searchUrl ?? "");
@@ -621,6 +660,65 @@ export default function Settings() {
                 )}
               </div>
 
+              <div className="border-t border-border/30 px-5 py-3">
+                <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                  LLM Traffic Shaping
+                  <InfoBubble text="Serializes model traffic so chat stays responsive and restart backlogs do not stampede the LLM server. Background jobs wait behind interactive work." side="right" />
+                </div>
+              </div>
+
+              {editing ? (
+                <>
+                  <NumericWorkerRow
+                    label="Max LLM concurrency"
+                    value={llmTrafficMaxConcurrent}
+                    onChange={setLlmTrafficMaxConcurrent}
+                    min={1}
+                    description="Concurrent LLM or embed requests allowed for this instance."
+                  />
+                  <NumericWorkerRow
+                    label="Background start gap"
+                    value={llmTrafficStartGapMs}
+                    onChange={setLlmTrafficStartGapMs}
+                    min={0}
+                    step={100}
+                    suffix="ms"
+                    description="Delay between starting background requests so the provider sees smoother traffic."
+                  />
+                  <NumericWorkerRow
+                    label="Startup delay"
+                    value={llmTrafficStartupDelayMs}
+                    onChange={setLlmTrafficStartupDelayMs}
+                    min={0}
+                    step={1000}
+                    suffix="ms"
+                    description="How long workers wait after boot before draining queued background jobs."
+                  />
+                  <NumericWorkerRow
+                    label="Swarm agent concurrency"
+                    value={llmTrafficSwarmAgentConcurrency}
+                    onChange={setLlmTrafficSwarmAgentConcurrency}
+                    min={1}
+                    description="How many swarm sub-agents may run at once inside a single background job."
+                  />
+                  <NumericWorkerRow
+                    label="Reserved interactive slots"
+                    value={llmTrafficReservedInteractiveSlots}
+                    onChange={setLlmTrafficReservedInteractiveSlots}
+                    min={0}
+                    description="Capacity held back from background work so chats and deferred tasks can still start immediately."
+                  />
+                </>
+              ) : (
+                <>
+                  <ConfigRow label="Max LLM concurrency" value={String(config.workers?.llmTraffic?.maxConcurrent ?? DEFAULT_LLM_TRAFFIC.maxConcurrent)} />
+                  <ConfigRow label="Background start gap" value={`${config.workers?.llmTraffic?.startGapMs ?? DEFAULT_LLM_TRAFFIC.startGapMs}ms`} />
+                  <ConfigRow label="Startup delay" value={`${config.workers?.llmTraffic?.startupDelayMs ?? DEFAULT_LLM_TRAFFIC.startupDelayMs}ms`} />
+                  <ConfigRow label="Swarm agent concurrency" value={String(config.workers?.llmTraffic?.swarmAgentConcurrency ?? DEFAULT_LLM_TRAFFIC.swarmAgentConcurrency)} />
+                  <ConfigRow label="Reserved interactive slots" value={String(config.workers?.llmTraffic?.reservedInteractiveSlots ?? DEFAULT_LLM_TRAFFIC.reservedInteractiveSlots)} />
+                </>
+              )}
+
               {/* Last Run Info */}
               {config.workers?.lastRun && (
                 <div className="flex items-center justify-between border-t border-border/30 px-5 py-3">
@@ -947,6 +1045,44 @@ function EditableRow({
         placeholder={placeholder}
         className="w-full max-w-xs rounded-md border border-border/50 bg-background px-2.5 py-1.5 text-right font-mono text-sm text-foreground placeholder-muted-foreground/50 outline-none transition-colors focus:border-primary/50 focus:ring-1 focus:ring-primary/25"
       />
+    </div>
+  );
+}
+
+function NumericWorkerRow({
+  label,
+  value,
+  onChange,
+  description,
+  min = 0,
+  step = 1,
+  suffix,
+}: {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  description: string;
+  min?: number;
+  step?: number;
+  suffix?: string;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 border-t border-border/30 px-5 py-3">
+      <div className="flex flex-col gap-0.5">
+        <span className="text-xs text-foreground">{label}</span>
+        <span className="text-[10px] text-muted-foreground">{description}</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <input
+          type="number"
+          min={min}
+          step={step}
+          value={value}
+          onChange={(event) => onChange(Math.max(min, Number(event.target.value) || min))}
+          className="w-24 rounded-md border border-border/50 bg-background px-2.5 py-1.5 text-right font-mono text-sm text-foreground outline-none transition-colors focus:border-primary/50 focus:ring-1 focus:ring-primary/25"
+        />
+        {suffix ? <span className="text-xs text-muted-foreground">{suffix}</span> : null}
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -104,6 +104,13 @@ export interface ConfigInfo {
     backgroundLearning?: boolean;
     briefing?: boolean;
     knowledgeCleanup?: boolean;
+    llmTraffic?: {
+      maxConcurrent?: number;
+      startGapMs?: number;
+      startupDelayMs?: number;
+      swarmAgentConcurrency?: number;
+      reservedInteractiveSlots?: number;
+    };
     lastRun?: Record<string, string | null>;
   };
   knowledge?: {
@@ -158,11 +165,35 @@ export interface TelemetrySummary {
 export interface ProcessAggregate extends TelemetrySummary {
   process: string;
   avgStepCount: number;
+  avgQueueWaitMs: number;
+  p95QueueWaitMs: number;
 }
 
 export interface ModelAggregate extends TelemetrySummary {
   provider: string | null;
   model: string | null;
+}
+
+export interface QueueProcessAggregate {
+  process: string;
+  calls: number;
+  avgQueueWaitMs: number;
+  p95QueueWaitMs: number;
+}
+
+export interface QueueLaneSnapshot {
+  active: number;
+  queued: number;
+}
+
+export interface LiveQueueSnapshot {
+  activeRequests: number;
+  queuedRequests: number;
+  lanes: Record<"interactive" | "deferred" | "background", QueueLaneSnapshot>;
+  startupDelayUntil: string | null;
+  backgroundActiveWorkId: string | null;
+  backgroundActiveKind: string | null;
+  pendingBackgroundJobs: number;
 }
 
 export interface ObservabilityOverview {
@@ -171,6 +202,12 @@ export interface ObservabilityOverview {
   totals: TelemetrySummary;
   topProcesses: ProcessAggregate[];
   topModels: ModelAggregate[];
+  queue: {
+    avgWaitMs: number;
+    p95WaitMs: number;
+    byProcess: QueueProcessAggregate[];
+  };
+  live?: LiveQueueSnapshot;
 }
 
 export interface ThreadMessageUsage {


### PR DESCRIPTION
## Summary
- add instance-level LLM traffic shaping with queue lanes, staggered starts, and reserved interactive capacity
- add a persistent background dispatcher for research, swarm, and briefing work with restart recovery and queue metadata
- surface queue state in observability, jobs, inbox, and settings so owners can see what is waiting and why

## Verification
- pnpm run ci