### PR TITLE
Persist insight memories and balance recall types in semantic search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **End-to-end telemetry coverage** — Chat, Telegram, background learning, briefings, research, swarm execution, memory extraction, and knowledge embeddings now emit standardized process-level telemetry. Assistant thread messages also persist compact usage summaries for diagnostics without exposing raw metrics in normal user-facing flows.
 - **Background dispatch smoothing** — Research, swarm, and daily briefing generation now enqueue into a single background dispatcher instead of starting immediately. Restarts requeue unfinished research/swarm/briefing work as `pending`, scheduled jobs dedupe by schedule, manual work is prioritized ahead of scheduled and maintenance work, and swarm agent execution is staggered to avoid bursting the LLM server.
 - **Cerebras default model** — Setup wizard, Settings presets, and `pai init` now default Cerebras to `gpt-oss-120b` instead of `zai-glm-4.7` so fresh configurations land on a model that works with the currently tested account access path.
+- **Memory insight persistence** — `remember()` now persists extracted insight beliefs alongside the primary fact belief, so insight-type memories populate during normal usage instead of only via manual creation paths.
+- **Recall type balancing** — Semantic recall now caps `insight`/`meta` entries to about one-third of the requested limit when concrete fact/preference/procedural/architectural matches exist, preventing high-level beliefs from crowding out actionable memories.
 
 ### Security
 

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -154,6 +154,35 @@ export interface Belief {
 
 const BASE_HALF_LIFE_DAYS = 30;
 
+function prioritizeRecallTypes<T extends { beliefId: string; type: string }>(results: T[], limit: number): T[] {
+  if (results.length <= limit) return results;
+
+  const maxInsightMeta = Math.max(1, Math.floor(limit / 3));
+  const selected: T[] = [];
+  const selectedIds = new Set<string>();
+  let insightMetaCount = 0;
+
+  for (const row of results) {
+    if (selected.length >= limit) break;
+    const isInsightOrMeta = row.type === "insight" || row.type === "meta";
+    if (isInsightOrMeta && insightMetaCount >= maxInsightMeta) continue;
+    selected.push(row);
+    selectedIds.add(row.beliefId);
+    if (isInsightOrMeta) insightMetaCount += 1;
+  }
+
+  if (selected.length < limit) {
+    for (const row of results) {
+      if (selected.length >= limit) break;
+      if (selectedIds.has(row.beliefId)) continue;
+      selected.push(row);
+      selectedIds.add(row.beliefId);
+    }
+  }
+
+  return selected;
+}
+
 function decayConfidence(confidence: number, updatedAt: string, stability = 1.0): number {
   // normalizeTimestamp handles both SQLite UTC ("2026-01-01 00:00:00") and ISO ("2026-01-01T00:00:00Z")
   const normalized = updatedAt.trim().replace(/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})$/, "$1T$2Z");
@@ -531,10 +560,12 @@ export function semanticSearch(
     .filter((r): r is SimilarBelief & { cosine: number } => r !== null);
 
   // Filter by cosine similarity threshold, then sort by ranking score
-  const results = scored
-    .filter((r) => r.cosine >= COSINE_THRESHOLD)
-    .sort((a, b) => b.similarity - a.similarity)
-    .slice(0, limit);
+  const results = prioritizeRecallTypes(
+    scored
+      .filter((r) => r.cosine >= COSINE_THRESHOLD)
+      .sort((a, b) => b.similarity - a.similarity),
+    limit,
+  );
 
   // Graph traversal: batch-fetch linked neighbors for top-3 results (avoids N+1)
   const resultIds = new Set(results.map((r) => r.beliefId));
@@ -581,7 +612,7 @@ export function semanticSearch(
       }
     }
   }
