### PR TITLE
fix: surface run_code chart artifacts

### DIFF
--- a/packages/plugin-assistant/src/index.ts
+++ b/packages/plugin-assistant/src/index.ts
@@ -59,7 +59,7 @@ Every claim from search results MUST have its citation inline, right next to the
 - **task_list**: Show tasks
 - **task_add**: Create a new task
 - **task_done**: Mark a task complete
-- **run_code**: Execute Python/JS code in a sandboxed environment — for data analysis, charting, calculations. Output files are saved as artifacts.
+- **run_code**: Execute Python/JS code in a sandboxed environment — for data analysis, charting, calculations. The sandbox starts inside OUTPUT_DIR so relative file saves become artifacts automatically. When generating charts for inline display, save PNG/JPEG/WebP images instead of HTML-only files unless the user asks for interactive HTML.
 - **generate_report**: Create a downloadable Markdown report — use when the user asks to generate a report, analysis document, or summary they can download and share
 - **browse_navigate**: Navigate the browser to a URL — use for JavaScript-rendered pages, SPAs, or login-gated content that read_page can't handle
 - **browse_snapshot**: Get interactive elements on the current page (buttons, links, inputs) — use to understand page structure before taking actions

--- a/packages/plugin-assistant/src/tools.ts
+++ b/packages/plugin-assistant/src/tools.ts
@@ -543,7 +543,7 @@ export function createAgentTools(ctx: AgentContext) {
     // Conditionally add sandbox tool
     ...(resolveSandboxUrl(ctx.config.sandboxUrl) ? {
       run_code: tool({
-        description: "Execute Python or JavaScript code in an isolated sandbox. Use for data analysis, chart generation, calculations, or file processing. Files written to the OUTPUT_DIR directory will be saved as artifacts. Available packages: matplotlib, pandas, numpy, plotly, yfinance.",
+        description: "Execute Python or JavaScript code in an isolated sandbox. Use for data analysis, chart generation, calculations, or file processing. The sandbox starts inside OUTPUT_DIR, so relative file writes like `plt.savefig(\"chart.png\")` are saved as artifacts automatically. For charts the UI can preview inline, write PNG, JPEG, or WebP image files instead of HTML-only outputs unless the user explicitly asks for an interactive HTML file. Available packages: matplotlib, pandas, numpy, plotly, yfinance.",
         inputSchema: z.object({
           language: z.enum(["python", "node"]).describe("Programming language to execute"),
           code: z.string().describe("The code to execute"),

--- a/packages/ui/src/components/chat/tool-uis.tsx
+++ b/packages/ui/src/components/chat/tool-uis.tsx
@@ -211,6 +211,8 @@ export const RunCodeToolUI = makeAssistantToolUI({
       artifacts?: Array<{ id: string; name: string; mimeType: string }>;
       error?: string;
     } | undefined;
+    const artifacts = output?.artifacts ?? [];
+    const hasError = state === "output-error" || Boolean(output?.error);
 
     if (state === "input-available") {
       return (
@@ -223,28 +225,30 @@ export const RunCodeToolUI = makeAssistantToolUI({
       );
     }
 
-    if (state === "output-error" || output?.error) {
-      return (
-        <div className="my-2 rounded-lg border border-red-500/30 bg-red-500/5 p-3 space-y-2">
-          <div className="text-sm font-medium text-red-400">Code execution failed</div>
-          {input.code && (
-            <pre className="overflow-x-auto rounded bg-background/60 p-2 text-xs font-mono whitespace-pre-wrap">{input.code}</pre>
-          )}
-          {output?.error && (
-            <pre className="overflow-x-auto rounded bg-red-500/10 p-2 text-xs font-mono text-red-400 whitespace-pre-wrap">{output.error}</pre>
+    return (
+      <div
+        className={`my-2 rounded-lg p-3 space-y-2 ${
+          hasError
+            ? "border border-red-500/30 bg-red-500/5"
+            : "border border-border/30 bg-card/50"
+        }`}
+      >
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div
+            className={`text-xs font-medium uppercase tracking-wide ${
+              hasError ? "text-red-400" : "text-muted-foreground"
+            }`}
+          >
+            {hasError ? "Code execution completed with errors" : input.language ?? "Code"}
+          </div>
+          {typeof output?.exitCode === "number" && (
+            <div className={`text-xs ${hasError ? "text-red-300/80" : "text-muted-foreground"}`}>
+              Exit code: {output.exitCode}
+            </div>
           )}
         </div>
-      );
-    }
-
-    return (
-      <div className="my-2 rounded-lg border border-border/30 bg-card/50 p-3 space-y-2">
-        <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">{input.language ?? "Code"}</div>
         {input.code && (
           <pre className="overflow-x-auto rounded bg-background/60 p-2 text-xs font-mono whitespace-pre-wrap">{input.code}</pre>
-        )}
-        {typeof output?.exitCode === "number" && (
-          <div className="text-xs text-muted-foreground">Exit code: {output.exitCode}</div>
         )}
         {output?.stdout && (
           <>
@@ -258,8 +262,19 @@ export const RunCodeToolUI = makeAssistantToolUI({
             <pre className="overflow-x-auto rounded bg-background/60 p-2 text-xs font-mono whitespace-pre-wrap">{output.stderr}</pre>
           </>
         )}
-        {output?.artifacts && output.artifacts.length > 0 && (
-          <ArtifactGallery artifacts={output.artifacts} title="Files" />
+        {output?.error && (
+          <>
+            <div className="text-xs font-medium uppercase tracking-wide text-red-400">Error</div>
+            <pre className="overflow-x-auto rounded bg-red-500/10 p-2 text-xs font-mono text-red-400 whitespace-pre-wrap">{output.error}</pre>
+          </>
+        )}
+        {hasError && artifacts.length > 0 && (
+          <p className="text-xs text-red-200/80">
+            Generated files were still saved and may be usable.
+          </p>
+        )}
+        {artifacts.length > 0 && (
+          <ArtifactGallery artifacts={artifacts} title={hasError ? "Generated files" : "Files"} />
         )}
       </div>
     );

--- a/packages/ui/src/components/results/ArtifactGallery.tsx
+++ b/packages/ui/src/components/results/ArtifactGallery.tsx
@@ -71,7 +71,8 @@ export function ArtifactGallery({ artifacts, title = "Artifacts" }: ArtifactGall
                 <img
                   src={`/api/artifacts/${artifact.id}`}
                   alt={artifact.name}
-                  className="mt-2 max-h-56 rounded border border-border/20 object-contain"
+                  className="mt-2 max-h-56 w-full rounded border border-border/20 bg-black/10 object-contain"
+                  loading="lazy"
                 />
               )}
             </div>

--- a/sandbox/entrypoint.py
+++ b/sandbox/entrypoint.py
@@ -135,11 +135,17 @@ def execute_code(language: str, code: str, timeout: int) -> dict:
     ext = ".py" if language == "python" else ".js"
     script_path = os.path.join(work_dir, f"script{ext}")
 
-    # Inject output directory path so scripts can save files there
+    # Inject OUTPUT_DIR and switch into it so ordinary relative writes become artifacts.
     if language == "python":
-        header = f'import os; os.environ["OUTPUT_DIR"] = {repr(output_dir)}\n'
+        header = (
+            f'import os; os.environ["OUTPUT_DIR"] = {repr(output_dir)}\n'
+            'os.chdir(os.environ["OUTPUT_DIR"])\n'
+        )
     else:
-        header = f'process.env.OUTPUT_DIR = {json.dumps(output_dir)};\n'
+        header = (
+            f'process.env.OUTPUT_DIR = {json.dumps(output_dir)};\n'
+            'process.chdir(process.env.OUTPUT_DIR);\n'
+        )
 
     with open(script_path, "w") as f:
         f.write(header + code)
@@ -156,7 +162,7 @@ def execute_code(language: str, code: str, timeout: int) -> dict:
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            cwd=work_dir,
+            cwd=output_dir,
             env={**SAFE_ENV, "OUTPUT_DIR": output_dir},
             # Run in new process group so we can kill all children
             preexec_fn=os.setsid,


### PR DESCRIPTION
## Summary
- run sandbox code inside OUTPUT_DIR so relative file saves become returned artifacts
- keep run_code artifact previews visible in chat even when execution reports partial errors
- clarify run_code guidance so chart generation prefers previewable image outputs

## Verification
- pnpm --filter @personal-ai/plugin-assistant build
- pnpm --filter @personal-ai/ui build
- POST http://127.0.0.1:8888/run returns relative file writes in files
- validated live chart flow in the web UI after rebuilding the sandbox image