### PR TITLE
Fallback to artifact-derived report visuals when briefing visuals are empty (Inbox & Jobs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cerebras default model** — Setup wizard, Settings presets, and `pai init` now default Cerebras to `gpt-oss-120b` instead of `zai-glm-4.7` so fresh configurations land on a model that works with the currently tested account access path.
 - **Memory insight persistence** — `remember()` now persists extracted insight beliefs alongside the primary fact belief, so insight-type memories populate during normal usage instead of only via manual creation paths.
 - **Recall type balancing** — Semantic recall now caps `insight`/`meta` entries to about one-third of the requested limit when concrete fact/preference/procedural/architectural matches exist, preventing high-level beliefs from crowding out actionable memories.
+- **Research/swarm chart fallback in Inbox + Jobs** — Report detail endpoints now fall back to artifact-derived visuals when persisted briefing metadata contains an empty `visuals` array, restoring chart rendering for existing research and swarm reports in both Inbox and Jobs views.
 
 ### Security
 

--- a/packages/server/src/routes/inbox.ts
+++ b/packages/server/src/routes/inbox.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import type { ServerContext } from "../index.js";
 import { getLatestBriefing, getBriefingById, listBriefings, listAllBriefings, clearAllBriefings, getResearchBriefings, getDailyBriefingState } from "../briefing.js";
-import type { ResearchResultType } from "@personal-ai/core";
+import { deriveReportVisuals, type ReportVisual, type ResearchResultType } from "@personal-ai/core";
 
 export function registerInboxRoutes(app: FastifyInstance, { ctx, backgroundDispatcher }: ServerContext): void {
   app.get("/api/inbox", async () => {
@@ -40,6 +40,30 @@ export function registerInboxRoutes(app: FastifyInstance, { ctx, backgroundDispa
   app.get<{ Params: { id: string } }>("/api/inbox/:id", async (request, reply) => {
     const briefing = getBriefingById(ctx.storage, request.params.id);
     if (!briefing) return reply.status(404).send({ error: "Briefing not found" });
+
+    if (briefing.type === "research" && briefing.sections && typeof briefing.sections === "object") {
+      const sections = briefing.sections as unknown as Record<string, unknown>;
+      const storedVisuals: ReportVisual[] = Array.isArray(sections.visuals)
+        ? sections.visuals as ReportVisual[]
+        : [];
+      if (storedVisuals.length === 0) {
+        const artifactJobId = request.params.id.startsWith("research-")
+          ? request.params.id.slice("research-".length)
+          : request.params.id.startsWith("swarm-")
+            ? request.params.id.slice("swarm-".length)
+            : request.params.id;
+
+        const hydratedBriefing = {
+          ...briefing,
+          sections: {
+            ...sections,
+            visuals: deriveReportVisuals(ctx.storage, artifactJobId),
+          },
+        };
+        return { briefing: hydratedBriefing };
+      }
+    }
+
     return { briefing };
   });
 

--- a/packages/server/src/routes/jobs.ts
+++ b/packages/server/src/routes/jobs.ts
@@ -31,9 +31,10 @@ function getStoredPresentation(
       const extracted = extractPresentationBlocks(
         typeof sections.report === "string" ? sections.report : reportText ?? "",
       );
-      const visuals = Array.isArray(sections.visuals)
-        ? sections.visuals as Parameters<typeof buildReportPresentation>[0]["visuals"]
-        : fallbackVisuals;
+      const storedVisuals: NonNullable<Parameters<typeof buildReportPresentation>[0]["visuals"]> = Array.isArray(sections.visuals)
+        ? sections.visuals as NonNullable<Parameters<typeof buildReportPresentation>[0]["visuals"]>
+        : [];
+      const visuals = storedVisuals.length > 0 ? storedVisuals : fallbackVisuals;
       return buildReportPresentation({
         report: extracted.report,
         structuredResult: typeof sections.structuredResult === "string"

--- a/packages/server/test/routes.test.ts
+++ b/packages/server/test/routes.test.ts
@@ -20,6 +20,7 @@ import jwt from "jsonwebtoken";
 // ---------------------------------------------------------------------------
 const mockGetArtifact = vi.fn();
 const mockListArtifacts = vi.fn();
+const mockDeriveReportVisuals = vi.fn();
 
 // ---------------------------------------------------------------------------
 // Mock @personal-ai/core — isolate route handlers from real storage/LLM
@@ -62,6 +63,7 @@ vi.mock("@personal-ai/core", async (importOriginal) => {
     loadConfigFile: (...args: unknown[]) => mockLoadConfigFile(...args),
     getArtifact: (...args: unknown[]) => mockGetArtifact(...args),
     listArtifacts: (...args: unknown[]) => mockListArtifacts(...args),
+    deriveReportVisuals: (...args: unknown[]) => mockDeriveReportVisuals(...args),
     createLLMClient: (...args: unknown[]) => mockCreateLLMClient(...args),
     getObservabilityOverview: (...args: unknown[]) => mockGetObservabilityOverview(...args),
     listProcessAggregates: (...args: unknown[]) => mockListProcessAggregates(...args),
@@ -2220,6 +2222,36 @@ describe("Inbox routes", () => {
     expect(res.json().briefing.id).toBe("brief_456");
   });
 
+  it("GET /api/inbox/:id derives visuals for research briefings when visuals are empty", async () => {
+    mockGetBriefingById.mockReturnValue({
+      id: "research-job123",
+      generatedAt: "2026-02-25T10:00:00Z",
+      type: "research",
+      sections: {
+        goal: "Research markets",
+        report: "Report body",
+        visuals: [],
+      },
+      status: "ready",
+    });
+    mockDeriveReportVisuals.mockReturnValue([
+      {
+        artifactId: "art-1",
+        mimeType: "image/png",
+        kind: "chart",
+        title: "Price trend",
+        order: 1,
+      },
+    ]);
+
+    const res = await app.inject({ method: "GET", url: "/api/inbox/research-job123" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(mockDeriveReportVisuals).toHaveBeenCalledWith(serverCtx.ctx.storage, "job123");
+    expect(body.briefing.sections.visuals).toHaveLength(1);
+    expect(body.briefing.sections.visuals[0].artifactId).toBe("art-1");
+  });
+
   it("POST /api/inbox/clear clears all briefings", async () => {
     mockClearAllBriefings.mockReturnValue(3);
     const res = await app.inject({ method: "POST", url: "/api/inbox/clear", payload: {} });
@@ -2385,6 +2417,7 @@ describe("jobs routes", () => {
     mockGetBriefingById.mockReturnValue(null);
     mockListArtifacts.mockReturnValue([]);
     mockGetArtifact.mockReturnValue(null);
+    mockDeriveReportVisuals.mockReturnValue([]);
     app = Fastify();
     serverCtx = createMockServerCtx();
     registerJobRoutes(app, serverCtx);
@@ -2637,6 +2670,43 @@ describe("jobs routes", () => {
     expect(body.presentation.report).toBe("Normalized report body");
     expect(body.presentation.execution).toBe("analysis");
     expect(body.presentation.visuals[0].artifactId).toBe("art-1");
+  });
+
+  it("GET /api/jobs/:id derives visuals when briefing visuals are empty", async () => {
+    mockGetResearchJob.mockReturnValue({
+      id: "rj3",
+      goal: "Research markets",
+      status: "done",
+      report: "Legacy report body",
+      briefingId: "research-rj3",
+      resultType: "stock",
+    });
+    mockGetBriefingById.mockReturnValue({
+      id: "research-rj3",
+      status: "ready",
+      type: "research",
+      sections: {
+        goal: "Research markets",
+        report: "Normalized report body",
+        resultType: "stock",
+        visuals: [],
+      },
+    });
+    mockDeriveReportVisuals.mockReturnValue([
+      {
+        artifactId: "art-fallback-1",
+        mimeType: "image/png",
+        kind: "chart",
+        title: "NVDA Price Chart",
+        order: 1,
+      },
+    ]);
+
+    const res = await app.inject({ method: "GET", url: "/api/jobs/rj3" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.presentation.visuals).toHaveLength(1);
+    expect(body.presentation.visuals[0].artifactId).toBe("art-fallback-1");
   });
 
   // ---- GET /api/jobs/:id/agents ----


### PR DESCRIPTION
### Motivation

- Restore chart rendering for legacy research/swarm reports whose persisted briefing metadata contains an empty `visuals` array by deriving visuals from artifacts. 

### Description

- Add `deriveReportVisuals` usage in the `GET /api/inbox/:id` handler to hydrate `briefing.sections.visuals` when the stored visuals array is empty for `research` briefings. 
- Update job presentation assembly in `getStoredPresentation` to prefer non-empty persisted `visuals` but fall back to `deriveReportVisuals` when the stored array is empty. 
- Wire `deriveReportVisuals` into the test mocks and add two unit tests that assert visuals are derived for inbox and jobs endpoints when `visuals: []`. 
- Add a changelog entry describing the research/swarm chart fallback behavior in `CHANGELOG.md`.

### Testing

- Ran unit tests with `vitest` in `packages/server/test/routes.test.ts`, including new tests `GET /api/inbox/:id derives visuals for research briefings when visuals are empty` and `GET /api/jobs/:id derives visuals when briefing visuals are empty`, and all tests passed. 
- Existing inbox and jobs route tests were executed and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abe699ebb4832f9cf383e13250d235)