### PR TITLE
feat: add Cerebras provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Cerebras provider support** — Added first-class Cerebras support across the core LLM client, config validation, CLI setup, settings/onboarding flows, health checks, and context budgeting. Cerebras uses the official `@ai-sdk/cerebras` provider with local embedding fallback.
 - **Per-instance diagnostics** — Added a local observability system that records LLM, embed, tool, HTTP, and worker spans in SQLite. New owner-facing diagnostics panel lives in Settings with Overview, Processes, Threads, Jobs, and Errors tabs for token, latency, and failure visibility.
 - **LLM traffic shaping controls** — Added instance-level queue controls in Settings for max LLM concurrency, background start gap, startup delay, and swarm agent concurrency. Jobs and diagnostics now expose queue position, wait reason, queue wait metrics, and live lane depth.
 - **Swarm-friendly traffic defaults** — Default LLM traffic shaping now allows up to 5 concurrent swarm sub-agents with one reserved interactive slot, so a single swarm can investigate in parallel without fully blocking chat responsiveness.
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **End-to-end telemetry coverage** — Chat, Telegram, background learning, briefings, research, swarm execution, memory extraction, and knowledge embeddings now emit standardized process-level telemetry. Assistant thread messages also persist compact usage summaries for diagnostics without exposing raw metrics in normal user-facing flows.
 - **Background dispatch smoothing** — Research, swarm, and daily briefing generation now enqueue into a single background dispatcher instead of starting immediately. Restarts requeue unfinished research/swarm/briefing work as `pending`, scheduled jobs dedupe by schedule, manual work is prioritized ahead of scheduled and maintenance work, and swarm agent execution is staggered to avoid bursting the LLM server.
+- **Cerebras default model** — Setup wizard, Settings presets, and `pai init` now default Cerebras to `gpt-oss-120b` instead of `zai-glm-4.7` so fresh configurations land on a model that works with the currently tested account access path.
 
 ### Security
 
@@ -57,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Provider setup error visibility** — LLM setup "Test Connection" now performs a tiny inference instead of a shallow provider health check, so billing, quota, auth, and model-access failures surface with the provider's actual error message.
 - **Wasteful thread title token usage** — Short chats now keep cheap heuristic titles instead of immediately invoking the full LLM title path. LLM-generated title refreshes only start on longer threads and the title call itself is capped to a tiny output budget, cutting unnecessary token burn and queue time.
 - **Hung background LLM calls** — Research, swarm, and daily briefing generation now set explicit AI SDK timeouts so a stalled provider step cannot hold the background dispatcher indefinitely and leave jobs stuck in `running`.
 - **Nested chat LLM slowdown** — Nested LLM work inside an active chat or analysis turn now reuses the parent traffic permit instead of queueing for a second slot. This keeps sub-agent delegation and in-turn follow-up LLM calls from stalling behind background work.

--- a/README.md
+++ b/README.md
@@ -217,11 +217,11 @@ Environment variables or `~/.personal-ai/config.json` (editable via Settings UI)
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PAI_DATA_DIR` | `~/.personal-ai/data` | Database location |
-| `PAI_LLM_PROVIDER` | `ollama` | `ollama`, `openai`, `anthropic`, or `google` |
+| `PAI_LLM_PROVIDER` | `ollama` | `ollama`, `openai`, `anthropic`, `google`, or `cerebras` |
 | `PAI_LLM_MODEL` | `llama3.2` | Chat model |
 | `PAI_LLM_EMBED_MODEL` | `nomic-embed-text` | Embedding model |
 | `PAI_LLM_BASE_URL` | `http://127.0.0.1:11434` | Provider URL |
-| `PAI_LLM_API_KEY` | | API key (Ollama Cloud / OpenAI) |
+| `PAI_LLM_API_KEY` | | API key (required for cloud providers) |
 | `PAI_TELEGRAM_TOKEN` | | Telegram bot token from @BotFather |
 | `PAI_LOG_LEVEL` | `silent` | `silent`, `error`, `warn`, `info`, `debug` |
 | `PAI_JWT_SECRET` | _(auto-generated)_ | Custom JWT signing secret |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -136,7 +136,7 @@ In the Railway service settings, add these variables:
 
 | Variable | Value | Required |
 |----------|-------|----------|
