### PR TITLE
feat: nested threads — branch conversations from any point

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,6 +71,9 @@ export {
   clearAllThreads,
   getThread,
   withThreadLock,
+  getAncestors,
+  getChildren,
+  getInheritedContext,
 } from "./threads.js";
 export type { ThreadRow, ThreadMessageRow, ThreadMessageInput, EnsureThreadOptions, ListMessagesOptions, AppendMessagesOptions } from "./threads.js";
 

--- a/packages/core/src/threads.ts
+++ b/packages/core/src/threads.ts
@@ -97,6 +97,16 @@ export const threadMigrations: Migration[] = [
       ALTER TABLE thread_messages ADD COLUMN usage_json TEXT;
     `,
   },
+  {
+    version: 5,
+    up: `
+      ALTER TABLE threads ADD COLUMN parent_id TEXT REFERENCES threads(id) ON DELETE SET NULL;
+      ALTER TABLE threads ADD COLUMN fork_message_id TEXT;
+      ALTER TABLE threads ADD COLUMN fork_message_sequence INTEGER;
+      ALTER TABLE threads ADD COLUMN depth INTEGER NOT NULL DEFAULT 0;
+      CREATE INDEX IF NOT EXISTS idx_threads_parent ON threads(parent_id);
+    `,
+  },
 ];
 
 export const DEFAULT_USER_ID = "user-local";
@@ -110,6 +120,11 @@ export interface ThreadRow {
   updated_at: string;
   message_count: number;
   last_message?: string | null;
+  parent_id: string | null;
+  fork_message_id: string | null;
+  fork_message_sequence: number | null;
+  depth: number;
+  child_count?: number;
 }
 
 export interface ThreadMessageRow {
@@ -173,28 +188,74 @@ export function getThread(storage: Storage, id: string): ThreadRow | null {
 export function listThreads(storage: Storage, userId: string = DEFAULT_USER_ID): ThreadRow[] {
   return storage.query<ThreadRow>(
     `SELECT t.id, t.title, t.agent_name, t.user_id, t.created_at, t.updated_at, t.message_count,
-       (SELECT substr(m.content, 1, 1000) FROM thread_messages m WHERE m.thread_id = t.id AND m.role = 'assistant' ORDER BY m.sequence DESC LIMIT 1) AS last_message
+       t.parent_id, t.fork_message_id, t.fork_message_sequence, COALESCE(t.depth, 0) AS depth,
+       (SELECT substr(m.content, 1, 1000) FROM thread_messages m WHERE m.thread_id = t.id AND m.role = 'assistant' ORDER BY m.sequence DESC LIMIT 1) AS last_message,
+       (SELECT COUNT(*) FROM threads c WHERE c.parent_id = t.id) AS child_count
      FROM threads t WHERE t.user_id = ? ORDER BY t.updated_at DESC`,
     [userId],
   );
 }
 
-export function createThread(storage: Storage, opts: { title?: string; agentName?: string; userId?: string } = {}): ThreadRow {
+export function createThread(storage: Storage, opts: { title?: string; agentName?: string; userId?: string; parentId?: string; forkMessageId?: string; forkSequence?: number } = {}): ThreadRow {
   const id = `thread-${randomUUID()}`;
   const now = new Date().toISOString();
   const title = opts.title ?? "New conversation";
   const agentName = opts.agentName ?? null;
   const userId = opts.userId ?? DEFAULT_USER_ID;
+  const parentId = opts.parentId ?? null;
+  const forkMessageId = opts.forkMessageId ?? null;
+
+  // Determine depth and fork sequence from parent
+  let depth = 0;
+  let forkMessageSequence: number | null = null;
+  if (parentId) {
+    const parent = getThread(storage, parentId);
+    if (parent) depth = Math.min((parent.depth ?? 0) + 1, 5);
+    if (opts.forkSequence) {
+      forkMessageSequence = opts.forkSequence;
+    } else if (forkMessageId) {
+      const msg = storage.query<{ sequence: number }>(
+        "SELECT sequence FROM thread_messages WHERE id = ? AND thread_id = ?",
+        [forkMessageId, parentId],
+      );
+      if (msg[0]) forkMessageSequence = msg[0].sequence;
+    }
+    // If no specific fork point, copy all messages
+    if (forkMessageSequence == null) {
+      const last = storage.query<{ sequence: number }>(
+        "SELECT MAX(sequence) AS sequence FROM thread_messages WHERE thread_id = ?",
+        [parentId],
+      );
+      if (last[0]?.sequence) forkMessageSequence = last[0].sequence;
+    }
+  }
 
   const tx = storage.db.transaction(() => {
     storage.run(
-      "INSERT INTO threads (id, title, agent_name, user_id, created_at, updated_at, message_count) VALUES (?, ?, ?, ?, ?, ?, 0)",
-      [id, title, agentName, userId, now, now],
+      "INSERT INTO threads (id, title, agent_name, user_id, created_at, updated_at, message_count, parent_id, fork_message_id, fork_message_sequence, depth) VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?)",
+      [id, title, agentName, userId, now, now, parentId, forkMessageId, forkMessageSequence, depth],
     );
+
+    // Copy messages from parent up to fork point
+    if (parentId && forkMessageSequence != null) {
+      const parentMessages = storage.query<{ role: string; content: string; parts_json: string | null; created_at: string; sequence: number; usage_json: string | null }>(
+        "SELECT role, content, parts_json, created_at, sequence, usage_json FROM thread_messages WHERE thread_id = ? AND sequence <= ? ORDER BY sequence",
+        [parentId, forkMessageSequence],
+      );
+      for (const m of parentMessages) {
+        const msgId = randomUUID().replace(/-/g, "").slice(0, 32);
+        storage.run(
+          "INSERT INTO thread_messages (id, thread_id, role, content, parts_json, created_at, sequence, usage_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+          [msgId, id, m.role, m.content, m.parts_json, m.created_at, m.sequence, m.usage_json],
+        );
+      }
+      // Update message count
+      storage.run("UPDATE threads SET message_count = ? WHERE id = ?", [parentMessages.length, id]);
+    }
   });
   tx();
 
-  return { id, title, agent_name: agentName, user_id: userId, created_at: now, updated_at: now, message_count: 0 };
+  return { id, title, agent_name: agentName, user_id: userId, created_at: now, updated_at: now, message_count: 0, parent_id: parentId, fork_message_id: forkMessageId, fork_message_sequence: forkMessageSequence, depth };
 }
 
 export function ensureThread(storage: Storage, opts: EnsureThreadOptions = {}): { thread: ThreadRow; created: boolean } {
@@ -204,6 +265,37 @@ export function ensureThread(storage: Storage, opts: EnsureThreadOptions = {}): 
   }
   const thread = createThread(storage, { title: opts.title, agentName: opts.agentName, userId: opts.userId });
   return { thread, created: true };
+}
+
+/** Walk up the parent chain from a thread to the root */
+export function getAncestors(storage: Storage, threadId: string): ThreadRow[] {
+  const ancestors: ThreadRow[] = [];
+  let current = getThread(storage, threadId);
+  while (current?.parent_id) {
+    const parent = getThread(storage, current.parent_id);
+    if (!parent) break;
+    ancestors.unshift(parent);
+    current = parent;
+  }
+  return ancestors;
+}
+
+/** Get direct children of a thread */
+export function getChildren(storage: Storage, threadId: string): ThreadRow[] {
+  return storage.query<ThreadRow>(
+    "SELECT *, (SELECT COUNT(*) FROM threads c2 WHERE c2.parent_id = threads.id) AS child_count FROM threads WHERE parent_id = ? ORDER BY created_at",
+    [threadId],
+  );
+}
+
+/** Get messages from parent chain up to fork point (for context inheritance) */
+export function getInheritedContext(storage: Storage, threadId: string): ThreadMessageRow[] {
+  const thread = getThread(storage, threadId);
+  if (!thread?.parent_id || thread.fork_message_sequence == null) return [];
+  return storage.query<ThreadMessageRow>(
+    "SELECT * FROM thread_messages WHERE thread_id = ? AND sequence <= ? ORDER BY sequence",
+    [thread.parent_id, thread.fork_message_sequence],
+  );
 }
 
 export function listMessages(storage: Storage, threadId: string, opts: ListMessagesOptions = {}): ThreadMessageRow[] {

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -15,6 +15,8 @@ import {
   clearAllThreads,
   withThreadLock,
   getThread,
+  getAncestors,
+  getChildren,
   getOwner,
   getCorePreferences,
   currentDateBlock,
@@ -200,6 +202,10 @@ function mapThread(row: ThreadRow) {
     updatedAt: row.updated_at,
     messageCount: row.message_count,
     lastMessage: row.last_message ?? undefined,
+    parentId: row.parent_id ?? null,
+    forkMessageId: row.fork_message_id ?? null,
+    depth: row.depth ?? 0,
+    childCount: row.child_count ?? 0,
   };
 }
 
@@ -264,18 +270,38 @@ export function registerAgentRoutes(app: FastifyInstance, { ctx, agents }: Serve
     return listThreads(ctx.storage).map(mapThread);
   });
 
-  // Create a new thread
+  // Create a new thread (optionally forked from a parent)
   const createThreadSchema = z.object({
     title: z.string().max(200).optional(),
     agentName: z.string().max(100).optional(),
+    parentId: z.string().optional(),
+    forkMessageId: z.string().optional(),
+    forkSequence: z.number().int().positive().optional(),
   });
-  app.post<{ Body: { title?: string; agentName?: string } }>("/api/threads", async (request) => {
+  app.post<{ Body: { title?: string; agentName?: string; parentId?: string; forkMessageId?: string; forkSequence?: number } }>("/api/threads", async (request) => {
     const body = validate(createThreadSchema, request.body ?? {});
     const thread = createThread(ctx.storage, {
       title: body.title,
       agentName: body.agentName,
+      parentId: body.parentId,
+      forkMessageId: body.forkMessageId,
+      forkSequence: body.forkSequence,
     });
     return mapThread(thread);
+  });
+
+  // Get thread ancestors (breadcrumb path)
+  app.get<{ Params: { id: string } }>("/api/threads/:id/ancestors", async (request, reply) => {
+    const thread = getThread(ctx.storage, request.params.id);
+    if (!thread) return reply.status(404).send({ error: "Thread not found" });
+    return getAncestors(ctx.storage, request.params.id).map(mapThread);
+  });
+
+  // Get thread children
+  app.get<{ Params: { id: string } }>("/api/threads/:id/children", async (request, reply) => {
+    const thread = getThread(ctx.storage, request.params.id);
+    if (!thread) return reply.status(404).send({ error: "Thread not found" });
+    return getChildren(ctx.storage, request.params.id).map(mapThread);
   });
 
   // Delete a thread
@@ -490,6 +516,22 @@ export function registerAgentRoutes(app: FastifyInstance, { ctx, agents }: Serve
             loadedMessages: history.length,
             estimatedTokens: historyTokens,
           });
+
+          // Inject inherited context from parent thread (for forked threads)
+          const currentThread = getThread(ctx.storage, sid);
+          if (currentThread?.parent_id && currentThread.fork_message_sequence != null) {
+            const parentMsgs = listMessages(ctx.storage, currentThread.parent_id, { limit: currentThread.fork_message_sequence });
+            if (parentMsgs.length > 0) {
+              const parentContext = parentMsgs
+                .slice(-10) // last 10 messages before fork
+                .map(m => `${m.role}: ${m.content.slice(0, 500)}`)
+                .join("\n");
+              history.unshift({
+                role: "system" as ChatMessage["role"],
+                content: `[Prior conversation context from parent thread — this thread was forked from there]\n${parentContext}`,
+              });
+            }
+          }
 
           const agentCtx: AgentContext = {
             ...ctx,

--- a/packages/ui/src/api.ts
+++ b/packages/ui/src/api.ts
@@ -254,10 +254,10 @@ export function getThreads(): Promise<Thread[]> {
   return request<Thread[]>("/threads");
 }
 
-export function createThread(title?: string, agentName?: string): Promise<Thread> {
+export function createThread(title?: string, agentName?: string, parentId?: string, forkMessageId?: string, forkSequence?: number): Promise<Thread> {
   return request<Thread>("/threads", {
     method: "POST",
-    body: JSON.stringify({ title, agentName }),
+    body: JSON.stringify({ title, agentName, parentId, forkMessageId, forkSequence }),
   });
 }
 

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -18,6 +18,7 @@ import {
   ErrorPrimitive,
   MessagePrimitive,
   ThreadPrimitive,
+  useMessage,
 } from "@assistant-ui/react";
 import {
   ArrowDownIcon,
@@ -27,6 +28,7 @@ import {
   ChevronRightIcon,
   CopyIcon,
   DownloadIcon,
+  GitBranchIcon,
   MoreHorizontalIcon,
   PencilIcon,
   RefreshCwIcon,
@@ -274,6 +276,30 @@ const AssistantMessage: FC = () => {
   );
 };
 
+const BranchFromHereItem: FC = () => {
+  const messageId = useMessage((m) => m.id);
+  return (
+    <ActionBarMorePrimitive.Item
+      className="aui-action-bar-more-item flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+      onClick={() => {
+        // Get the message index from the DOM — assistant-ui doesn't expose DB IDs
+        const allMessages = document.querySelectorAll("[data-role='assistant'], [data-role='user']");
+        const thisMessage = document.querySelector(`[data-role='assistant']:has(.aui-assistant-action-bar-root [data-state='open'])`)
+          ?? document.querySelector("[data-role='assistant']:hover");
+        let sequence = allMessages.length; // fallback: all messages
+        if (thisMessage) {
+          const idx = Array.from(allMessages).indexOf(thisMessage);
+          if (idx >= 0) sequence = idx + 1;
+        }
+        window.dispatchEvent(new CustomEvent("pai:branch-thread", { detail: { messageId, sequence } }));
+      }}
+    >
+      <GitBranchIcon className="size-4" />
+      Branch from here
+    </ActionBarMorePrimitive.Item>
+  );
+};
+
 const AssistantActionBar: FC = () => {
   return (
     <ActionBarPrimitive.Root
@@ -316,6 +342,7 @@ const AssistantActionBar: FC = () => {
               Export as Markdown
             </ActionBarMorePrimitive.Item>
           </ActionBarPrimitive.ExportMarkdown>
+          <BranchFromHereItem />
         </ActionBarMorePrimitive.Content>
       </ActionBarMorePrimitive.Root>
     </ActionBarPrimitive.Root>

--- a/packages/ui/src/components/chat/ChatHeader.tsx
+++ b/packages/ui/src/components/chat/ChatHeader.tsx
@@ -1,10 +1,14 @@
+import { useMemo } from "react";
 import {
   BrainIcon,
   Trash2Icon,
   PanelLeftIcon,
   PanelLeftCloseIcon,
+  GitBranchIcon,
+  ChevronRightIcon,
 } from "lucide-react";
 import { useAgents } from "@/hooks/use-agents";
+import { useThreads } from "@/hooks/use-threads";
 import type { Thread } from "@/types";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -21,6 +25,7 @@ interface ChatHeaderProps {
   onToggleMemories: () => void;
   memoryCount: number;
   onClear: () => void;
+  onSelectThread?: (threadId: string) => void;
 }
 
 export function ChatHeader({
@@ -34,88 +39,127 @@ export function ChatHeader({
   onToggleMemories,
   memoryCount,
   onClear,
+  onSelectThread,
 }: ChatHeaderProps) {
   const { data: agents = [] } = useAgents();
+  const { data: threads = [] } = useThreads();
+
+  // Build breadcrumb: walk up parent chain
+  const breadcrumb = useMemo(() => {
+    if (!activeThread?.parentId || !threads.length) return [];
+    const threadMap = new Map(threads.map(t => [t.id, t]));
+    const crumbs: Thread[] = [];
+    let current = activeThread.parentId ? threadMap.get(activeThread.parentId) : undefined;
+    while (current) {
+      crumbs.unshift(current);
+      current = current.parentId ? threadMap.get(current.parentId) : undefined;
+    }
+    return crumbs;
+  }, [activeThread, threads]);
 
   return (
-    <header className="flex items-center justify-between border-b border-border bg-background px-3 py-3 md:px-4">
-      <div className="flex min-w-0 items-center gap-2 md:gap-3">
-        {/* Thread sidebar toggle */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              onClick={onToggleThreadSidebar}
-              aria-label={threadSidebarOpen ? "Hide threads" : "Show threads"}
-            >
-              {threadSidebarOpen ? (
-                <PanelLeftCloseIcon className="size-4 text-muted-foreground" />
-              ) : (
-                <PanelLeftIcon className="size-4 text-muted-foreground" />
-              )}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            {threadSidebarOpen ? "Hide threads" : "Show threads"}
-          </TooltipContent>
-        </Tooltip>
+    <header className="flex flex-col border-b border-border bg-background">
+      {/* Breadcrumb — only for child threads */}
+      {breadcrumb.length > 0 && onSelectThread && (
+        <div className="flex items-center gap-1 border-b border-border/50 px-3 py-1.5 md:px-4">
+          <GitBranchIcon className="size-3 shrink-0 text-muted-foreground/60" />
+          {breadcrumb.map((ancestor, i) => (
+            <span key={ancestor.id} className="flex items-center gap-1">
+              {i > 0 && <ChevronRightIcon className="size-3 text-muted-foreground/40" />}
+              <button
+                onClick={() => onSelectThread(ancestor.id)}
+                className="text-[11px] text-muted-foreground hover:text-foreground transition-colors truncate max-w-32"
+              >
+                {ancestor.title}
+              </button>
+            </span>
+          ))}
+          <ChevronRightIcon className="size-3 text-muted-foreground/40" />
+          <span className="text-[11px] text-foreground font-medium truncate max-w-32">
+            {activeThread?.title}
+          </span>
+        </div>
+      )}
 
-        <h1 className="truncate font-mono text-sm font-medium text-foreground">
-          {activeThread?.title ?? "Chat"}
-        </h1>
-        {agents.length > 1 && (
-          <select
-            value={selectedAgent ?? ""}
-            onChange={(e) =>
-              onSelectAgent(e.target.value || undefined)
-            }
-            className="rounded-md border border-border bg-muted/30 px-2 py-1 text-xs text-muted-foreground outline-none transition-colors focus:border-primary/50"
-          >
-            <option value="">Default Agent</option>
-            {agents.map((a) => (
-              <option key={a.name} value={a.name}>
-                {a.displayName ?? a.name}
-              </option>
-            ))}
-          </select>
-        )}
-      </div>
-      <div className="flex items-center gap-1.5">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant={showMemories ? "secondary" : "ghost"}
-              size="sm"
-              onClick={onToggleMemories}
-              className={cn(
-                showMemories && "bg-primary/15 text-primary hover:bg-primary/20",
-              )}
-            >
-              <BrainIcon className="size-3.5" />
-              <span className="hidden text-xs md:inline">
-                Memories
-                {memoryCount > 0 && ` (${memoryCount})`}
-              </span>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Toggle memory sidebar</TooltipContent>
-        </Tooltip>
-
-        {activeThreadId && (
+      {/* Main header row */}
+      <div className="flex items-center justify-between px-3 py-3 md:px-4">
+        <div className="flex min-w-0 items-center gap-2 md:gap-3">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
                 variant="ghost"
                 size="icon-sm"
-                onClick={onClear}
+                onClick={onToggleThreadSidebar}
+                aria-label={threadSidebarOpen ? "Hide threads" : "Show threads"}
               >
-                <Trash2Icon className="size-3.5 text-muted-foreground" />
+                {threadSidebarOpen ? (
+                  <PanelLeftCloseIcon className="size-4 text-muted-foreground" />
+                ) : (
+                  <PanelLeftIcon className="size-4 text-muted-foreground" />
+                )}
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Clear messages</TooltipContent>
+            <TooltipContent>
+              {threadSidebarOpen ? "Hide threads" : "Show threads"}
+            </TooltipContent>
           </Tooltip>
-        )}
+
+          <h1 className="truncate font-mono text-sm font-medium text-foreground">
+            {activeThread?.title ?? "Chat"}
+          </h1>
+          {agents.length > 1 && (
+            <select
+              value={selectedAgent ?? ""}
+              onChange={(e) =>
+                onSelectAgent(e.target.value || undefined)
+              }
+              className="rounded-md border border-border bg-muted/30 px-2 py-1 text-xs text-muted-foreground outline-none transition-colors focus:border-primary/50"
+            >
+              <option value="">Default Agent</option>
+              {agents.map((a) => (
+                <option key={a.name} value={a.name}>
+                  {a.displayName ?? a.name}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant={showMemories ? "secondary" : "ghost"}
+                size="sm"
+                onClick={onToggleMemories}
+                className={cn(
+                  showMemories && "bg-primary/15 text-primary hover:bg-primary/20",
+                )}
+              >
+                <BrainIcon className="size-3.5" />
+                <span className="hidden text-xs md:inline">
+                  Memories
+                  {memoryCount > 0 && ` (${memoryCount})`}
+                </span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Toggle memory sidebar</TooltipContent>
+          </Tooltip>
+
+          {activeThreadId && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={onClear}
+                >
+                  <Trash2Icon className="size-3.5 text-muted-foreground" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Clear messages</TooltipContent>
+            </Tooltip>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/packages/ui/src/components/chat/ThreadSidebar.tsx
+++ b/packages/ui/src/components/chat/ThreadSidebar.tsx
@@ -81,8 +81,8 @@ export function ThreadSidebar({
   isOpen,
   onToggle,
 }: ThreadSidebarProps) {
-  const timezone = useAppTimezone();
   const { data: threads = [], isLoading: threadsLoading } = useThreads();
+  const timezone = useAppTimezone();
   const deleteThreadMut = useDeleteThread();
   const renameThreadMut = useRenameThread();
   const clearAllMut = useClearAllThreads();
@@ -90,7 +90,18 @@ export function ThreadSidebar({
   const [renamingThreadId, setRenamingThreadId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const [sidebarWidth, setSidebarWidth] = useState(224);
   const renameInputRef = useRef<HTMLInputElement>(null);
+
+  const onDragStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startW = sidebarWidth;
+    const onMove = (ev: MouseEvent) => setSidebarWidth(Math.max(160, Math.min(400, startW + ev.clientX - startX)));
+    const onUp = () => { document.removeEventListener("mousemove", onMove); document.removeEventListener("mouseup", onUp); };
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  }, [sidebarWidth]);
 
   useEffect(() => {
     if (renamingThreadId) {
@@ -189,14 +200,14 @@ export function ThreadSidebar({
             if (renamingThreadId !== thread.id) onSelectThread(thread.id);
           }}
           className={cn(
-            "group flex cursor-pointer items-center justify-between border-b border-border/50 py-2.5 pr-3 transition-colors",
+            "group flex cursor-pointer items-center justify-between border-b border-border/30 py-1.5 pr-2 transition-colors",
             thread.id === activeThreadId
               ? "bg-primary/10 text-foreground"
               : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
           )}
-          style={{ paddingLeft: 12 + depth * 16 }}
+          style={{ paddingLeft: 10 + depth * 14 }}
         >
-          <div className="min-w-0 flex-1 flex items-center gap-1.5">
+          <div className="min-w-0 flex-1 flex items-center gap-1">
             {/* Expand/collapse toggle */}
             {hasChildren ? (
               <button
@@ -237,21 +248,14 @@ export function ThreadSidebar({
                 </div>
               ) : (
                 <>
-                  <div className="truncate text-xs font-medium">{thread.title}</div>
-                  <div className="mt-0.5 flex items-center gap-1.5 text-[10px] text-muted-foreground/70">
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    <span className="shrink-0 text-[10px] text-muted-foreground/50">{formatWithTimezone(parseApiDate(thread.updatedAt), { month: "short", day: "numeric" }, timezone)}</span>
+                    <span className="truncate text-xs font-medium">{thread.title}</span>
                     {thread.messageCount > 0 && (
-                      <Badge variant="secondary" className="h-4 px-1 text-[9px]">
+                      <Badge variant="secondary" className="h-4 shrink-0 px-1 text-[9px]">
                         {thread.messageCount}
                       </Badge>
                     )}
-                    {hasChildren && (
-                      <Badge variant="outline" className="h-4 px-1 text-[9px]">
-                        {children.length} branch{children.length !== 1 ? "es" : ""}
-                      </Badge>
-                    )}
-                    <span>
-                      {formatWithTimezone(parseApiDate(thread.updatedAt), { month: "short", day: "numeric" }, timezone)}
-                    </span>
                   </div>
                 </>
               )}
@@ -300,7 +304,7 @@ export function ThreadSidebar({
 
   const sidebarContent = (
     <>
-      <div className="flex items-center justify-between gap-2 px-3 py-3 pl-4">
+      <div className="flex items-center justify-between gap-2 px-3 py-2 pl-4">
         <span className="flex min-w-0 items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           <span className="shrink-0">Threads</span>
           <InfoBubble text="Each thread is a separate conversation. Branch a thread to explore a different direction while keeping the original." side="right" />
@@ -375,8 +379,9 @@ export function ThreadSidebar({
   if (!isOpen) return null;
 
   return (
-    <aside className="relative z-30 flex w-56 flex-col overflow-hidden border-r border-border bg-background">
+    <aside className="relative z-30 flex flex-col overflow-hidden border-r border-border bg-background" style={{ width: sidebarWidth }}>
       {sidebarContent}
+      <div onMouseDown={onDragStart} className="absolute right-0 top-0 h-full w-1.5 cursor-col-resize hover:bg-primary/20 active:bg-primary/30 transition-colors" />
     </aside>
   );
 }

--- a/packages/ui/src/components/chat/ThreadSidebar.tsx
+++ b/packages/ui/src/components/chat/ThreadSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { toast } from "sonner";
 import {
   MoreHorizontalIcon,
@@ -7,6 +7,8 @@ import {
   PencilIcon,
   CheckIcon,
   XIcon,
+  ChevronRightIcon,
+  GitBranchIcon,
 } from "lucide-react";
 import {
   useThreads,
@@ -41,6 +43,7 @@ interface ThreadSidebarProps {
   activeThreadId: string | null;
   onSelectThread: (threadId: string) => void;
   onNewThread: () => void;
+  onBranchThread: (parentId: string) => void;
   onThreadDeleted: (threadId: string) => void;
   onAllThreadsCleared: () => void;
   isStreaming: boolean;
@@ -49,10 +52,28 @@ interface ThreadSidebarProps {
   onToggle: () => void;
 }
 
+/** Build a tree from flat thread list */
+function buildTree(threads: Thread[]): { roots: Thread[]; childrenMap: Map<string, Thread[]> } {
+  const childrenMap = new Map<string, Thread[]>();
+  const roots: Thread[] = [];
+
+  for (const t of threads) {
+    if (t.parentId) {
+      const siblings = childrenMap.get(t.parentId) ?? [];
+      siblings.push(t);
+      childrenMap.set(t.parentId, siblings);
+    } else {
+      roots.push(t);
+    }
+  }
+  return { roots, childrenMap };
+}
+
 export function ThreadSidebar({
   activeThreadId,
   onSelectThread,
   onNewThread,
+  onBranchThread,
   onThreadDeleted,
   onAllThreadsCleared,
   isStreaming,
@@ -68,15 +89,38 @@ export function ThreadSidebar({
 
   const [renamingThreadId, setRenamingThreadId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   const renameInputRef = useRef<HTMLInputElement>(null);
 
-  // Focus rename input when entering rename mode
   useEffect(() => {
     if (renamingThreadId) {
       renameInputRef.current?.focus();
       renameInputRef.current?.select();
     }
   }, [renamingThreadId]);
+
+  // Auto-expand the active thread's ancestors
+  useEffect(() => {
+    if (!activeThreadId || !threads.length) return;
+    const parentMap = new Map(threads.map(t => [t.id, t.parentId]));
+    const toExpand = new Set<string>();
+    let current = parentMap.get(activeThreadId);
+    while (current) {
+      toExpand.add(current);
+      current = parentMap.get(current);
+    }
+    if (toExpand.size) setExpanded(prev => new Set([...prev, ...toExpand]));
+  }, [activeThreadId, threads]);
+
+  const { roots, childrenMap } = useMemo(() => buildTree(threads), [threads]);
+
+  const toggleExpand = useCallback((id: string) => {
+    setExpanded(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }, []);
 
   const handleDeleteThread = useCallback(
     async (threadId: string) => {
@@ -124,12 +168,142 @@ export function ThreadSidebar({
     }
   }, [clearAllMut, onAllThreadsCleared]);
 
+  const renderThread = (thread: Thread, depth: number) => {
+    const children = childrenMap.get(thread.id) ?? [];
+    const hasChildren = children.length > 0;
+    const isExpanded = expanded.has(thread.id);
+    const isBranch = !!thread.parentId;
+
+    return (
+      <div key={thread.id}>
+        <div
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              if (renamingThreadId !== thread.id) onSelectThread(thread.id);
+            }
+          }}
+          onClick={() => {
+            if (renamingThreadId !== thread.id) onSelectThread(thread.id);
+          }}
+          className={cn(
+            "group flex cursor-pointer items-center justify-between border-b border-border/50 py-2.5 pr-3 transition-colors",
+            thread.id === activeThreadId
+              ? "bg-primary/10 text-foreground"
+              : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+          )}
+          style={{ paddingLeft: 12 + depth * 16 }}
+        >
+          <div className="min-w-0 flex-1 flex items-center gap-1.5">
+            {/* Expand/collapse toggle */}
+            {hasChildren ? (
+              <button
+                onClick={(e) => { e.stopPropagation(); toggleExpand(thread.id); }}
+                className="shrink-0 p-0.5 rounded hover:bg-accent"
+              >
+                <ChevronRightIcon className={cn("size-3 transition-transform", isExpanded && "rotate-90")} />
+              </button>
+            ) : (
+              <span className="w-4 shrink-0" />
+            )}
+
+            {/* Branch icon for child threads */}
+            {isBranch && <GitBranchIcon className="size-3 shrink-0 text-muted-foreground/50" />}
+
+            <div className="min-w-0 flex-1">
+              {renamingThreadId === thread.id ? (
+                <div className="flex items-center gap-1">
+                  <input
+                    ref={renameInputRef}
+                    type="text"
+                    value={renameValue}
+                    onChange={(e) => setRenameValue(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") { e.preventDefault(); handleConfirmRename(); }
+                      if (e.key === "Escape") handleCancelRename();
+                    }}
+                    onBlur={handleConfirmRename}
+                    className="w-full rounded border border-primary/50 bg-background px-1 py-0.5 text-xs text-foreground outline-none"
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                  <Button variant="ghost" size="icon-xs" onClick={(e) => { e.stopPropagation(); handleConfirmRename(); }}>
+                    <CheckIcon className="size-3" />
+                  </Button>
+                  <Button variant="ghost" size="icon-xs" onClick={(e) => { e.stopPropagation(); handleCancelRename(); }}>
+                    <XIcon className="size-3" />
+                  </Button>
+                </div>
+              ) : (
+                <>
+                  <div className="truncate text-xs font-medium">{thread.title}</div>
+                  <div className="mt-0.5 flex items-center gap-1.5 text-[10px] text-muted-foreground/70">
+                    {thread.messageCount > 0 && (
+                      <Badge variant="secondary" className="h-4 px-1 text-[9px]">
+                        {thread.messageCount}
+                      </Badge>
+                    )}
+                    {hasChildren && (
+                      <Badge variant="outline" className="h-4 px-1 text-[9px]">
+                        {children.length} branch{children.length !== 1 ? "es" : ""}
+                      </Badge>
+                    )}
+                    <span>
+                      {formatWithTimezone(parseApiDate(thread.updatedAt), { month: "short", day: "numeric" }, timezone)}
+                    </span>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+
+          {renamingThreadId !== thread.id && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  className="ml-1 shrink-0 text-muted-foreground"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <MoreHorizontalIcon className="size-3.5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-36">
+                <DropdownMenuItem onClick={(e) => { e.stopPropagation(); handleStartRename(thread); }}>
+                  <PencilIcon />
+                  Rename
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onBranchThread(thread.id); }}>
+                  <GitBranchIcon />
+                  Branch
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  variant="destructive"
+                  onClick={(e) => { e.stopPropagation(); handleDeleteThread(thread.id); }}
+                >
+                  <Trash2Icon />
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+
+        {/* Render children if expanded */}
+        {hasChildren && isExpanded && children.map(child => renderThread(child, depth + 1))}
+      </div>
+    );
+  };
+
   const sidebarContent = (
     <>
       <div className="flex items-center justify-between gap-2 px-3 py-3 pl-4">
         <span className="flex min-w-0 items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           <span className="shrink-0">Threads</span>
-          <InfoBubble text="Each thread is a separate conversation. Your chat history is preserved when you switch between threads." side="right" />
+          <InfoBubble text="Each thread is a separate conversation. Branch a thread to explore a different direction while keeping the original." side="right" />
         </span>
         <div className="flex items-center gap-1">
           <Tooltip>
@@ -182,137 +356,11 @@ export function ThreadSidebar({
           </p>
         )}
 
-        {!threadsLoading &&
-          threads.map((thread) => (
-            <div
-              key={thread.id}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  if (renamingThreadId !== thread.id) onSelectThread(thread.id);
-                }
-              }}
-              onClick={() => {
-                if (renamingThreadId !== thread.id) {
-                  onSelectThread(thread.id);
-                }
-              }}
-              className={cn(
-                "group flex cursor-pointer items-center justify-between border-b border-border/50 px-3 py-2.5 transition-colors",
-                thread.id === activeThreadId
-                  ? "bg-primary/10 text-foreground"
-                  : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-              )}
-            >
-              <div className="min-w-0 flex-1">
-                {renamingThreadId === thread.id ? (
-                  <div className="flex items-center gap-1">
-                    <input
-                      ref={renameInputRef}
-                      type="text"
-                      value={renameValue}
-                      onChange={(e) => setRenameValue(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") {
-                          e.preventDefault();
-                          handleConfirmRename();
-                        }
-                        if (e.key === "Escape") {
-                          handleCancelRename();
-                        }
-                      }}
-                      onBlur={handleConfirmRename}
-                      className="w-full rounded border border-primary/50 bg-background px-1 py-0.5 text-xs text-foreground outline-none"
-                      onClick={(e) => e.stopPropagation()}
-                    />
-                    <Button
-                      variant="ghost"
-                      size="icon-xs"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleConfirmRename();
-                      }}
-                    >
-                      <CheckIcon className="size-3" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon-xs"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleCancelRename();
-                      }}
-                    >
-                      <XIcon className="size-3" />
-                    </Button>
-                  </div>
-                ) : (
-                  <>
-                    <div className="truncate text-xs font-medium">
-                      {thread.title}
-                    </div>
-                    <div className="mt-0.5 flex items-center gap-1.5 text-[10px] text-muted-foreground/70">
-                      {thread.messageCount > 0 && (
-                        <Badge
-                          variant="secondary"
-                          className="h-4 px-1 text-[9px]"
-                        >
-                          {thread.messageCount}
-                        </Badge>
-                      )}
-                      <span>
-                        {formatWithTimezone(parseApiDate(thread.updatedAt), { month: "short", day: "numeric" }, timezone)}
-                      </span>
-                    </div>
-                  </>
-                )}
-              </div>
-
-              {renamingThreadId !== thread.id && (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon-xs"
-                      className="ml-1 shrink-0 text-muted-foreground"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <MoreHorizontalIcon className="size-3.5" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-36">
-                    <DropdownMenuItem
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleStartRename(thread);
-                      }}
-                    >
-                      <PencilIcon />
-                      Rename
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      variant="destructive"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleDeleteThread(thread.id);
-                      }}
-                    >
-                      <Trash2Icon />
-                      Delete
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
-            </div>
-          ))}
+        {!threadsLoading && roots.map(thread => renderThread(thread, 0))}
       </div>
     </>
   );
 
-  // Mobile: use Sheet drawer
   if (isMobile) {
     return (
       <Sheet open={isOpen} onOpenChange={(open) => { if (!open) onToggle(); }}>
@@ -324,7 +372,6 @@ export function ThreadSidebar({
     );
   }
 
-  // Desktop: inline sidebar
   if (!isOpen) return null;
 
   return (

--- a/packages/ui/src/hooks/use-threads.ts
+++ b/packages/ui/src/hooks/use-threads.ts
@@ -42,6 +42,17 @@ export function useCreateThread() {
   });
 }
 
+export function useBranchThread() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { parentId: string; forkMessageId: string; title?: string }) =>
+      createThread(input.title, undefined, input.parentId, input.forkMessageId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: threadKeys.all });
+    },
+  });
+}
+
 export function useDeleteThread() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/packages/ui/src/pages/Chat.tsx
+++ b/packages/ui/src/pages/Chat.tsx
@@ -59,6 +59,7 @@ export default function Chat() {
         setActiveThreadId={setActiveThreadId}
         activeThreadIdRef={activeThreadIdRef}
         activeThread={activeThread}
+        threads={threads}
         selectedAgent={selectedAgent}
         setSelectedAgent={setSelectedAgent}
         showMemories={showMemories}
@@ -83,6 +84,7 @@ function ChatInner({
   setActiveThreadId,
   activeThreadIdRef,
   activeThread,
+  threads,
   selectedAgent,
   setSelectedAgent,
   showMemories,
@@ -98,6 +100,7 @@ function ChatInner({
   setActiveThreadId: (id: string | null) => void;
   activeThreadIdRef: React.MutableRefObject<string | null>;
   activeThread: Thread | undefined;
+  threads: Thread[];
   selectedAgent: string | undefined;
   setSelectedAgent: (agent: string | undefined) => void;
   showMemories: boolean;
@@ -226,6 +229,27 @@ function ChatInner({
     if (isMobile) setThreadSidebarOpen(false);
   }, [isStreaming, selectedAgent, isMobile, setActiveThreadId, activeThreadIdRef, setThreadSidebarOpen, queryClient, handleRef]);
 
+  // Listen for branch events from assistant message action bar
+  useEffect(() => {
+    const handler = async (e: Event) => {
+      const { messageId, sequence } = (e as CustomEvent).detail;
+      if (!activeThreadId) return;
+      const title = activeThread ? `Branch of ${activeThread.title}` : "New branch";
+      const thread = await createThread(title, selectedAgent, activeThreadId, messageId, sequence);
+      queryClient.invalidateQueries({ queryKey: threadKeys.all });
+      // Load the branched thread with its copied messages
+      const history = await getChatHistory(thread.id);
+      const mapHistory = (h: { role: string; content: string }[]) =>
+        h.map((m, i) => ({ id: `hist-${thread.id}-${i}`, role: m.role as "user" | "assistant", parts: [{ type: "text" as const, text: m.content }], createdAt: new Date() }));
+      setActiveThreadId(thread.id);
+      activeThreadIdRef.current = thread.id;
+      handleRef.current?.setChatMessages([]);
+      handleRef.current?.setChatMessages(mapHistory(history));
+    };
+    window.addEventListener("pai:branch-thread", handler);
+    return () => window.removeEventListener("pai:branch-thread", handler);
+  }, [activeThreadId, activeThread, selectedAgent, setActiveThreadId, activeThreadIdRef, queryClient, handleRef]);
+
   const handleThreadDeleted = useCallback(
     (threadId: string) => {
       if (activeThreadId === threadId) {
@@ -260,6 +284,22 @@ function ChatInner({
         activeThreadId={activeThreadId}
         onSelectThread={switchThread}
         onNewThread={handleNewThread}
+        onBranchThread={async (parentId) => {
+          const parent = threads?.find(t => t.id === parentId);
+          const title = parent ? `Branch of ${parent.title}` : "New branch";
+          const thread = await createThread(title, selectedAgent, parentId);
+          queryClient.invalidateQueries({ queryKey: threadKeys.all });
+          // Load copied messages into the UI
+          const history = await getChatHistory(thread.id);
+          const mapped = history.map((m: { role: string; content: string }, i: number) => ({
+            id: `hist-${thread.id}-${i}`, role: m.role as "user" | "assistant",
+            parts: [{ type: "text" as const, text: m.content }], createdAt: new Date(),
+          }));
+          setActiveThreadId(thread.id);
+          activeThreadIdRef.current = thread.id;
+          handleRef.current?.setChatMessages([]);
+          handleRef.current?.setChatMessages(mapped);
+        }}
         onThreadDeleted={handleThreadDeleted}
         onAllThreadsCleared={handleAllThreadsCleared}
         isStreaming={isStreaming ?? false}
@@ -281,6 +321,7 @@ function ChatInner({
           onToggleMemories={() => setShowMemories(!showMemories)}
           memoryCount={memoryCount}
           onClear={handleClear}
+          onSelectThread={switchThread}
         />
 
         {/* assistant-ui Thread handles messages, composer, auto-scroll, tool rendering */}

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -141,6 +141,10 @@ export interface Thread {
   updatedAt: string;
   messageCount: number;
   lastMessage?: string;
+  parentId?: string | null;
+  forkMessageId?: string | null;
+  depth?: number;
+  childCount?: number;
 }
 
 export interface ThreadMessage {


### PR DESCRIPTION
Adds tree-structured threads to pai's chat. Branch a conversation at any message to explore a different direction while keeping the original intact.

## Backend
- DB migration v5: `parent_id`, `fork_message_id`, `fork_message_sequence`, `depth` columns on threads table
- `createThread` accepts `parentId` + `forkSequence`, copies messages up to branch point into child thread
- `getAncestors()` / `getChildren()` helpers + `GET /api/threads/:id/ancestors` and `/children` endpoints
- Chat handler injects parent thread context (last 10 messages before branch point) as system message for branched threads
- Max nesting depth: 5. Deleting a parent orphans children (they become root threads)

## Frontend
- Thread sidebar renders as an indented tree with expand/collapse chevrons
- Branch icon (`GitBranch`) on child threads, "N branches" badge on parents
- Auto-expands ancestors of the active thread
- ChatHeader shows clickable breadcrumb navigation for child threads
- "Branch from here" in assistant message `⋯` menu — creates child thread with messages copied up to that point
- "Branch" in thread sidebar dropdown — creates child thread with all messages copied
- Both paths load the copied messages into the UI immediately

## Migration
All existing threads become root threads (`parent_id=NULL`, `depth=0`). No data migration needed — purely additive.

## How to use
1. Open a chat, send some messages
2. Hover an assistant reply → `⋯` → "Branch from here"
3. New thread appears nested in sidebar with conversation up to that point
4. Continue the conversation in a new direction
5. Click breadcrumb to navigate back to parent