### PR TITLE
fix: gracefully handle research budget exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Graceful search-budget exits for research and swarm** — Background research and swarm agents now treat exhausted search/page budgets as structured stop signals, stop tool loops deterministically, and synthesize partial findings from collected evidence instead of surfacing raw "budget exhausted" text or empty agent output.
 - **Built UI asset routing** — Production server static hosting now serves nested `/assets/*` files correctly, preventing blank-page reloads caused by JavaScript and CSS requests falling through to `index.html`.
 - **Provider setup error visibility** — LLM setup "Test Connection" now performs a tiny inference instead of a shallow provider health check, so billing, quota, auth, and model-access failures surface with the provider's actual error message.
 - **Wasteful thread title token usage** — Short chats now keep cheap heuristic titles instead of immediately invoking the full LLM title path. LLM-generated title refreshes only start on longer threads and the title call itself is capped to a tiny output budget, cutting unnecessary token burn and queue time.

--- a/packages/plugin-research/src/research.ts
+++ b/packages/plugin-research/src/research.ts
@@ -96,6 +96,124 @@ export interface ResearchContext {
   fetchPage: (url: string) => Promise<{ title: string; markdown: string; url: string } | null>;
 }
 
+type ToolCallLike = {
+  toolName?: string;
+  args?: unknown;
+};
+
+type ToolResultLike = {
+  result?: unknown;
+  output?: unknown;
+};
+
+type StepLike = {
+  toolCalls?: ToolCallLike[];
+  toolResults?: ToolResultLike[];
+};
+
+type BudgetResource = "search" | "page";
+
+interface BudgetExhaustedSignal {
+  status: "budget_exhausted";
+  resource: BudgetResource;
+  used: number;
+  max: number;
+  nextAction: "synthesize";
+  message: string;
+}
+
+function createBudgetSignal(resource: BudgetResource, used: number, max: number): BudgetExhaustedSignal {
+  const label = resource === "search" ? "web searches" : "page reads";
+  return {
+    status: "budget_exhausted",
+    resource,
+    used,
+    max,
+    nextAction: "synthesize",
+    message: `Budget exhausted: used ${used}/${max} ${label}. Synthesize findings from existing information.`,
+  };
+}
+
+function getToolPayload(value: unknown): unknown {
+  if (!value || typeof value !== "object") return value;
+  const maybe = value as ToolResultLike;
+  if ("output" in maybe && maybe.output !== undefined) return maybe.output;
+  if ("result" in maybe && maybe.result !== undefined) return maybe.result;
+  return value;
+}
+
+function isBudgetSignal(value: unknown): value is BudgetExhaustedSignal {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<BudgetExhaustedSignal>;
+  return candidate.status === "budget_exhausted"
+    && (candidate.resource === "search" || candidate.resource === "page")
+    && typeof candidate.used === "number"
+    && typeof candidate.max === "number";
+}
+
+function hasBudgetSignal(steps: StepLike[]): boolean {
+  return steps.some((step) =>
+    (step.toolResults ?? []).some((toolResult) => isBudgetSignal(getToolPayload(toolResult))),
+  );
+}
+
+function hasBudgetSignalInLastStep(steps: StepLike[]): boolean {
+  const lastStep = steps[steps.length - 1];
+  if (!lastStep) return false;
+  return (lastStep.toolResults ?? []).some((toolResult) => isBudgetSignal(getToolPayload(toolResult)));
+}
+
+function isBudgetPlaceholderText(text: string | undefined): boolean {
+  if (!text) return false;
+  return /budget exhausted/i.test(text)
+    || /used all your web searches/i.test(text)
+    || /used all your page reads/i.test(text);
+}
+
+function stringifyForPrompt(value: unknown, maxChars = 1600): string {
+  if (typeof value === "string") {
+    return value.slice(0, maxChars);
+  }
+  if (isBudgetSignal(value)) {
+    return `${value.message} (${value.used}/${value.max})`;
+  }
+  try {
+    return JSON.stringify(value, null, 2).slice(0, maxChars);
+  } catch {
+    return String(value).slice(0, maxChars);
+  }
+}
+
+function summarizeToolResults(steps: StepLike[], maxChars = 30_000): string {
+  const sections: string[] = [];
+  let usedChars = 0;
+
+  for (const step of steps) {
+    const toolCalls = step.toolCalls ?? [];
+    const toolResults = step.toolResults ?? [];
+    const count = Math.max(toolCalls.length, toolResults.length);
+    for (let index = 0; index < count; index++) {
+      const toolCall = toolCalls[index];
+      const raw = getToolPayload(toolResults[index]);
+      if (raw == null) continue;
+
+      const body = stringifyForPrompt(raw);
+      if (!body.trim()) continue;
+
+      const args = toolCall?.args !== undefined ? ` ${stringifyForPrompt(toolCall.args, 240)}` : "";
+      const header = toolCall?.toolName ? `Tool: ${toolCall.toolName}${args}` : "Tool result";
+      const section = `${header}\n${body}`.slice(0, 2200);
+      if (usedChars + section.length > maxChars) {
+        return [...sections, "[truncated]"].join("\n\n---\n\n");
+      }
+      sections.push(section);
+      usedChars += section.length + 10;
+    }
+  }
+
+  return sections.join("\n\n---\n\n");
+}
+
 // ---- Data Access ----
 
 export function createResearchJob(
@@ -1058,7 +1176,7 @@ function createResearchTools(
       }),
       execute: async ({ query }: { query: string }) => {
         if (searchesUsed >= job.budgetMaxSearches) {
-          return "Budget exhausted — you've used all your web searches. Synthesize your findings into the report now.";
+          return createBudgetSignal("search", searchesUsed, job.budgetMaxSearches);
         }
         searchesUsed++;
         updateJob(ctx.storage, jobId, { searches_used: searchesUsed });
@@ -1080,7 +1198,7 @@ function createResearchTools(
       }),
       execute: async ({ url }: { url: string }) => {
         if (pagesRead >= job.budgetMaxPages) {
-          return "Budget exhausted — you've used all your page reads. Synthesize your findings into the report now.";
+          return createBudgetSignal("page", pagesRead, job.budgetMaxPages);
         }
         pagesRead++;
         updateJob(ctx.storage, jobId, { pages_learned: pagesRead });
@@ -1280,7 +1398,10 @@ export async function runResearchInBackground(
         ],
         tools,
         toolChoice: "auto",
-        stopWhen: stepCountIs(15),
+        stopWhen: [
+          stepCountIs(15),
+          ({ steps }) => hasBudgetSignalInLastStep(steps as StepLike[]),
+        ],
         maxRetries: 1,
         timeout: RESEARCH_LLM_TIMEOUT,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1299,19 +1420,16 @@ export async function runResearchInBackground(
     );
 
     let rawReport = result.text;
+    const summarizedToolResults = summarizeToolResults(result.steps as StepLike[]);
 
-    // If the LLM exhausted all steps on tool calls without producing a report,
-    // do a follow-up call to synthesize findings from the tool results.
-    if (!rawReport) {
-      ctx.logger.warn(`Research job ${jobId}: no report text, running synthesis pass`);
-      const toolResults = result.steps
-        .flatMap((s) => s.toolResults ?? [])
-        .map((r) => String((r as Record<string, unknown>).result ?? ""))
-        .filter((r) => r.length > 10)
-        .join("\n\n---\n\n")
-        .slice(0, 30_000);
+    // If the tool loop stopped at a limit or produced placeholder text,
+    // force a synthesis pass from collected tool output.
+    if (!rawReport?.trim() || isBudgetPlaceholderText(rawReport)) {
+      ctx.logger.warn(`Research job ${jobId}: incomplete report text, running synthesis pass`, {
+        budgetExhausted: hasBudgetSignal(result.steps as StepLike[]),
+      });
 
-      if (toolResults) {
+      if (summarizedToolResults) {
         const { result: synthResult } = await instrumentedGenerateText(
           { storage: ctx.storage, logger: ctx.logger },
           {
@@ -1319,7 +1437,7 @@ export async function runResearchInBackground(
             system: systemPrompt,
             messages: [
               { role: "user", content: `Research this topic thoroughly: ${job.goal}` },
-              { role: "assistant", content: `I've gathered the following research data:\n\n${toolResults}` },
+              { role: "assistant", content: `I've gathered the following research data:\n\n${summarizedToolResults}` },
               { role: "user", content: "Now synthesize all findings into the structured markdown report." },
             ],
             maxRetries: 1,
@@ -1334,7 +1452,7 @@ export async function runResearchInBackground(
             jobId,
             provider: ctx.provider ?? "ollama",
             model: ctx.model ?? "",
-            requestSizeChars: toolResults.length,
+            requestSizeChars: summarizedToolResults.length,
           },
         );
         rawReport = synthResult.text || "";

--- a/packages/plugin-research/test/research.test.ts
+++ b/packages/plugin-research/test/research.test.ts
@@ -156,6 +156,66 @@ describe("Research jobs", () => {
       expect(tracked!.status).toBe("done");
       expect(tracked!.type).toBe("research");
     });
+
+    it("synthesizes from structured budget signals instead of persisting placeholder text", async () => {
+      const { generateText } = await import("ai");
+      (generateText as ReturnType<typeof vi.fn>)
+        .mockImplementationOnce(async (options: Record<string, unknown>) => {
+          const stopWhen = options.stopWhen as unknown[];
+          expect(Array.isArray(stopWhen)).toBe(true);
+          expect(stopWhen.some((condition) => typeof condition === "function")).toBe(true);
+
+          const tools = options.tools as Record<string, { execute: (input: Record<string, unknown>) => Promise<unknown> }>;
+          for (let index = 0; index < 5; index++) {
+            await tools.web_search!.execute({ query: `query-${index}` });
+          }
+          const budgetResult = await tools.web_search!.execute({ query: "query-overflow" });
+          expect(budgetResult).toEqual(expect.objectContaining({
+            status: "budget_exhausted",
+            resource: "search",
+            used: 5,
+            max: 5,
+          }));
+
+          return {
+            text: "Budget exhausted — you've used all your web searches.",
+            steps: [
+              {
+                toolCalls: [{ toolName: "web_search", args: { query: "typescript frameworks" } }],
+                toolResults: [{ result: "Authoritative source result." }],
+              },
+              {
+                toolCalls: [{ toolName: "web_search", args: { query: "query-overflow" } }],
+                toolResults: [{ result: budgetResult }],
+              },
+            ],
+          };
+        })
+        .mockImplementationOnce(async (options: Record<string, unknown>) => {
+          const messages = options.messages as Array<{ role: string; content: string }>;
+          expect(messages[1]!.content).toContain("Tool: web_search");
+          expect(messages[1]!.content).toContain("Budget exhausted: used 5/5 web searches");
+          expect(messages[1]!.content).not.toContain("[object Object]");
+
+          return {
+            text: "# Research Report\n\n## Summary\nRecovered from partial findings.",
+            steps: [],
+          };
+        });
+
+      const ctx = makeCtx();
+      const id = createResearchJob(storage, {
+        goal: "Budget-limited research",
+        threadId: null,
+      });
+
+      await runResearchInBackground(ctx, id);
+
+      const job = getResearchJob(storage, id);
+      expect(job!.status).toBe("done");
+      expect(job!.report).toContain("Recovered from partial findings");
+      expect(job!.report).not.toContain("Budget exhausted");
+    });
   });
 
   describe("report delivery", () => {

--- a/packages/plugin-swarm/src/swarm.ts
+++ b/packages/plugin-swarm/src/swarm.ts
@@ -67,6 +67,118 @@ export interface SwarmContext {
   fetchPage: (url: string) => Promise<{ title: string; markdown: string; url: string } | null>;
 }
 
+type ToolCallLike = {
+  toolName?: string;
+  args?: unknown;
+};
+
+type ToolResultLike = {
+  result?: unknown;
+  output?: unknown;
+};
+
+type StepLike = {
+  toolCalls?: ToolCallLike[];
+  toolResults?: ToolResultLike[];
+};
+
+type BudgetResource = "search" | "page";
+
+interface BudgetExhaustedSignal {
+  status: "budget_exhausted";
+  resource: BudgetResource;
+  used: number;
+  max: number;
+  nextAction: "summarize";
+  message: string;
+}
+
+function createBudgetSignal(resource: BudgetResource, used: number, max: number): BudgetExhaustedSignal {
+  const label = resource === "search" ? "web searches" : "page reads";
+  return {
+    status: "budget_exhausted",
+    resource,
+    used,
+    max,
+    nextAction: "summarize",
+    message: `Budget exhausted: used ${used}/${max} ${label}. Summarize existing findings and stop calling search tools.`,
+  };
+}
+
+function getToolPayload(value: unknown): unknown {
+  if (!value || typeof value !== "object") return value;
+  const maybe = value as ToolResultLike;
+  if ("output" in maybe && maybe.output !== undefined) return maybe.output;
+  if ("result" in maybe && maybe.result !== undefined) return maybe.result;
+  return value;
+}
+
+function isBudgetSignal(value: unknown): value is BudgetExhaustedSignal {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<BudgetExhaustedSignal>;
+  return candidate.status === "budget_exhausted"
+    && (candidate.resource === "search" || candidate.resource === "page")
+    && typeof candidate.used === "number"
+    && typeof candidate.max === "number";
+}
+
+function hasBudgetSignalInLastStep(steps: StepLike[]): boolean {
+  const lastStep = steps[steps.length - 1];
+  if (!lastStep) return false;
+  return (lastStep.toolResults ?? []).some((toolResult) => isBudgetSignal(getToolPayload(toolResult)));
+}
+
+function isBudgetPlaceholderText(text: string | undefined): boolean {
+  if (!text) return false;
+  return /budget exhausted/i.test(text)
+    || /used all your web searches/i.test(text)
+    || /used all your page reads/i.test(text);
+}
+
+function stringifyForSummary(value: unknown, maxChars = 1600): string {
+  if (typeof value === "string") {
+    return value.slice(0, maxChars);
+  }
+  if (isBudgetSignal(value)) {
+    return `${value.message} (${value.used}/${value.max})`;
+  }
+  try {
+    return JSON.stringify(value, null, 2).slice(0, maxChars);
+  } catch {
+    return String(value).slice(0, maxChars);
+  }
+}
+
+function summarizeToolResults(steps: StepLike[], maxChars = 4_000): string {
+  const sections: string[] = [];
+  let usedChars = 0;
+
+  for (const step of steps) {
+    const toolCalls = step.toolCalls ?? [];
+    const toolResults = step.toolResults ?? [];
+    const count = Math.max(toolCalls.length, toolResults.length);
+    for (let index = 0; index < count; index++) {
+      const toolCall = toolCalls[index];
+      const raw = getToolPayload(toolResults[index]);
+      if (raw == null) continue;
+
+      const body = stringifyForSummary(raw);
+      if (!body.trim()) continue;
+
+      const args = toolCall?.args !== undefined ? ` ${stringifyForSummary(toolCall.args, 240)}` : "";
+      const header = toolCall?.toolName ? `Tool: ${toolCall.toolName}${args}` : "Tool result";
+      const section = `${header}\n${body}`.slice(0, 2200);
+      if (usedChars + section.length > maxChars) {
+        return [...sections, "[truncated]"].join("\n\n---\n\n");
+      }
+      sections.push(section);
+      usedChars += section.length + 10;
+    }
+  }
+
+  return sections.join("\n\n---\n\n");
+}
+
 function getSubAgentPrompt(role: string, resultType: string, timezone?: string): string {
   // Domain-specific roles first
   if (role === "flight_researcher") return getFlightResearcherPrompt(timezone);
@@ -479,7 +591,10 @@ async function runSubAgent(
       ],
       tools,
       toolChoice: "auto",
-      stopWhen: stepCountIs(AGENT_STEP_LIMIT),
+      stopWhen: [
+        stepCountIs(AGENT_STEP_LIMIT),
+        ({ steps }) => hasBudgetSignalInLastStep(steps as StepLike[]),
+      ],
       maxRetries: 1,
       timeout: SWARM_LLM_TIMEOUT,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -497,7 +612,10 @@ async function runSubAgent(
     },
   );
 
-  const agentResult = result.text || "Agent completed but produced no text output.";
+  const toolSummary = summarizeToolResults(result.steps as StepLike[]);
+  const agentResult = (!result.text?.trim() || isBudgetPlaceholderText(result.text))
+    ? (toolSummary || "Agent completed but produced no text output.")
+    : result.text;
 
   // Post final result to blackboard if not already posted
   insertBlackboardEntry(ctx.storage, {
@@ -536,7 +654,7 @@ function createSubAgentTools(
       }),
       execute: async ({ query }: { query: string }) => {
         if (searchesUsed >= MAX_SEARCHES_PER_AGENT) {
-          return "Budget exhausted — you've used all your web searches. Post your findings to the blackboard now.";
+          return createBudgetSignal("search", searchesUsed, MAX_SEARCHES_PER_AGENT);
         }
         searchesUsed++;
         try {
@@ -556,7 +674,7 @@ function createSubAgentTools(
       }),
       execute: async ({ url }: { url: string }) => {
         if (pagesRead >= MAX_PAGES_PER_AGENT) {
-          return "Budget exhausted — you've used all your page reads. Post your findings to the blackboard now.";
+          return createBudgetSignal("page", pagesRead, MAX_PAGES_PER_AGENT);
         }
         pagesRead++;
         try {

--- a/packages/plugin-swarm/test/swarm.test.ts
+++ b/packages/plugin-swarm/test/swarm.test.ts
@@ -531,5 +531,117 @@ describe("Swarm jobs", () => {
       expect(tracked).toBeDefined();
       expect(tracked!.status).toBe("done");
     });
+
+    it("summarizes partial tool results when a sub-agent exhausts its search budget", async () => {
+      mockInstrumentedGenerateText.mockImplementation(async (_runtime, options, telemetry) => {
+        const process = (telemetry as { process?: string }).process;
+
+        if (process === "swarm.plan") {
+          return {
+            result: {
+              text: '```json\n[{"role":"researcher","task":"Research the budget-limited topic","tools":["web_search"]},{"role":"analyst","task":"Analyze the gathered evidence","tools":["knowledge_search"]},{"role":"chart_generator","task":"Summarize visuals","tools":["knowledge_search"]}]\n```',
+              steps: [],
+            },
+            traceId: "trace-plan",
+            spanId: "span-plan",
+          };
+        }
+
+        if (process === "swarm.agent") {
+          const message = ((options as { messages?: Array<{ content?: string }> }).messages ?? [])[0]?.content ?? "";
+          if (message.includes("Research the budget-limited topic")) {
+            const stopWhen = (options as { stopWhen?: unknown }).stopWhen;
+            expect(Array.isArray(stopWhen)).toBe(true);
+            expect((stopWhen as unknown[]).some((condition) => typeof condition === "function")).toBe(true);
+
+            const tools = (options as { tools?: Record<string, { execute: (input: Record<string, unknown>) => Promise<unknown> }> }).tools ?? {};
+            for (let index = 0; index < 4; index++) {
+              await tools.web_search!.execute({ query: `query-${index}` });
+            }
+            const budgetResult = await tools.web_search!.execute({ query: "query-overflow" });
+            expect(budgetResult).toEqual(expect.objectContaining({
+              status: "budget_exhausted",
+              resource: "search",
+              used: 4,
+              max: 4,
+            }));
+
+            return {
+              result: {
+                text: "",
+                steps: [
+                  {
+                    toolCalls: [{ toolName: "web_search", args: { query: "topic facts" } }],
+                    toolResults: [{ result: "Authoritative source A" }],
+                  },
+                  {
+                    toolCalls: [{ toolName: "web_search", args: { query: "query-overflow" } }],
+                    toolResults: [{ result: budgetResult }],
+                  },
+                ],
+              },
+              traceId: "trace-agent-budget",
+              spanId: "span-agent-budget",
+            };
+          }
+
+          if (message.includes("Analyze the gathered evidence")) {
+            return {
+              result: {
+                text: "Analysis highlights the strongest evidence.",
+                steps: [],
+              },
+              traceId: "trace-agent-analyst",
+              spanId: "span-agent-analyst",
+            };
+          }
+
+          return {
+            result: {
+              text: "No chart generated, but the available evidence is summarized.",
+              steps: [],
+            },
+            traceId: "trace-agent-chart",
+            spanId: "span-agent-chart",
+          };
+        }
+
+        if (process === "swarm.synthesize") {
+          const message = ((options as { messages?: Array<{ content?: string }> }).messages ?? [])[0]?.content ?? "";
+          expect(message).toContain("Authoritative source A");
+          expect(message).toContain("Budget exhausted: used 4/4 web searches");
+
+          return {
+            result: {
+              text: "# Swarm Report\n\nBudget-limited findings were synthesized correctly.",
+              steps: [],
+            },
+            traceId: "trace-synth",
+            spanId: "span-synth",
+          };
+        }
+
+        throw new Error(`Unexpected process: ${process ?? "unknown"}`);
+      });
+
+      const ctx = makeCtx();
+      const id = createSwarmJob(storage, {
+        goal: "Budget-limited swarm",
+        threadId: null,
+      });
+
+      await runSwarmInBackground(ctx, id);
+
+      const job = getSwarmJob(storage, id);
+      expect(job!.status).toBe("done");
+      expect(job!.synthesis).toContain("Budget-limited findings were synthesized correctly");
+
+      const agents = getSwarmAgents(storage, id);
+      const researcher = agents.find((agent) => agent.role === "researcher");
+      expect(researcher).toBeDefined();
+      expect(researcher!.result).toContain("Authoritative source A");
+      expect(researcher!.result).toContain("Budget exhausted: used 4/4 web searches");
+      expect(researcher!.result).not.toContain("produced no text output");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- return structured budget exhaustion signals from research and swarm search/page tools
- stop tool loops deterministically when those signals appear and synthesize partial findings from collected tool results
- add regression tests and changelog coverage for budget-limited exits

## Testing
- pnpm --filter @personal-ai/plugin-research test
- pnpm --filter @personal-ai/plugin-swarm test