-| `PAI_LLM_PROVIDER` | `openai`, `anthropic`, or `google` | Yes |
+| `PAI_LLM_PROVIDER` | `openai`, `anthropic`, `google`, or `cerebras` | Yes |
 | `PAI_LLM_API_KEY` | Your provider API key | Yes |
 | `PAI_LLM_MODEL` | e.g. `gpt-4o`, `claude-sonnet-4-20250514` | Recommended |
 | `PAI_DATA_DIR` | `/data` | Yes |

--- a/docs/landing-page-copy.md
+++ b/docs/landing-page-copy.md
@@ -45,7 +45,7 @@ Web UI, Telegram bot, CLI, or integrate with Claude Code / Cursor / Windsurf via
 
 **Your data stays yours.**
 
-Single SQLite file. No cloud dependency. No telemetry. Run it on your laptop, a Raspberry Pi, or Railway. Bring your own LLM — Ollama, OpenAI, Anthropic, or Google.
+Single SQLite file. No cloud dependency. No telemetry. Run it on your laptop, a Raspberry Pi, or Railway. Bring your own LLM — Ollama, OpenAI, Anthropic, Google, or Cerebras.
 
 ---
 

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -51,6 +51,13 @@ export const PROVIDER_PRESETS: Record<string, ProviderPreset> = {
     embedModel: "text-embedding-004",
     needsKey: true,
   },