-  const combined = [...results, ...neighbors].slice(0, limit);
+  const combined = prioritizeRecallTypes([...results, ...neighbors], limit);
 
   // Batch-record access for returned beliefs (single UPDATE instead of N)
   if (combined.length > 0) {

--- a/packages/core/src/memory/remember.ts
+++ b/packages/core/src/memory/remember.ts
@@ -339,8 +339,20 @@ export async function remember(
   beliefIds.push(factResult.beliefId);
   if (factResult.isReinforcement) isReinforcement = true;
 
-  // Skip insight storage — insights are almost always generic noise
-  // (e.g., "Simple APIs are preferred over complex abstractions")
+  if (extracted.insight && extracted.insight.trim()) {
+    const insightResult = await processNewBelief(
+      storage,
+      llm,
+      extracted.insight.trim(),
+      "insight",
+      episode.id,
+      logger,
+      Math.max(1, Math.min(10, extracted.importance - 1)),
+      extracted.subject,
+    );
+    beliefIds.push(insightResult.beliefId);
+    if (insightResult.isReinforcement) isReinforcement = true;
+  }
 
   return { episodeId: episode.id, beliefIds, isReinforcement };
 }

--- a/packages/core/test/memory/lifecycle.test.ts
+++ b/packages/core/test/memory/lifecycle.test.ts
@@ -397,7 +397,7 @@ describe("Belief Lifecycle", () => {
     const llm = createMockLLM({
       chatResponses: [
         // 1st remember: extract fact
-        { text: '{"fact":"Project uses Zod for validation","insight":"Schema validation prevents runtime errors"}' },
+        { text: '{"fact":"Project uses Zod for validation","insight":null}' },
         // 2nd remember: same fact → reinforce
         { text: '{"fact":"Project uses Zod for validation","insight":null}' },
         // 3rd remember: contradicting fact + contradiction check
@@ -406,7 +406,7 @@ describe("Belief Lifecycle", () => {
       ],
       embedResponses: [
         { embedding: [0.5, 0.5, 0.0] }, // episode 1
-        { embedding: [1.0, 0.0, 0.0] }, // fact 1 (Zod) — insight is no longer stored
+        { embedding: [1.0, 0.0, 0.0] }, // fact 1 (Zod)
         { embedding: [0.5, 0.5, 0.0] }, // episode 2
         { embedding: [1.0, 0.0, 0.0] }, // fact 2 (same as Zod → reinforce)
         { embedding: [0.5, 0.5, 0.0] }, // episode 3
@@ -416,7 +416,7 @@ describe("Belief Lifecycle", () => {
 
     // Step 1: Agent learns project uses Zod
     const r1 = await remember(storage, llm, "This project uses Zod for schema validation");
-    expect(r1.beliefIds).toHaveLength(1); // fact only (insights no longer stored)
+    expect(r1.beliefIds).toHaveLength(1); // fact only (no insight extracted in this case)
     expect(r1.isReinforcement).toBe(false);
 
     // Step 2: Agent confirms Zod usage → should reinforce
@@ -441,7 +441,7 @@ describe("Belief Lifecycle", () => {
     );
     expect(zodStatus[0]!.status).toBe("invalidated");
 
-    // Final state: Joi belief (active), Zod (invalidated) — insights no longer stored
+    // Final state: Joi belief (active), Zod (invalidated)
     const active = listBeliefs(storage);
     expect(active.length).toBe(1); // Joi only
 

--- a/packages/core/test/memory/memory.test.ts
+++ b/packages/core/test/memory/memory.test.ts
@@ -676,6 +676,37 @@ describe("Embeddings", () => {
     expect(results[0]!.cosine).toBeGreaterThan(0.9);
   });
 
+
+  it("should cap insight/meta recall results when primary belief types exist", () => {
+    const factualA = createBelief(storage, { statement: "Project uses TypeScript", confidence: 0.8, type: "factual" });
+    const factualB = createBelief(storage, { statement: "Prefers Vitest", confidence: 0.8, type: "preference" });
+    const insight = createBelief(storage, { statement: "Smaller PRs merge faster", confidence: 0.8, type: "insight" });
+    const meta = createBelief(storage, { statement: "Testing beliefs were synthesized", confidence: 0.8, type: "meta" });
+
+    storeEmbedding(storage, factualA.id, [1.0, 0.0, 0.0]);
+    storeEmbedding(storage, factualB.id, [0.99, 0.01, 0.0]);
+    storeEmbedding(storage, insight.id, [0.98, 0.02, 0.0]);
+    storeEmbedding(storage, meta.id, [0.97, 0.03, 0.0]);
+
+    const results = semanticSearch(storage, [1.0, 0.0, 0.0], 3);
+    expect(results).toHaveLength(3);
+
+    const insightMetaCount = results.filter((r) => r.type === "insight" || r.type === "meta").length;
+    expect(insightMetaCount).toBeLessThanOrEqual(1);
+  });
+
+  it("should still return insight/meta results when no primary beliefs match", () => {
+    const insight = createBelief(storage, { statement: "Morning routines improve focus", confidence: 0.8, type: "insight" });
+    const meta = createBelief(storage, { statement: "Memory synthesis found routine pattern", confidence: 0.8, type: "meta" });
+
+    storeEmbedding(storage, insight.id, [1.0, 0.0, 0.0]);
+    storeEmbedding(storage, meta.id, [0.99, 0.01, 0.0]);
+
+    const results = semanticSearch(storage, [1.0, 0.0, 0.0], 3);
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.type === "insight" || r.type === "meta")).toBe(true);
+  });
+
   it("should synthesize meta-beliefs from clusters", async () => {
     // Create a cluster of similar beliefs with embeddings
     const b1 = createBelief(storage, { statement: "TypeScript strict mode is helpful", confidence: 0.6, type: "factual" });

--- a/packages/core/test/memory/remember.test.ts
+++ b/packages/core/test/memory/remember.test.ts
@@ -92,21 +92,28 @@ describe("remember", () => {
     expect(embRows).toHaveLength(1);
   });
 
-  it("should only store fact belief and skip insight (insights are generic noise)", async () => {
+  it("should store both fact and insight beliefs when insight is extracted", async () => {
     const mockLLM: LLMClient = {
       chat: vi.fn().mockResolvedValue({
-        text: '{"fact":"User likes coffee in the morning","insight":"Morning routines provide consistency"}',
+        text: '{"fact":"User likes coffee in the morning","factType":"preference","importance":7,"insight":"Morning routines provide consistency"}',
         usage: { inputTokens: 10, outputTokens: 15 },
       }),
       embed: vi.fn()
         .mockResolvedValueOnce({ embedding: [0.5, 0.5, 0.0] })   // episode embedding
-        .mockResolvedValueOnce({ embedding: [1.0, 0.0, 0.0] }),   // fact embedding only
+        .mockResolvedValueOnce({ embedding: [1.0, 0.0, 0.0] })   // fact embedding
+        .mockResolvedValueOnce({ embedding: [0.0, 1.0, 0.0] }),  // insight embedding
       health: vi.fn().mockResolvedValue({ ok: true, provider: "mock" }),
     };
 
     const result = await remember(storage, mockLLM, "I like coffee in the morning");
-    expect(result.beliefIds).toHaveLength(1); // Only fact, no insight
+    expect(result.beliefIds).toHaveLength(2); // Fact + insight
     expect(result.isReinforcement).toBe(false);
+
+    const beliefTypes = storage.query<{ type: string }>(
+      "SELECT type FROM beliefs WHERE id IN (?, ?) ORDER BY type",
+      [result.beliefIds[0], result.beliefIds[1]],
+    ).map((row) => row.type);
+    expect(beliefTypes).toEqual(["insight", "preference"]);
   });
 
   it("should reinforce existing belief when semantically similar", async () => {


### PR DESCRIPTION
### Motivation

- Improve memory usefulness by persisting extracted insight beliefs so they participate in normal recall flows instead of being discarded. 
- Prevent high-level `insight`/`meta` beliefs from crowding out actionable memories during semantic recall by capping their proportion in results.

### Description

- Persist extracted insights in `remember()` by calling `processNewBelief(...)` for non-empty `insight` text so both fact and insight beliefs are stored. 
- Add `prioritizeRecallTypes()` to cap `insight`/`meta` entries to approximately one-third of the requested `limit` and use it to filter/slice search results. 
- Apply `prioritizeRecallTypes()` to both the primary `semanticSearch` results and the combined result+neighbor list to enforce balanced recall. 
- Update related tests and `CHANGELOG.md` entries to reflect `Memory insight persistence` and `Recall type balancing` changes.

### Testing

- Ran unit tests for the memory package including `remember.test.ts`, `memory.test.ts`, and `lifecycle.test.ts` which were updated to cover insight persistence and recall capping. 
- All updated memory-related tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abc7bec5e0832f97d86f8621f73812)