### PR TITLE
fix: improve Telegram report table formatting and default to dark mode

### DIFF
--- a/packages/core/src/spec-to-html.ts
+++ b/packages/core/src/spec-to-html.ts
@@ -96,9 +96,9 @@ function renderElement(id: string, spec: JsonRenderSpec, opts: SpecToHtmlOptions
   switch (el.type) {
     case "Section": {
       const title = esc(props.title);
-      const subtitle = props.subtitle ? `<p style="color:#6b7280;font-size:0.9em;margin:4px 0 12px">${esc(props.subtitle)}</p>` : "";
+      const subtitle = props.subtitle ? `<p style="color:var(--muted, #6b7280);font-size:0.9em;margin:4px 0 12px">${esc(props.subtitle)}</p>` : "";
       return `<div style="margin-bottom:24px">
-        <h3 style="font-size:1.1em;font-weight:600;border-bottom:1px solid #e5e7eb;padding-bottom:6px;margin-bottom:8px">${title}</h3>
+        <h3 style="font-size:1.1em;font-weight:600;border-bottom:1px solid var(--border, #e5e7eb);padding-bottom:6px;margin-bottom:8px">${title}</h3>
         ${subtitle}
         ${childrenHtml}
       </div>`;
@@ -119,13 +119,13 @@ function renderElement(id: string, spec: JsonRenderSpec, opts: SpecToHtmlOptions
     case "MetricCard": {
       const trend = props.trend === "up" ? '<span style="color:#16a34a;margin-left:6px">&#x2191;</span>'
         : props.trend === "down" ? '<span style="color:#dc2626;margin-left:6px">&#x2193;</span>'
-          : props.trend === "neutral" ? '<span style="color:#6b7280;margin-left:6px">&#x2212;</span>'
+          : props.trend === "neutral" ? '<span style="color:var(--muted, #6b7280);margin-left:6px">&#x2212;</span>'
             : "";
-      const unit = props.unit ? ` <span style="font-size:0.75em;font-weight:400;color:#6b7280">${esc(props.unit)}</span>` : "";
-      const desc = props.description ? `<div style="font-size:0.75em;color:#6b7280;margin-top:4px">${esc(props.description)}</div>` : "";
-      return `<div style="border:1px solid #e5e7eb;border-radius:8px;padding:12px;background:#fafafa">
-        <div style="font-size:0.75em;color:#6b7280;margin-bottom:4px">${esc(props.label)}</div>
-        <div style="font-size:1.25em;font-weight:700;color:#1a1a1a">${esc(props.value)}${unit}${trend}</div>
+      const unit = props.unit ? ` <span style="font-size:0.75em;font-weight:400;color:var(--muted, #6b7280)">${esc(props.unit)}</span>` : "";
+      const desc = props.description ? `<div style="font-size:0.75em;color:var(--muted, #6b7280);margin-top:4px">${esc(props.description)}</div>` : "";
+      return `<div style="border:1px solid var(--border, #e5e7eb);border-radius:8px;padding:12px;background:var(--card-bg, #fafafa)">
+        <div style="font-size:0.75em;color:var(--muted, #6b7280);margin-bottom:4px">${esc(props.label)}</div>
+        <div style="font-size:1.25em;font-weight:700;color:var(--fg, #1a1a1a)">${esc(props.value)}${unit}${trend}</div>
         ${desc}
       </div>`;
     }
@@ -142,16 +142,16 @@ function renderElement(id: string, spec: JsonRenderSpec, opts: SpecToHtmlOptions
 
       const thCells = columns.map((c) => {
         const align = c.align === "right" ? "text-align:right" : c.align === "center" ? "text-align:center" : "text-align:left";
-        return `<th style="padding:8px 10px;font-weight:600;font-size:0.85em;border-bottom:2px solid #2563eb;background:#eff6ff;${align}">${esc(c.label)}</th>`;
+        return `<th style="padding:8px 10px;font-weight:600;font-size:0.85em;border-bottom:2px solid var(--accent, #2563eb);background:var(--accent-bg, #eff6ff);${align}">${esc(c.label)}</th>`;
       }).join("");
 
       const bodyRows = rows.map((row, ri) => {
         const cells = columns.map((c) => {
           const align = c.align === "right" ? "text-align:right" : c.align === "center" ? "text-align:center" : "text-align:left";
           const val = row[c.key] != null ? String(row[c.key]) : "\u2014";
-          return `<td style="padding:6px 10px;border-bottom:1px solid #e5e7eb;${align}">${esc(val)}</td>`;
+          return `<td style="padding:6px 10px;border-bottom:1px solid var(--border, #e5e7eb);${align}">${esc(val)}</td>`;
         }).join("");
-        const bg = ri % 2 === 1 ? "background:#f9fafb;" : "";
+        const bg = ri % 2 === 1 ? "background:var(--card-bg, #f9fafb);" : "";
         return `<tr style="${bg}">${cells}</tr>`;
       }).join("");
 
@@ -173,8 +173,8 @@ function renderElement(id: string, spec: JsonRenderSpec, opts: SpecToHtmlOptions
       const pct = Math.min(100, (value / max) * 100);
       const variant = String(props.variant ?? "info");
       const color = PROGRESS_COLORS[variant] ?? PROGRESS_COLORS.info;
-      const label = props.label ? `<div style="font-size:0.8em;color:#6b7280;margin-bottom:4px">${esc(props.label)} \u2014 ${value}/${max}</div>` : "";
-      return `<div>${label}<div style="height:8px;background:#e5e7eb;border-radius:4px;overflow:hidden"><div style="height:100%;width:${pct}%;background:${color};border-radius:4px"></div></div></div>`;
+      const label = props.label ? `<div style="font-size:0.8em;color:var(--muted, #6b7280);margin-bottom:4px">${esc(props.label)} \u2014 ${value}/${max}</div>` : "";
+      return `<div>${label}<div style="height:8px;background:var(--border, #e5e7eb);border-radius:4px;overflow:hidden"><div style="height:100%;width:${pct}%;background:${color};border-radius:4px"></div></div></div>`;
     }
 
     case "LineChart": {
@@ -195,7 +195,7 @@ function renderElement(id: string, spec: JsonRenderSpec, opts: SpecToHtmlOptions
 
       const gridLines = Array.from({ length: 4 }, (_, i) => padding + (i / 3) * (chartBottom - padding));
       const gridSvg = gridLines.map((y, i) =>
-        `<line x1="${padding}" x2="${width - padding}" y1="${y}" y2="${y}" stroke="#e5e7eb" stroke-opacity="0.9" ${i < gridLines.length - 1 ? 'stroke-dasharray="3 3"' : ""}/>`
+        `<line x1="${padding}" x2="${width - padding}" y1="${y}" y2="${y}" stroke="var(--border, #e5e7eb)" stroke-opacity="0.9" ${i < gridLines.length - 1 ? 'stroke-dasharray="3 3"' : ""}/>`
       ).join("");
 
       const areaPath = props.showArea ? buildAreaPath(points, chartBottom, padding) : "";
@@ -203,17 +203,17 @@ function renderElement(id: string, spec: JsonRenderSpec, opts: SpecToHtmlOptions
 
       const pointsSvg = points.map((p, i) =>
         `<circle cx="${p.x}" cy="${p.y}" r="3.5" fill="${stroke}"/>
-         <text x="${p.x}" y="${height - 8}" text-anchor="middle" font-size="10" fill="#6b7280">${esc(labels[i])}</text>`
+         <text x="${p.x}" y="${height - 8}" text-anchor="middle" font-size="10" fill="var(--muted, #6b7280)">${esc(labels[i])}</text>`
       ).join("");
 
       const title = props.title ? `<div style="font-weight:600;font-size:0.9em;margin-bottom:8px">${esc(props.title)}</div>` : "";
-      const footer = `<div style="display:flex;justify-content:space-between;font-size:0.75em;color:#6b7280;margin-top:4px;padding:4px 0;border-top:1px solid #e5e7eb">
+      const footer = `<div style="display:flex;justify-content:space-between;font-size:0.75em;color:var(--muted, #6b7280);margin-top:4px;padding:4px 0;border-top:1px solid var(--border, #e5e7eb)">
         <span>Min ${formatChartValue(bounds.min, props.valuePrefix as string | null, props.valueSuffix as string | null)}</span>
-        <span style="font-weight:600;color:#1a1a1a">Latest ${formatChartValue(currentValue, props.valuePrefix as string | null, props.valueSuffix as string | null)}</span>
+        <span style="font-weight:600;color:var(--fg, #1a1a1a)">Latest ${formatChartValue(currentValue, props.valuePrefix as string | null, props.valueSuffix as string | null)}</span>
         <span>Max ${formatChartValue(bounds.max, props.valuePrefix as string | null, props.valueSuffix as string | null)}</span>
       </div>`;
 
-      return `<div style="border:1px solid #e5e7eb;border-radius:8px;overflow:hidden;margin:12px 0">
+      return `<div style="border:1px solid var(--border, #e5e7eb);border-radius:8px;overflow:hidden;margin:12px 0">
         ${title ? `<div style="padding:12px 12px 0">${title}</div>` : ""}
         <div style="padding:8px">
           <svg viewBox="0 0 ${width} ${height}" style="width:100%">
@@ -245,16 +245,16 @@ function renderElement(id: string, spec: JsonRenderSpec, opts: SpecToHtmlOptions
         const x = padding + (i * (width - padding * 2)) / data.length + ((width - padding * 2) / data.length - barWidth) / 2;
         const y = padding + chartHeight - barH;
         return `<rect x="${x}" y="${y}" width="${barWidth}" height="${barH}" rx="4" fill="${color}"/>
-          <text x="${x + barWidth / 2}" y="${y - 4}" text-anchor="middle" font-size="10" fill="#374151" font-weight="500">${formatChartValue(item.value, props.valuePrefix as string | null, props.valueSuffix as string | null)}</text>
-          <text x="${x + barWidth / 2}" y="${height - 8}" text-anchor="middle" font-size="10" fill="#6b7280">${esc(item.label)}</text>`;
+          <text x="${x + barWidth / 2}" y="${y - 4}" text-anchor="middle" font-size="10" fill="var(--fg, #374151)" font-weight="500">${formatChartValue(item.value, props.valuePrefix as string | null, props.valueSuffix as string | null)}</text>
+          <text x="${x + barWidth / 2}" y="${height - 8}" text-anchor="middle" font-size="10" fill="var(--muted, #6b7280)">${esc(item.label)}</text>`;
       }).join("");
 
       const title = props.title ? `<div style="padding:12px 12px 0;font-weight:600;font-size:0.9em">${esc(props.title)}</div>` : "";
-      return `<div style="border:1px solid #e5e7eb;border-radius:8px;overflow:hidden;margin:12px 0">
+      return `<div style="border:1px solid var(--border, #e5e7eb);border-radius:8px;overflow:hidden;margin:12px 0">
         ${title}
         <div style="padding:8px">
           <svg viewBox="0 0 ${width} ${height}" style="width:100%">
-            <line x1="${padding}" x2="${width - padding}" y1="${padding + chartHeight}" y2="${padding + chartHeight}" stroke="#e5e7eb"/>
+            <line x1="${padding}" x2="${width - padding}" y1="${padding + chartHeight}" y2="${padding + chartHeight}" stroke="var(--border, #e5e7eb)"/>
             ${bars}
           </svg>
         </div>
@@ -283,21 +283,21 @@ function renderElement(id: string, spec: JsonRenderSpec, opts: SpecToHtmlOptions
           <td style="padding:4px 8px"><span style="display:inline-block;width:12px;height:12px;border-radius:50%;background:${color}"></span></td>
           <td style="padding:4px 8px;font-size:0.85em">${esc(seg.label)}</td>
           <td style="padding:4px 8px;text-align:right;font-size:0.85em;font-weight:500">${formatChartValue(seg.value, null, props.valueSuffix as string | null)}</td>
-          <td style="padding:4px 8px;text-align:right;font-size:0.8em;color:#6b7280">${Math.round(seg.percentage * 100)}%</td>
+          <td style="padding:4px 8px;text-align:right;font-size:0.8em;color:var(--muted, #6b7280)">${Math.round(seg.percentage * 100)}%</td>
         </tr>`;
       }).join("");
 
       const title = props.title ? `<div style="padding:12px 12px 0;font-weight:600;font-size:0.9em">${esc(props.title)}</div>` : "";
-      return `<div style="border:1px solid #e5e7eb;border-radius:8px;overflow:hidden;margin:12px 0">
+      return `<div style="border:1px solid var(--border, #e5e7eb);border-radius:8px;overflow:hidden;margin:12px 0">
         ${title}
         <div style="padding:12px;display:flex;align-items:center;gap:24px;flex-wrap:wrap">
           <div style="flex-shrink:0">
             <svg viewBox="0 0 120 120" width="140" height="140" style="transform:rotate(-90deg)">
-              <circle cx="60" cy="60" r="${radius}" fill="none" stroke="#e5e7eb" stroke-width="16"/>
+              <circle cx="60" cy="60" r="${radius}" fill="none" stroke="var(--border, #e5e7eb)" stroke-width="16"/>
               ${segmentsSvg}
               <g transform="rotate(90 60 60)">
-                <text x="60" y="54" text-anchor="middle" font-size="11" fill="#6b7280">${centerLabel}</text>
-                <text x="60" y="70" text-anchor="middle" font-size="15" font-weight="700" fill="#1a1a1a">${formatChartValue(total, null, props.valueSuffix as string | null)}</text>
+                <text x="60" y="54" text-anchor="middle" font-size="11" fill="var(--muted, #6b7280)">${centerLabel}</text>
+                <text x="60" y="70" text-anchor="middle" font-size="15" font-weight="700" fill="var(--fg, #1a1a1a)">${formatChartValue(total, null, props.valueSuffix as string | null)}</text>
               </g>
             </svg>
           </div>
@@ -311,7 +311,7 @@ function renderElement(id: string, spec: JsonRenderSpec, opts: SpecToHtmlOptions
       const sizes: Record<string, string> = {
         "1": "font-size:1.4em;font-weight:700",
         "2": "font-size:1.15em;font-weight:600",
-        "3": "font-size:1em;font-weight:600;color:#374151",
+        "3": "font-size:1em;font-weight:600;color:var(--fg, #374151)",
       };
       const style = sizes[level] ?? sizes["2"];
       const tag = level === "1" ? "h2" : level === "3" ? "h4" : "h3";
@@ -320,10 +320,10 @@ function renderElement(id: string, spec: JsonRenderSpec, opts: SpecToHtmlOptions
 
     case "Text": {
       const variants: Record<string, string> = {
-        body: "font-size:0.9em;color:#374151",
-        caption: "font-size:0.8em;color:#6b7280",
-        bold: "font-size:0.9em;font-weight:600;color:#1a1a1a",
-        muted: "font-size:0.9em;color:#6b7280",
+        body: "font-size:0.9em;color:var(--fg, #374151)",
+        caption: "font-size:0.8em;color:var(--muted, #6b7280)",
+        bold: "font-size:0.9em;font-weight:600;color:var(--fg, #1a1a1a)",
+        muted: "font-size:0.9em;color:var(--muted, #6b7280)",
       };
       const style = variants[String(props.variant ?? "body")] ?? variants.body;
       return `<p style="${style};margin:6px 0">${esc(props.content)}</p>`;
@@ -357,9 +357,9 @@ function renderElement(id: string, spec: JsonRenderSpec, opts: SpecToHtmlOptions
         success: "#166534",
         danger: "#991b1b",
         warning: "#854d0e",
-        default: "#374151",
+        default: "var(--fg, #374151)",
       };
-      const textColor = variantColors[String(props.variant ?? "default")] ?? variantColors.default;
+      const textColor = variantColors[String(props.variant ?? "default")] ?? "var(--fg, #374151)";
 
       const lis = items.map((item) =>
         `<li style="display:flex;align-items:flex-start;gap:8px;margin:4px 0;font-size:0.9em;color:${textColor}"><span style="color:${iconColor};flex-shrink:0">${prefix}</span><span>${esc(item)}</span></li>`
@@ -378,14 +378,14 @@ function renderElement(id: string, spec: JsonRenderSpec, opts: SpecToHtmlOptions
       const items = sources.map((s, i) =>
         `<span style="display:inline-block;margin:3px 6px 3px 0;font-size:0.8em">[${i + 1}] <a href="${esc(s.url)}" style="color:#2563eb;text-decoration:none">${esc(s.title)}</a></span>`
       ).join("");
-      return `<div style="margin-top:12px;padding-top:8px;border-top:1px solid #e5e7eb">${items}</div>`;
+      return `<div style="margin-top:12px;padding-top:8px;border-top:1px solid var(--border, #e5e7eb)">${items}</div>`;
     }
 
     case "ChartImage": {
       const src = resolve(String(props.src ?? ""));
       const alt = esc(props.alt ?? "Chart");
-      const caption = props.caption ? `<div style="font-size:0.8em;color:#6b7280;padding:6px 12px;border-top:1px solid #e5e7eb">${esc(props.caption)}</div>` : "";
-      return `<div style="border:1px solid #e5e7eb;border-radius:8px;overflow:hidden;margin:12px 0">
+      const caption = props.caption ? `<div style="font-size:0.8em;color:var(--muted, #6b7280);padding:6px 12px;border-top:1px solid var(--border, #e5e7eb)">${esc(props.caption)}</div>` : "";
+      return `<div style="border:1px solid var(--border, #e5e7eb);border-radius:8px;overflow:hidden;margin:12px 0">
         <img src="${esc(src)}" alt="${alt}" style="width:100%;display:block"/>
         ${caption}
       </div>`;
@@ -393,16 +393,16 @@ function renderElement(id: string, spec: JsonRenderSpec, opts: SpecToHtmlOptions
 
     case "FlightOption": {
       const isGood = props.score != null && Number(props.score) >= 80;
-      const borderColor = isGood ? "#86efac" : "#e5e7eb";
-      const bg = isGood ? "#f0fdf4" : "#fafafa";
+      const borderColor = isGood ? "#86efac" : "var(--border, #e5e7eb)";
+      const bg = isGood ? "#f0fdf4" : "var(--card-bg, #fafafa)";
       const stops = Number(props.stops ?? 0);
       const stopsText = stops === 0 ? "Nonstop" : `${stops} stop${stops > 1 ? "s" : ""}`;
       const price = `${esc(props.price)}${props.currency ? ` ${esc(props.currency)}` : ""}`;
       const extras: string[] = [];
       if (props.baggage) extras.push(esc(props.baggage));
       if (props.refundable != null) extras.push(props.refundable ? "Refundable" : "Non-refundable");
-      const extrasHtml = extras.length > 0 ? `<div style="font-size:0.8em;color:#6b7280;margin-top:6px">${extras.join(" &middot; ")}</div>` : "";
-      const scoreHtml = props.score != null ? `<div style="font-size:0.8em;color:#6b7280;margin-top:4px">Score: ${props.score}/100${props.scoreReason ? ` \u2014 ${esc(props.scoreReason)}` : ""}</div>` : "";
+      const extrasHtml = extras.length > 0 ? `<div style="font-size:0.8em;color:var(--muted, #6b7280);margin-top:6px">${extras.join(" &middot; ")}</div>` : "";
+      const scoreHtml = props.score != null ? `<div style="font-size:0.8em;color:var(--muted, #6b7280);margin-top:4px">Score: ${props.score}/100${props.scoreReason ? ` \u2014 ${esc(props.scoreReason)}` : ""}</div>` : "";
       const bookingHtml = props.bookingUrl ? `<a href="${esc(props.bookingUrl)}" style="display:inline-block;margin-top:6px;font-size:0.8em;color:#2563eb;text-decoration:none">Book &rarr;</a>` : "";
 
       return `<div style="border:1px solid ${borderColor};border-radius:8px;padding:12px;margin:8px 0;background:${bg}">

--- a/packages/plugin-telegram/src/formatter.ts
+++ b/packages/plugin-telegram/src/formatter.ts
@@ -262,7 +262,11 @@ export function markdownToTelegramHTML(md: string): string {
     return `\x00LK${idx}\x00`;
   });
 
-  // 5. Convert markdown tables to readable card-style format
+  // 5. Collapse blank lines between markdown table rows so the table regex matches.
+  //    LLMs often emit tables with blank lines between header, separator, and body rows.
+  result = result.replace(/(\|[^\n]+\|)\n(?:\s*\n)+(?=\|)/gm, "$1\n");
+
+  // Convert markdown tables to readable card-style format
   result = result.replace(
     /^(\|.+\|)\n(\|[\s:|-]+\|)\n((?:\|.+\|\n?)+)/gm,
     (_m, headerRow: string, _sep: string, bodyRows: string) => {

--- a/packages/plugin-telegram/src/report-document.ts
+++ b/packages/plugin-telegram/src/report-document.ts
@@ -22,26 +22,26 @@ interface TelegramReportDocumentOptions {
 
 const REPORT_DOCUMENT_STYLE = `
   :root {
-    color-scheme: light dark;
-    --bg: #ffffff;
-    --fg: #132238;
-    --muted: #5b6b82;
-    --border: #d9e0ea;
-    --accent: #0f766e;
-    --accent-bg: #f0fdfa;
-    --code-bg: #f4f7fb;
-    --card-bg: #f8fafc;
+    color-scheme: dark light;
+    --bg: #0b1220;
+    --fg: #e6edf7;
+    --muted: #9eb0c7;
+    --border: #243247;
+    --accent: #5eead4;
+    --accent-bg: #0f2230;
+    --code-bg: #111b2c;
+    --card-bg: #101827;
   }
-  @media (prefers-color-scheme: dark) {
+  @media (prefers-color-scheme: light) {
     :root {
-      --bg: #0b1220;
-      --fg: #e6edf7;
-      --muted: #9eb0c7;
-      --border: #243247;
-      --accent: #5eead4;
-      --accent-bg: #0f2230;
-      --code-bg: #111b2c;
-      --card-bg: #101827;
+      --bg: #ffffff;
+      --fg: #132238;
+      --muted: #5b6b82;
+      --border: #d9e0ea;
+      --accent: #0f766e;
+      --accent-bg: #f0fdfa;
+      --code-bg: #f4f7fb;
+      --card-bg: #f8fafc;
     }
   }
   * { box-sizing: border-box; }
@@ -233,7 +233,7 @@ export function buildTelegramReportDocument(
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="color-scheme" content="light dark">
+  <meta name="color-scheme" content="dark light">
   <title>${escapeHTML(title)}</title>
   <style>${REPORT_DOCUMENT_STYLE}</style>
 </head>

--- a/packages/plugin-telegram/test/telegram.test.ts
+++ b/packages/plugin-telegram/test/telegram.test.ts
@@ -164,6 +164,24 @@ describe("markdownToTelegramHTML", () => {
     expect(output).not.toContain("```");
     expect(output).not.toContain("-+-");
   });
+
+  it("converts tables with blank lines between rows", () => {
+    const input = "| Dimension | Finnhub | Alpha Vantage |\n\n|-----------|---------|---------------|\n\n| Coverage | Global | US only |\n\n| Latency | 15s | 20min |";
+    const output = markdownToTelegramHTML(input);
+    // Should convert to card-style (3 columns), not show raw pipes
+    expect(output).toContain("Dimension: Coverage");
+    expect(output).toContain("Finnhub: Global");
+    expect(output).toContain("Alpha Vantage: US only");
+    expect(output).not.toContain("|");
+  });
+
+  it("converts 2-column tables with blank lines between rows", () => {
+    const input = "| Key | Value |\n\n|-----|-------|\n\n| Name | Alice |\n\n| Age | 30 |";
+    const output = markdownToTelegramHTML(input);
+    expect(output).toContain("\u2022 Name: Alice");
+    expect(output).toContain("\u2022 Age: 30");
+    expect(output).not.toContain("|");
+  });
 });
 
 describe("splitMessage", () => {


### PR DESCRIPTION
- Fix markdown table detection to handle blank lines between rows (common
  LLM output pattern) by collapsing blank lines before the table regex
- Default HTML report documents to dark mode instead of light mode
- Update spec-to-html to use CSS variables with fallbacks so rendered
  components (DataTable, MetricCard, charts, etc.) respect the report
  document's dark/light theme

https://claude.ai/code/session_01B3t6ETJCZBe12N1kMWec7v