+  cerebras: {
+    provider: "cerebras",
+    model: "gpt-oss-120b",
+    baseUrl: "https://api.cerebras.ai/v1",
+    embedModel: "text-embedding-3-small",
+    needsKey: true,
+  },
 };
 
 const VALID_CHOICES = Object.keys(PROVIDER_PRESETS);

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -18,6 +18,7 @@ describe("pai init PROVIDER_PRESETS", () => {
     expect(keys).toContain("openai");
     expect(keys).toContain("anthropic");
     expect(keys).toContain("google");
+    expect(keys).toContain("cerebras");
   });
 
   it("ollama local does not require a key", () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.45",
+    "@ai-sdk/cerebras": "^2.0.39",
     "@ai-sdk/google": "^3.0.30",
     "@ai-sdk/openai": "^3.0.29",
     "ai": "^6.0.0",

--- a/packages/core/src/context-budget.ts
+++ b/packages/core/src/context-budget.ts
@@ -5,6 +5,7 @@ const PROVIDER_DEFAULTS: Record<string, number> = {
   openai: 128_000,
   anthropic: 200_000,
   google: 1_000_000,
+  cerebras: 131_072,
 };
 
 export interface ContextBudget {
@@ -23,7 +24,7 @@ let cachedBudget: { key: string; budget: ContextBudget } | null = null;
  * Resolution order:
  * 1. `contextWindow` override (from config or PAI_CONTEXT_WINDOW env)
  * 2. TokenLens static catalog (337+ cloud models)
- * 3. Provider defaults (ollama=200K, openai=128K, anthropic=200K, google=1M)
+ * 3. Provider defaults (ollama=200K, openai=128K, anthropic=200K, google=1M, cerebras=131072)
  * 4. Fallback: 8,192
  */
 export function getContextBudget(

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -1,6 +1,7 @@
 import { streamText, embed as aiEmbed, stepCountIs } from "ai";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createAnthropic } from "@ai-sdk/anthropic";
+import { createCerebras } from "@ai-sdk/cerebras";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOllama } from "ai-sdk-ollama";
 import type { LLMClient, ChatMessage, ChatOptions, ChatResult, StreamEvent, Config, Logger, Storage, EmbedOptions } from "./types.js";
@@ -54,6 +55,8 @@ function createProviderModel(provider: Config["llm"]["provider"], model: string,
       return createOllama({ baseURL: baseUrl, headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined })(model);
     case "anthropic":
       return createAnthropic({ baseURL: baseUrl, apiKey: apiKey ?? "" })(model);
+    case "cerebras":
+      return createCerebras({ baseURL: baseUrl, apiKey: apiKey ?? "" })(model);
     case "google":
       return createGoogleGenerativeAI({ baseURL: baseUrl, apiKey: apiKey ?? "" })(model);
     case "openai":
@@ -70,8 +73,9 @@ function createProviderEmbedding(provider: string, embedModelName: string, baseU
       return createOpenAI({ baseURL: baseUrl, apiKey: apiKey ?? "" }).textEmbeddingModel(embedModelName);
     case "google":
       return createGoogleGenerativeAI({ baseURL: baseUrl, apiKey: apiKey ?? "" }).textEmbeddingModel(embedModelName);
+    case "cerebras":
     case "anthropic":
-      // Anthropic does not offer a native embedding API; return null to trigger local fallback
+      // Anthropic and Cerebras do not offer native embeddings; return null to trigger local fallback
       return null;
     default:
       return null;
@@ -116,6 +120,12 @@ async function localEmbed(text: string, log: Logger): Promise<number[] | null> {
   await initLocalPipeline(log);
   if (!localPipeline) return null;
   return localPipeline(text);
+}
+
+/** Reset local embedding cache (for tests). */
+export function _resetLocalEmbeddingCache(): void {
+  localPipeline = null;
+  localPipelineLoading = null;
 }
 
 // --- Main factory ---
@@ -292,6 +302,13 @@ export function createLLMClient(llmConfig: Config["llm"], logger?: Logger, stora
           headers: { "x-goog-api-key": apiKey ?? "" },
         });
         return { ok: res.ok, provider: "google" };
+      }
+      if (provider === "cerebras") {
+        const url = baseUrl.replace(/\/+$/, "") + "/models";
+        const res = await fetch(url, {
+          headers: { Authorization: `Bearer ${apiKey ?? ""}` },
+        });
+        return { ok: res.ok, provider: "cerebras" };
       }
       // openai (default)
       const res = await fetch(`${baseUrl}/models`, {

--- a/packages/core/src/provider-options.ts
+++ b/packages/core/src/provider-options.ts
@@ -3,7 +3,7 @@
  *
  * - Anthropic: auto-compaction + tool-use clearing at 85% of context window
  * - OpenAI: auto-truncation
- * - Others (Ollama, Google): rely on adaptive message loading only
+ * - Others (Ollama, Google, Cerebras): rely on adaptive message loading only
  */
 export function getProviderOptions(provider: string, contextWindow: number): Record<string, Record<string, unknown>> | undefined {
   const triggerTokens = Math.floor(contextWindow * 0.85);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -85,7 +85,7 @@ export interface Config {
   dataDir: string;
   logLevel: LogLevel;
   llm: {
-    provider: "ollama" | "openai" | "anthropic" | "google";
+    provider: "ollama" | "openai" | "anthropic" | "google" | "cerebras";
     model: string;
     baseUrl: string;
     apiKey?: string;

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -207,6 +207,16 @@ describe("loadConfig with config file merging", () => {
     expect(config.llm.model).toBe("claude-opus-4-6");
   });
 
+  it("should allow config file to set llm.provider to cerebras", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pai-test-"));
+    dirs.push(dir);
+    const fileConfig = { llm: { provider: "cerebras", model: "gpt-oss-120b", baseUrl: "https://api.cerebras.ai/v1", apiKey: "csk-test" } };
+    writeFileSync(join(dir, "config.json"), JSON.stringify(fileConfig));
+    const config = loadConfig({ PAI_HOME: dir });
+    expect(config.llm.provider).toBe("cerebras");
+    expect(config.llm.model).toBe("gpt-oss-120b");
+  });
+
   it("should use dataDir from config file", () => {
     const dir = mkdtempSync(join(tmpdir(), "pai-test-"));
     dirs.push(dir);

--- a/packages/core/test/context-window.test.ts
+++ b/packages/core/test/context-window.test.ts
@@ -34,6 +34,7 @@ describe("context-budget", () => {
       expect(getContextBudget("openai", "nonexistent").contextWindow).toBe(128_000);
       expect(getContextBudget("anthropic", "nonexistent").contextWindow).toBe(200_000);
       expect(getContextBudget("google", "nonexistent").contextWindow).toBe(1_000_000);
+      expect(getContextBudget("cerebras", "nonexistent").contextWindow).toBe(131_072);
     });
 
     it("historyBudget is 50% of contextWindow", () => {

--- a/packages/core/test/llm.test.ts
+++ b/packages/core/test/llm.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { createLLMClient } from "../src/llm.js";
+import { createLLMClient, _resetLocalEmbeddingCache } from "../src/llm.js";
 import { createStorage } from "../src/storage.js";
 import { telemetryMigrations } from "../src/telemetry.js";
 
@@ -14,22 +14,29 @@ vi.mock("ai", () => ({
 }));
 
 vi.mock("@huggingface/transformers", () => ({
-  pipeline: vi.fn().mockResolvedValue(
-    vi.fn().mockResolvedValue({ data: new Float32Array(384).fill(0.1) }),
-  ),
+  pipeline: vi.fn(),
   env: {},
 }));
 
 import { generateText, streamText, embed as aiEmbed } from "ai";
+import { pipeline as transformersPipeline } from "@huggingface/transformers";
 const mockGenerateText = vi.mocked(generateText);
 const mockStreamText = vi.mocked(streamText);
 const mockEmbed = vi.mocked(aiEmbed);
+const mockTransformersPipeline = vi.mocked(transformersPipeline);
 
 describe("LLMClient", () => {
   const originalFetch = globalThis.fetch;
 
+  beforeEach(() => {
+    mockTransformersPipeline.mockResolvedValue(
+      vi.fn().mockResolvedValue({ data: new Float32Array(384).fill(0.1) }) as any,
+    );
+  });
+
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    _resetLocalEmbeddingCache();
     vi.restoreAllMocks();
   });
 
@@ -277,6 +284,79 @@ describe("LLMClient", () => {
     expect(result.embedding).toBeInstanceOf(Array);
     expect(result.embedding.length).toBe(384); // all-MiniLM-L6-v2 dimensions
     // Remote mock should NOT have been called (no OpenAI fallback with Anthropic key)
+    expect(mockEmbed).not.toHaveBeenCalled();
+  });
+
+  // --- Cerebras provider tests ---
+
+  it("should construct with cerebras config", () => {
+    const client = createLLMClient({
+      provider: "cerebras",
+      model: "zai-glm-4.7",
+      baseUrl: "https://api.cerebras.ai/v1",
+      apiKey: "csk-test",
+      fallbackMode: "strict",
+    });
+    expect(client).toBeDefined();
+    expect(client.chat).toBeTypeOf("function");
+    expect(client.health).toBeTypeOf("function");
+    expect(client.embed).toBeTypeOf("function");
+  });
+
+  it("chat should return text and usage via cerebras provider", async () => {
+    mockGenerateText.mockResolvedValue({
+      text: "Cerebras says hi",
+      usage: { inputTokens: 18, outputTokens: 9 },
+    } as any);
+
+    const client = createLLMClient({
+      provider: "cerebras",
+      model: "zai-glm-4.7",
+      baseUrl: "https://api.cerebras.ai/v1",
+      apiKey: "csk-test",
+      fallbackMode: "strict",
+    });
+
+    const result = await client.chat([{ role: "user", content: "Hi" }]);
+    expect(result.text).toBe("Cerebras says hi");
+    expect(result.usage.inputTokens).toBe(18);
+    expect(result.usage.outputTokens).toBe(9);
+    expect(result.usage.totalTokens).toBe(27);
+  });
+
+  it("health should return ok for cerebras", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    globalThis.fetch = mockFetch;
+    const client = createLLMClient({
+      provider: "cerebras",
+      model: "zai-glm-4.7",
+      baseUrl: "https://api.cerebras.ai/v1",
+      apiKey: "csk-test",
+      fallbackMode: "strict",
+    });
+    const result = await client.health();
+    expect(result.ok).toBe(true);
+    expect(result.provider).toBe("cerebras");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.cerebras.ai/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer csk-test" }),
+      }),
+    );
+  });
+
+  it("embed should use local fallback for cerebras provider (no native embeddings)", async () => {
+    const client = createLLMClient({
+      provider: "cerebras",
+      model: "zai-glm-4.7",
+      baseUrl: "https://api.cerebras.ai/v1",
+      apiKey: "csk-test",
+      fallbackMode: "strict",
+    });
+
+    const result = await client.embed("test text");
+    expect(result.embedding).toBeInstanceOf(Array);
+    expect(result.embedding.length).toBe(384);
     expect(mockEmbed).not.toHaveBeenCalled();
   });
 

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -82,7 +82,7 @@ function getEnvOverrides(): string[] {
 }
 
 const updateConfigSchema = z.object({
-  provider: z.enum(["ollama", "openai", "anthropic", "google"]).optional(),
+  provider: z.enum(["ollama", "openai", "anthropic", "google", "cerebras"]).optional(),
   model: z.string().optional(),
   baseUrl: z
     .string()
@@ -307,9 +307,11 @@ export function registerConfigRoutes(app: FastifyInstance, serverCtx: ServerCont
     return sanitizeConfig(serverCtx.ctx.config as never);
   });
 
-  // Test LLM config without saving — used by the setup wizard
+  // Test LLM config without saving — used by the setup wizard.
+  // This performs a tiny generation instead of a shallow health check so
+  // provider-specific quota, billing, auth, and model access issues surface.
   const testConfigSchema = z.object({
-    provider: z.enum(["ollama", "openai", "anthropic", "google"]),
+    provider: z.enum(["ollama", "openai", "anthropic", "google", "cerebras"]),
     model: z.string().min(1),
     baseUrl: z.string().url(),
     apiKey: z.string().optional(),
@@ -326,8 +328,19 @@ export function registerConfigRoutes(app: FastifyInstance, serverCtx: ServerCont
       embedModel: body.embedModel ?? "nomic-embed-text",
       fallbackMode: "local-first",
     });
-    const result = await testLlm.health();
-    return { ok: result.ok, provider: result.provider };
+    try {
+      await testLlm.chat(
+        [{ role: "user", content: "Reply with exactly OK." }],
+        { maxTokens: 8 },
+      );
+      return { ok: true, provider: body.provider };
+    } catch (err) {
+      return {
+        ok: false,
+        provider: body.provider,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
   });
 
   // Directory browser endpoint for the UI — restricted to home directory

--- a/packages/server/test/routes.test.ts
+++ b/packages/server/test/routes.test.ts
@@ -88,6 +88,7 @@ const mockWriteConfig = vi.fn();
 const mockLoadConfigFile = vi.fn().mockReturnValue({});
 const mockCreateLLMClient = vi.fn().mockReturnValue({
   health: vi.fn().mockResolvedValue({ ok: true, provider: "openai" }),
+  chat: vi.fn().mockResolvedValue({ text: "OK" }),
 });
 const mockGetObservabilityOverview = vi.fn();
 const mockListProcessAggregates = vi.fn();
@@ -1942,7 +1943,7 @@ describe("Config routes", () => {
 
   it("POST /api/config/test returns ok for valid config", async () => {
     mockCreateLLMClient.mockReturnValue({
-      health: vi.fn().mockResolvedValue({ ok: true, provider: "openai" }),
+      chat: vi.fn().mockResolvedValue({ text: "OK" }),
     });
 
     const res = await app.inject({
@@ -1962,9 +1963,29 @@ describe("Config routes", () => {
     expect(body.provider).toBe("openai");
   });
 
-  it("POST /api/config/test returns not ok for failed health check", async () => {
+  it("POST /api/config/test accepts cerebras", async () => {
     mockCreateLLMClient.mockReturnValue({
-      health: vi.fn().mockResolvedValue({ ok: false, provider: "openai" }),
+      chat: vi.fn().mockResolvedValue({ text: "OK" }),
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/config/test",
+      payload: {
+        provider: "cerebras",
+        model: "gpt-oss-120b",
+        baseUrl: "https://api.cerebras.ai/v1",
+        apiKey: "csk-test",
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true, provider: "cerebras" });
+  });
+
+  it("POST /api/config/test returns not ok for failed inference check", async () => {
+    mockCreateLLMClient.mockReturnValue({
+      chat: vi.fn().mockRejectedValue(new Error("Invalid API key for openai. Please check your API key in Settings.")),
     });
 
     const res = await app.inject({
@@ -1979,7 +2000,11 @@ describe("Config routes", () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json().ok).toBe(false);
+    expect(res.json()).toEqual({
+      ok: false,
+      provider: "openai",
+      error: "Invalid API key for openai. Please check your API key in Settings.",
+    });
   });
 
   it("POST /api/config/test rejects missing required fields", async () => {

--- a/packages/ui/src/api.ts
+++ b/packages/ui/src/api.ts
@@ -378,8 +378,8 @@ export function testConfig(config: {
   baseUrl: string;
   apiKey?: string;
   embedModel?: string;
-}): Promise<{ ok: boolean; provider: string }> {
-  return request<{ ok: boolean; provider: string }>("/config/test", {
+}): Promise<{ ok: boolean; provider: string; error?: string }> {
+  return request<{ ok: boolean; provider: string; error?: string }>("/config/test", {
     method: "POST",
     body: JSON.stringify(config),
   });

--- a/packages/ui/src/components/LLMSetupWizard.tsx
+++ b/packages/ui/src/components/LLMSetupWizard.tsx
@@ -9,7 +9,7 @@ const isCloudDeployment =
   window.location.hostname !== "localhost" &&
   window.location.hostname !== "127.0.0.1";
 
-type ProviderKey = "ollama-local" | "ollama-cloud" | "openai" | "anthropic" | "google";
+type ProviderKey = "ollama-local" | "ollama-cloud" | "openai" | "anthropic" | "google" | "cerebras";
 
 const PROVIDERS: Record<ProviderKey, {
   label: string;
@@ -73,6 +73,16 @@ const PROVIDERS: Record<ProviderKey, {
     keyUrl: "https://aistudio.google.com/apikey",
     badge: "Free tier",
   },
+  cerebras: {
+    label: "Cerebras",
+    description: "GPT OSS 120B — reliable Cerebras default",
+    provider: "cerebras",
+    baseUrl: "https://api.cerebras.ai/v1",
+    model: "gpt-oss-120b",
+    embedModel: "text-embedding-3-small",
+    needsKey: true,
+    keyUrl: "https://cloud.cerebras.ai/",
+  },
 };
 
 type Step = "mode" | "provider" | "apikey" | "local-guide";
@@ -124,7 +134,7 @@ export default function LLMSetupWizard({ onComplete, onSkip }: Props) {
         apiKey: apiKey || undefined,
         embedModel: preset.embedModel,
       });
-      setTestResult({ ok: result.ok });
+      setTestResult({ ok: result.ok, error: result.error });
     } catch (err) {
       setTestResult({ ok: false, error: err instanceof Error ? err.message : "Connection failed" });
     } finally {
@@ -187,7 +197,7 @@ export default function LLMSetupWizard({ onComplete, onSkip }: Props) {
 
   // Provider picker (cloud providers)
   if (step === "provider") {
-    const cloudProviders: ProviderKey[] = ["ollama-cloud", "openai", "anthropic", "google"];
+    const cloudProviders: ProviderKey[] = ["ollama-cloud", "openai", "anthropic", "google", "cerebras"];
     return (
       <div className="space-y-3">
         <p className="text-center text-xs text-muted-foreground">Pick your AI provider</p>
@@ -240,7 +250,7 @@ export default function LLMSetupWizard({ onComplete, onSkip }: Props) {
         {testResult && (
           <div className={`flex items-center gap-2 rounded-md p-2 text-xs ${testResult.ok ? "bg-green-500/10 text-green-600" : "bg-destructive/10 text-destructive"}`}>
             {testResult.ok ? <CheckCircleIcon className="size-4" /> : <XCircleIcon className="size-4" />}
-            {testResult.ok ? "Connected to Ollama!" : "Can't reach Ollama. Is it running?"}
+            {testResult.ok ? "Connected to Ollama!" : (testResult.error ?? "Can't reach Ollama. Is it running?")}
           </div>
         )}
         {testResult?.ok && (

--- a/packages/ui/src/pages/Landing.tsx
+++ b/packages/ui/src/pages/Landing.tsx
@@ -143,7 +143,7 @@ export default function Landing() {
           <ShieldCheckIcon className="mx-auto mb-3 h-7 w-7 text-muted-foreground" />
           <h2 className="mb-2 text-xl font-semibold tracking-tight sm:text-2xl">Your data stays yours.</h2>
           <p className="mx-auto max-w-md text-base text-muted-foreground">
-            Single SQLite file. No cloud dependency. No telemetry. Run it on your laptop, a Raspberry Pi, or Railway. Bring your own LLM — Ollama, OpenAI, Anthropic, or Google.
+            Single SQLite file. No cloud dependency. No telemetry. Run it on your laptop, a Raspberry Pi, or Railway. Bring your own LLM — Ollama, OpenAI, Anthropic, Google, or Cerebras.
           </p>
         </div>
       </section>

--- a/packages/ui/src/pages/Settings.tsx
+++ b/packages/ui/src/pages/Settings.tsx
@@ -23,6 +23,7 @@ const PROVIDER_PRESETS: Record<string, { baseUrl: string; model: string; embedMo
   openai: { baseUrl: "https://api.openai.com/v1", model: "gpt-4o", embedModel: "text-embedding-3-small" },
   anthropic: { baseUrl: "https://api.anthropic.com", model: "claude-sonnet-4-20250514", embedModel: "" },
   google: { baseUrl: "https://generativelanguage.googleapis.com/v1beta", model: "gemini-2.0-flash", embedModel: "text-embedding-004" },
+  cerebras: { baseUrl: "https://api.cerebras.ai/v1", model: "gpt-oss-120b", embedModel: "text-embedding-3-small" },
 };
 
 const DEFAULT_LLM_TRAFFIC = {
@@ -316,6 +317,7 @@ export default function Settings() {
                       <option value="openai">OpenAI</option>
                       <option value="anthropic">Anthropic</option>
                       <option value="google">Google AI</option>
+                      <option value="cerebras">Cerebras</option>
                     </select>
                   </div>
                   <EditableRow label="Model" value={model} onChange={setModel} placeholder={PROVIDER_PRESETS[provider]?.model ?? "model name"} envLabel={envOverrides.includes("model")} />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: ^3.0.45
         version: 3.0.45(zod@3.25.76)
+      '@ai-sdk/cerebras':
+        specifier: ^2.0.39
+        version: 2.0.39(zod@3.25.76)
       '@ai-sdk/google':
         specifier: ^3.0.30
         version: 3.0.30(zod@3.25.76)
@@ -542,6 +545,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/cerebras@2.0.39':
+    resolution: {integrity: sha512-aVDYGbRh+59auoZeUNoMxNlp4ZBEqiKt6tjRNbBpQyJbeOv92DekCcjQLnULjcQoPTZwrAaeRQDv2fe/aY4RSw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.46':
     resolution: {integrity: sha512-zH1UbNRjG5woOXXFOrVCZraqZuFTtmPvLardMGcgLkzpxKV0U3tAGoyWKSZ862H+eBJfI/Hf2yj/zzGJcCkycg==}
     engines: {node: '>=18'}
@@ -566,6 +575,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai-compatible@2.0.35':
+    resolution: {integrity: sha512-g3wA57IAQFb+3j4YuFndgkUdXyRETZVvbfAWM+UX7bZSxA3xjes0v3XKgIdKdekPtDGsh4ZX2byHD0gJIMPfiA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai@3.0.29':
     resolution: {integrity: sha512-ugVTIVpuSLKTjzSPe1F1DWiblJT/lwrrHx0OZEKjpMk/EYP6j6VD/F7SJqM1dsqOJryeBCJWFbUzLNqc99PrMA==}
     engines: {node: '>=18'}
@@ -574,6 +589,12 @@ packages:
 
   '@ai-sdk/provider-utils@4.0.15':
     resolution: {integrity: sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.19':
+    resolution: {integrity: sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -6803,6 +6824,13 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/cerebras@2.0.39(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/openai-compatible': 2.0.35(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
+      zod: 3.25.76
+
   '@ai-sdk/gateway@3.0.46(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -6844,6 +6872,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/openai-compatible@2.0.35(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
+      zod: 3.25.76
+
   '@ai-sdk/openai@3.0.29(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -6863,6 +6897,13 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.19(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
 
   '@ai-sdk/provider@3.0.8':
     dependencies:


### PR DESCRIPTION
## Summary
- add first-class Cerebras provider support across core, server validation, CLI setup, and UI configuration
- default Cerebras presets to `gpt-oss-120b` in setup flows based on the tested working account path
- make config testing perform a tiny inference so quota, billing, auth, and model-access issues surface clearly

## Verification
- pnpm typecheck
- pnpm --filter @personal-ai/core test
- pnpm --filter @personal-ai/server test
- pnpm --filter @personal-ai/cli test
- pre-push hook: pnpm run ci
