### PR TITLE
fix: strip LLM enrichment instructions from goals before embedding in briefs

### DIFF
--- a/packages/core/src/brief-schema.ts
+++ b/packages/core/src/brief-schema.ts
@@ -67,6 +67,16 @@ interface BuildReportBriefSectionInput {
   actionSummary?: ReportBriefActionSummaryInput | null;
 }
 
+/**
+ * Strip LLM enrichment instructions that buildEnrichedResearchGoal appends.
+ * These are internal prompts that should never appear in user-facing briefs.
+ */
+export function stripEnrichmentFromGoal(goal: string): string {
+  const marker = "\n\nIMPORTANT — PREVIOUS FINDINGS";
+  const idx = goal.indexOf(marker);
+  return idx === -1 ? goal : goal.slice(0, idx).trim();
+}
+
 function firstMeaningfulLine(report: string): string | null {
   return report
     .split("\n")
@@ -102,10 +112,13 @@ function structuredRecommendation(parsed: Record<string, unknown> | null): strin
 }
 
 export function buildReportBriefSection(input: BuildReportBriefSectionInput): StandardBriefSection {
+  // Strip any LLM enrichment instructions from the goal so they don't
+  // leak into user-visible brief fields (Telegram, PDF, etc.).
+  const cleanGoal = stripEnrichmentFromGoal(input.goal);
   const structured = parseStructuredResult(input.structuredResult);
   const recommendationSummary = structuredRecommendation(structured)
     ?? firstMeaningfulLine(input.report)
-    ?? `Review the latest ${input.execution === "analysis" ? "analysis" : "research"} for ${input.goal}.`;
+    ?? `Review the latest ${input.execution === "analysis" ? "analysis" : "research"} for ${cleanGoal}.`;
   const actionSummary = input.actionSummary;
   const staleFollowThrough = actionSummary && actionSummary.staleOpenCount > 0;
 
@@ -159,18 +172,18 @@ export function buildReportBriefSection(input: BuildReportBriefSectionInput): St
   }
 
   return {
-    title: input.program?.title ?? input.goal,
+    title: input.program?.title ?? cleanGoal,
     recommendation: {
       summary: staleFollowThrough
-        ? `Resolve the stale linked action before changing the recommendation for ${input.program?.title ?? input.goal}.`
+        ? `Resolve the stale linked action before changing the recommendation for ${input.program?.title ?? cleanGoal}.`
         : recommendationSummary,
       confidence: staleFollowThrough ? "high" : structuredRecommendation(structured) ? "high" : "medium",
       rationale: staleFollowThrough
         ? `${actionSummary!.staleOpenCount} linked action${actionSummary!.staleOpenCount === 1 ? "" : "s"} are stale, so follow-through should be closed before broadening the watch.`
-        : `This brief summarizes the latest ${input.execution === "analysis" ? "analysis" : "research"} run for ${input.goal}${input.program?.objective ? ` against the objective "${input.program.objective}".` : "."}`,
+        : `This brief summarizes the latest ${input.execution === "analysis" ? "analysis" : "research"} run for ${cleanGoal}${input.program?.objective ? ` against the objective "${input.program.objective}".` : "."}`,
     },
     what_changed: [
-      `A new ${input.execution === "analysis" ? "analysis" : "research"} run completed for ${input.goal}.`,
+      `A new ${input.execution === "analysis" ? "analysis" : "research"} run completed for ${cleanGoal}.`,
       ...(actionSummary && actionSummary.openCount > 0
         ? [`${actionSummary.openCount} linked action${actionSummary.openCount === 1 ? "" : "s"} remain open for this Program.`]
         : []),
@@ -191,7 +204,7 @@ export function buildReportBriefSection(input: BuildReportBriefSectionInput): St
     correction_hook: {
       prompt: "If this recommendation or one of its assumptions is wrong, correct it so the next brief improves.",
     },
-    goal: input.goal,
+    goal: cleanGoal,
     report: input.report,
     execution: input.execution,
     resultType: input.resultType ?? "general",
@@ -199,7 +212,7 @@ export function buildReportBriefSection(input: BuildReportBriefSectionInput): St
     renderSpec: input.renderSpec ?? undefined,
     visuals: input.visuals ?? [],
     appendix: {
-      goal: input.goal,
+      goal: cleanGoal,
       report: input.report,
       execution: input.execution,
       resultType: input.resultType ?? "general",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -100,7 +100,7 @@ export type { Owner } from "./auth.js";
 // Research schemas
 export { detectResearchDomain } from "./research-schemas.js";
 export type { FlightQuery, FlightOption, FlightReport, StockMetrics, ChartArtifact, StockReport, ResearchResult, ResearchResultType } from "./research-schemas.js";
-export { buildReportBriefSection, buildBriefSignalHash } from "./brief-schema.js";
+export { buildReportBriefSection, buildBriefSignalHash, stripEnrichmentFromGoal } from "./brief-schema.js";
 export type { StandardBriefSection } from "./brief-schema.js";
 export {
   extractPresentationBlocks,

--- a/packages/core/test/brief-schema.test.ts
+++ b/packages/core/test/brief-schema.test.ts
@@ -1,6 +1,22 @@
 import { describe, expect, it } from "vitest";
 
-import { buildBriefSignalHash, buildReportBriefSection } from "../src/brief-schema.js";
+import { buildBriefSignalHash, buildReportBriefSection, stripEnrichmentFromGoal } from "../src/brief-schema.js";
+
+describe("stripEnrichmentFromGoal", () => {
+  it("returns the original goal when no enrichment is present", () => {
+    expect(stripEnrichmentFromGoal("Track H4 visa appointments")).toBe("Track H4 visa appointments");
+  });
+
+  it("strips LLM enrichment instructions appended by buildEnrichedResearchGoal", () => {
+    const enriched =
+      "Track H4 visa appointments\n\n" +
+      "IMPORTANT — PREVIOUS FINDINGS (do NOT repeat these):\n" +
+      "No new slots available.\n\n" +
+      "Focus ONLY on what is NEW or CHANGED since 2026-03-14. " +
+      "If nothing meaningful changed, say so in one sentence instead of restating old findings.";
+    expect(stripEnrichmentFromGoal(enriched)).toBe("Track H4 visa appointments");
+  });
+});
 
 describe("brief-schema", () => {
   it("prefers a structured recommendation and carries program context into the brief", () => {
@@ -133,6 +149,28 @@ describe("brief-schema", () => {
       timing: "Now",
       detail: "Resolve the overdue linked action before changing the watch scope or recommendation.",
     }]);
+  });
+
+  it("strips enrichment instructions from goal so they do not leak into briefs", () => {
+    const enrichedGoal =
+      "Track H4 visa appointments\n\n" +
+      "IMPORTANT — PREVIOUS FINDINGS (do NOT repeat these):\n" +
+      "No new slots available.\n\n" +
+      "Focus ONLY on what is NEW or CHANGED since 2026-03-14. " +
+      "If nothing meaningful changed, say so in one sentence instead of restating old findings.";
+
+    const section = buildReportBriefSection({
+      goal: enrichedGoal,
+      execution: "research",
+      report: "No meaningful changes have been reported.",
+    });
+
+    // None of the user-facing fields should contain the enrichment text
+    expect(section.title).toBe("Track H4 visa appointments");
+    expect(section.goal).toBe("Track H4 visa appointments");
+    expect(section.appendix?.goal).toBe("Track H4 visa appointments");
+    expect(section.recommendation.rationale).not.toContain("PREVIOUS FINDINGS");
+    expect(section.what_changed[0]).not.toContain("PREVIOUS FINDINGS");
   });
 
   it("builds stable signal hashes from normalized brief fields", () => {


### PR DESCRIPTION
The buildEnrichedResearchGoal function appends internal LLM instructions
(like "Focus ONLY on what is NEW or CHANGED...") to the goal string.
This enriched goal was then passed through to buildReportBriefSection,
which embedded it in user-visible fields: title, recommendation,
what_changed, goal, and appendix. This caused the system prompt to
leak into Telegram messages and PDF reports.

The fix adds stripEnrichmentFromGoal() which removes the enrichment
suffix before the goal is used in any brief field. The enriched goal
still reaches the LLM for better research focus, but never appears
in user-facing output.

https://claude.ai/code/session_01Qoj4QqYL9tqvg2Qq9h3kmM