### PR TITLE
feat: light/dark/system theme support

### DIFF
--- a/packages/ui/index.html
+++ b/packages/ui/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
@@ -10,7 +10,7 @@
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <link rel="apple-touch-icon" href="/icon-192.png" />
   </head>
-  <body class="bg-[#0a0a0a] text-[#e5e5e5] antialiased">
+  <body class="bg-background text-foreground antialiased">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/packages/ui/src/components/ErrorBoundary.tsx
+++ b/packages/ui/src/components/ErrorBoundary.tsx
@@ -58,7 +58,7 @@ export class ErrorBoundary extends Component<Props, State> {
     const { error, copied } = this.state;
 
     return (
-      <div className="flex h-screen w-screen items-center justify-center bg-[#0a0a0a] p-6">
+      <div className="flex h-screen w-screen items-center justify-center bg-background p-6">
         <div className="flex max-w-md flex-col items-center gap-6 text-center">
           <div className="flex h-16 w-16 items-center justify-center rounded-full bg-destructive/10">
             <AlertTriangleIcon className="h-8 w-8 text-destructive" />

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -48,9 +48,9 @@ export default function Layout() {
   }, [location.pathname, latestId]);
 
   return (
-    <div className="flex h-dvh w-screen overflow-hidden bg-[#0a0a0a]">
+    <div className="flex h-dvh w-screen overflow-hidden bg-background">
       {/* Desktop sidebar — hidden on mobile, replaced by bottom tab bar */}
-      <nav className="hidden md:flex h-full w-14 flex-col items-center border-r border-border/40 bg-[#0a0a0a] py-4">
+      <nav className="hidden md:flex h-full w-14 flex-col items-center border-r border-border/40 bg-background py-4">
         {/* Branding */}
         <div className="mb-2 font-mono text-base font-bold tracking-tighter text-primary">
           pai
@@ -80,10 +80,10 @@ export default function Layout() {
                     <item.icon />
                   </NavLink>
                   {item.to === "/" && hasNewBriefing && (
-                    <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-primary ring-2 ring-[#0a0a0a] pointer-events-none" />
+                    <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-primary ring-2 ring-background pointer-events-none" />
                   )}
                   {item.to === "/jobs" && activeJobCount > 0 && (
-                    <span className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-bold text-primary-foreground ring-2 ring-[#0a0a0a] pointer-events-none">
+                    <span className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-bold text-primary-foreground ring-2 ring-background pointer-events-none">
                       {activeJobCount}
                     </span>
                   )}
@@ -98,7 +98,7 @@ export default function Layout() {
       </nav>
 
       {/* Main content — bottom padding on mobile to clear tab bar */}
-      <main className="flex flex-1 flex-col overflow-hidden bg-[#0f0f0f] pb-14 md:pb-0">
+      <main className="flex flex-1 flex-col overflow-hidden bg-card pb-14 md:pb-0">
         <OfflineBanner />
         <div className="flex-1 overflow-hidden">
           <Outlet />

--- a/packages/ui/src/components/MarkdownContent.tsx
+++ b/packages/ui/src/components/MarkdownContent.tsx
@@ -19,7 +19,7 @@ function CodeBlock({ children }: { children?: ReactNode }) {
     <div className="group/code relative my-3">
       <pre
         ref={preRef}
-        className="overflow-x-auto rounded-lg border border-border/50 bg-[#0a0a0a] p-4 text-[13px] leading-relaxed"
+        className="overflow-x-auto rounded-lg border border-border/50 bg-background p-4 text-[13px] leading-relaxed"
       >
         {children}
       </pre>

--- a/packages/ui/src/components/MobileTabBar.tsx
+++ b/packages/ui/src/components/MobileTabBar.tsx
@@ -49,7 +49,7 @@ export function MobileTabBar({ hasNewBriefing, activeJobCount }: MobileTabBarPro
   );
 
   return (
-    <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-border/40 bg-[#0a0a0a] pb-[env(safe-area-inset-bottom)] md:hidden">
+    <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-border/40 bg-background pb-[env(safe-area-inset-bottom)] md:hidden">
       <div className="flex items-stretch">
         {primaryTabs.map((tab) => (
           <NavLink
@@ -91,7 +91,7 @@ export function MobileTabBar({ hasNewBriefing, activeJobCount }: MobileTabBarPro
 
           {/* More popover */}
           {moreOpen && (
-            <div className="absolute bottom-full right-0 mb-2 mr-1 w-44 rounded-lg border border-border/50 bg-[#141414] py-1 shadow-xl">
+            <div className="absolute bottom-full right-0 mb-2 mr-1 w-44 rounded-lg border border-border/50 bg-popover py-1 shadow-xl">
               {moreTabs.map((tab) => (
                 <NavLink
                   key={tab.to}

--- a/packages/ui/src/context/ThemeContext.tsx
+++ b/packages/ui/src/context/ThemeContext.tsx
@@ -1,0 +1,78 @@
+import { createContext, useContext, useState, useEffect, type ReactNode } from "react";
+
+type Theme = "light" | "dark" | "system";
+
+interface ThemeState {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeState>({
+  theme: "system",
+  setTheme: () => {},
+});
+
+const STORAGE_KEY = "pai-theme";
+
+function getSystemTheme(): "light" | "dark" {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  const effectiveTheme = theme === "system" ? getSystemTheme() : theme;
+  
+  if (effectiveTheme === "dark") {
+    root.classList.add("dark");
+  } else {
+    root.classList.remove("dark");
+  }
+  
+  // Update theme-color meta tag
+  const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+  if (metaThemeColor) {
+    const bgColor = effectiveTheme === "dark" ? "#0a0a0a" : "#ffffff";
+    metaThemeColor.setAttribute("content", bgColor);
+  }
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return (stored === "light" || stored === "dark" || stored === "system") ? stored : "system";
+  });
+
+  useEffect(() => {
+    applyTheme(theme);
+    localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  // Listen for system theme changes when in system mode
+  useEffect(() => {
+    if (theme !== "system") return;
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => applyTheme("system");
+    
+    mediaQuery.addEventListener("change", handler);
+    return () => mediaQuery.removeEventListener("change", handler);
+  }, [theme]);
+
+  const setTheme = (newTheme: Theme) => {
+    setThemeState(newTheme);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeState {
+  return useContext(ThemeContext);
+}
+
+export function getEffectiveTheme(theme: Theme): "light" | "dark" {
+  return theme === "system" ? getSystemTheme() : theme;
+}

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from "react-router-dom";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "sonner";
 import { registerSW } from "virtual:pwa-register";
+import { ThemeProvider, useTheme, getEffectiveTheme } from "./context/ThemeContext";
 import App from "./App";
 import "./App.css";
 
@@ -17,23 +18,33 @@ registerSW({
   },
 });
 
+function ThemedToaster() {
+  const { theme } = useTheme();
+  const effectiveTheme = getEffectiveTheme(theme);
+  
+  return (
+    <Toaster
+      theme={effectiveTheme}
+      position="bottom-right"
+      toastOptions={{
+        style: {
+          background: effectiveTheme === "dark" ? "#1a1a1a" : "#ffffff",
+          border: effectiveTheme === "dark" ? "1px solid rgba(255,255,255,0.1)" : "1px solid rgba(0,0,0,0.1)",
+        },
+      }}
+    />
+  );
+}
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <BrowserRouter>
-      <TooltipProvider delayDuration={300}>
-        <App />
-        <Toaster
-          theme="dark"
-          position="bottom-right"
-          toastOptions={{
-            style: {
-              background: "#1a1a1a",
-              border: "1px solid rgba(255,255,255,0.1)",
-              color: "#e5e5e5",
-            },
-          }}
-        />
-      </TooltipProvider>
-    </BrowserRouter>
+    <ThemeProvider>
+      <BrowserRouter>
+        <TooltipProvider delayDuration={300}>
+          <App />
+          <ThemedToaster />
+        </TooltipProvider>
+      </BrowserRouter>
+    </ThemeProvider>
   </StrictMode>,
 );

--- a/packages/ui/src/pages/Jobs.tsx
+++ b/packages/ui/src/pages/Jobs.tsx
@@ -405,7 +405,7 @@ export default function Jobs() {
           <div className="flex h-full">
             {/* Drag handle — desktop only */}
             <div onMouseDown={onDragStart} className="hidden md:block h-full w-2 shrink-0 cursor-col-resize bg-border/20 hover:bg-primary/30 active:bg-primary/40 transition-colors" />
-            <div style={{ width: undefined }} className="fixed right-0 top-0 z-40 h-full w-full overflow-y-auto border-l border-border/40 bg-[#0f0f0f] md:static md:h-full" ref={(el) => { if (el && window.innerWidth >= 768) el.style.width = `${panelWidth}px`; }}>
+            <div style={{ width: undefined }} className="fixed right-0 top-0 z-40 h-full w-full overflow-y-auto border-l border-border/40 bg-card md:static md:h-full" ref={(el) => { if (el && window.innerWidth >= 768) el.style.width = `${panelWidth}px`; }}>
             <div className="p-6">
               <div className="flex items-start justify-between gap-3">
                 <div>

--- a/packages/ui/src/pages/Knowledge.tsx
+++ b/packages/ui/src/pages/Knowledge.tsx
@@ -278,7 +278,7 @@ export default function Knowledge() {
     <div className="flex h-full">
       <div className="flex flex-1 flex-col overflow-hidden">
         <FirstVisitBanner pageKey="knowledge" tip="Teach me web pages, docs, or articles. Paste a URL and I'll learn from it — then reference it when you ask questions." />
-        <header className="space-y-2 border-b border-border/40 bg-[#0a0a0a] px-3 py-3 md:space-y-4 md:px-6 md:py-4">
+        <header className="space-y-2 border-b border-border/40 bg-background px-3 py-3 md:space-y-4 md:px-6 md:py-4">
           <div className="flex items-center justify-between gap-2">
             <div className="flex min-w-0 items-center gap-3">
               <h1 className="shrink-0 font-mono text-sm font-semibold text-foreground">
@@ -535,7 +535,7 @@ export default function Knowledge() {
           </SheetContent>
         </Sheet>
       ) : (
-        <aside className="relative z-auto w-96 overflow-hidden border-l border-border/40 bg-[#0a0a0a]">
+        <aside className="relative z-auto w-96 overflow-hidden border-l border-border/40 bg-background">
           <SourceDetailPanel source={selectedSource} onClose={() => setSelectedSource(null)} editingTags={editingTags} setEditingTags={setEditingTags} tagsInput={tagsInput} setTagsInput={setTagsInput} handleSaveTags={handleSaveTags} setViewChunksSource={setViewChunksSource} handleRefresh={handleRefresh} isRefreshing={isRefreshing} handleCrawlSubPages={handleCrawlSubPages} isCrawling={isCrawling} setShowDeleteConfirm={setShowDeleteConfirm} />
         </aside>
       ))}

--- a/packages/ui/src/pages/Memory.tsx
+++ b/packages/ui/src/pages/Memory.tsx
@@ -218,7 +218,7 @@ export default function Memory() {
     <div className="flex h-full">
       <div className="flex flex-1 flex-col overflow-hidden">
         <FirstVisitBanner pageKey="memory" tip="Everything I know about you — built automatically from our conversations. Beliefs evolve as you share more." />
-        <header className="space-y-2 border-b border-border/40 bg-[#0a0a0a] px-3 py-3 md:space-y-4 md:px-6 md:py-4">
+        <header className="space-y-2 border-b border-border/40 bg-background px-3 py-3 md:space-y-4 md:px-6 md:py-4">
           <div className="flex items-center justify-between gap-2">
             <div className="flex min-w-0 items-center gap-3">
               <h1 className="shrink-0 font-mono text-sm font-semibold text-foreground">
@@ -353,7 +353,7 @@ export default function Memory() {
           )}
         </header>
 
-        <div className="border-b border-border/40 bg-[#0a0a0a] px-4 py-3 md:px-6">
+        <div className="border-b border-border/40 bg-background px-4 py-3 md:px-6">
           <div className="flex items-center gap-2">
             <input
               type="text"
@@ -435,7 +435,7 @@ export default function Memory() {
           </SheetContent>
         </Sheet>
       ) : (
-        <aside className="relative z-auto w-80 overflow-hidden border-l border-border/40 bg-[#0a0a0a]">
+        <aside className="relative z-auto w-80 overflow-hidden border-l border-border/40 bg-background">
           <BeliefDetailPanel belief={selectedBelief} onClose={() => { setSelectedBelief(null); setEditingStatement(null); }} editingStatement={editingStatement} setEditingStatement={setEditingStatement} handleSaveEdit={handleSaveEdit} isSavingEdit={isSavingEdit} handleForget={handleForget} />
         </aside>
       ))}

--- a/packages/ui/src/pages/Settings.tsx
+++ b/packages/ui/src/pages/Settings.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { useConfig, useUpdateConfig, useMemoryStats, useBrowseDir, useHealth, useLearningRuns } from "@/hooks";
 import { useAuth } from "../context/AuthContext";
+import { useTheme } from "../context/ThemeContext";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -13,7 +14,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { InfoBubble } from "../components/InfoBubble";
 import { DiagnosticsPanel } from "@/components/settings/DiagnosticsPanel";
-import { FolderIcon, FolderOpenIcon, ChevronUpIcon, ChevronDownIcon, BotIcon, CircleCheckIcon, CircleXIcon, LoaderIcon, CpuIcon, LogOutIcon } from "lucide-react";
+import { FolderIcon, FolderOpenIcon, ChevronUpIcon, ChevronDownIcon, BotIcon, CircleCheckIcon, CircleXIcon, LoaderIcon, CpuIcon, LogOutIcon, SunIcon, MoonIcon, MonitorIcon } from "lucide-react";
 import type { LearningRun } from "@/api";
 import { formatWithTimezone, parseApiDate } from "@/lib/datetime";
 
@@ -40,6 +41,7 @@ export default function Settings() {
   const { data: health, isLoading: healthLoading } = useHealth();
   const { data: learningData } = useLearningRuns();
   const { logout } = useAuth();
+  const { theme, setTheme } = useTheme();
   const navigate = useNavigate();
 
   const loading = configLoading || statsLoading;
@@ -470,6 +472,50 @@ export default function Settings() {
             </CardContent>
           </Card>
         )}
+
+        {/* Appearance */}
+        <Card className="gap-0 overflow-hidden border-border/50 bg-card/50 py-0">
+          <CardHeader className="px-5 py-4">
+            <CardTitle className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Appearance
+              <InfoBubble text="Choose between light, dark, or system theme. System theme automatically matches your device's appearance settings." side="right" />
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-0 px-0 py-0">
+            <div className="flex items-center justify-between gap-4 border-t border-border/30 px-5 py-3">
+              <label className="text-xs text-muted-foreground">Theme</label>
+              <div className="flex gap-1">
+                <Button
+                  variant={theme === "light" ? "default" : "ghost"}
+                  size="sm"
+                  className="h-7 gap-1.5 px-2.5 text-xs"
+                  onClick={() => setTheme("light")}
+                >
+                  <SunIcon className="size-3.5" />
+                  Light
+                </Button>
+                <Button
+                  variant={theme === "dark" ? "default" : "ghost"}
+                  size="sm"
+                  className="h-7 gap-1.5 px-2.5 text-xs"
+                  onClick={() => setTheme("dark")}
+                >
+                  <MoonIcon className="size-3.5" />
+                  Dark
+                </Button>
+                <Button
+                  variant={theme === "system" ? "default" : "ghost"}
+                  size="sm"
+                  className="h-7 gap-1.5 px-2.5 text-xs"
+                  onClick={() => setTheme("system")}
+                >
+                  <MonitorIcon className="size-3.5" />
+                  System
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
 
         {/* Telegram Bot */}
         {config && (

--- a/packages/ui/src/pages/Tasks.tsx
+++ b/packages/ui/src/pages/Tasks.tsx
@@ -284,7 +284,7 @@ export default function Tasks() {
     <div className="flex h-full flex-col overflow-hidden">
       <FirstVisitBanner pageKey="tasks" tip="Your to-do list with goals and priorities. Ask me in chat to add tasks, or create them here directly." />
       {/* Top-level tabs */}
-      <header className="space-y-2 border-b border-border/40 bg-[#0a0a0a] px-3 py-3 md:space-y-4 md:px-6 md:py-4">
+      <header className="space-y-2 border-b border-border/40 bg-background px-3 py-3 md:space-y-4 md:px-6 md:py-4">
         <Tabs
           value={activeTab}
           onValueChange={(v) => setActiveTab(v as "tasks" | "goals")}

--- a/packages/ui/src/pages/Timeline.tsx
+++ b/packages/ui/src/pages/Timeline.tsx
@@ -72,7 +72,7 @@ export default function Timeline() {
     <div className="flex h-full flex-col overflow-hidden">
       <FirstVisitBanner pageKey="timeline" tip="A chronological feed of everything I've learned about you — when beliefs were created or updated." />
       {/* Header */}
-      <header className="space-y-4 border-b border-border/40 bg-[#0a0a0a] px-4 py-4 md:px-6">
+      <header className="space-y-4 border-b border-border/40 bg-background px-4 py-4 md:px-6">
         <h1 className="flex items-center gap-1.5 font-mono text-sm font-semibold text-foreground">
           Timeline
           <InfoBubble text="A chronological feed of all beliefs, showing when they were created or updated. Filter by type to focus on specific categories." />
@@ -164,7 +164,7 @@ export default function Timeline() {
                       return (
                         <div key={belief.id} className="relative flex gap-3 py-2">
                           {/* Dot */}
-                          <div className={cn("relative z-10 mt-2 h-[15px] w-[15px] shrink-0 rounded-full border-2 border-[#0f0f0f]", dotClass)} />
+                          <div className={cn("relative z-10 mt-2 h-[15px] w-[15px] shrink-0 rounded-full border-2 border-background", dotClass)} />
 
                           {/* Card */}
                           <Card className={cn("flex-1 gap-2 border-border/50 border-l-2 bg-card/40 py-3 transition-colors hover:bg-card/70", accentClass)}>


### PR DESCRIPTION
Adds theme switching with three modes: Light, Dark, and System (auto-detects OS preference).

**Changes:**
- `ThemeContext` with localStorage persistence + `matchMedia` listener for system mode
- Replaced 33+ hardcoded hex colors (`#0a0a0a`, `#0f0f0f`, `#141414`) with semantic CSS tokens (`bg-background`, `bg-card`, `bg-popover`)
- `index.html`: removed hardcoded `class="dark"`, body uses `bg-background text-foreground`
- Sonner toast theme follows app theme dynamically
- Settings page: new Appearance section with Light/Dark/System toggle
- `theme-color` meta tag updates dynamically

Existing CSS tokens in App.css already defined both light and dark values — no CSS changes needed. All shadcn/ui components with `dark:` variants work automatically.

Spec: `docs/plans/light-dark-mode.md`