### PR TITLE
Suppress placeholder/meta lines in briefs and watch summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Image attachment support in chat** — JPG, PNG, GIF, and WebP images can now be uploaded in chat and are passed as multimodal image parts to the LLM. Knowledge page also accepts image uploads.
 
 ### Fixed
+- **Watch/brief placeholder text suppression** — Brief generation and watch summary parsing now filter meta placeholder lines (e.g. “Let me compile…” / “I need explicit direction…”) so recommendations and “what changed” use substantive findings instead of self-referential filler.
 - **Settings edit no longer clears API tokens** — Saving settings when the LLM API key, Linear API key, or Telegram token was provided via environment variables no longer silently drops those secrets from the config file. Preservation now falls back to the in-memory config (which includes env-var-sourced values).
 - **Scheduled research retries with exponential backoff** — Rate-limited research and swarm jobs now retry up to 3 times with exponential backoff (30s → 60s → 120s) instead of silently failing after 2 immediate retries. Swarm jobs now also retry on transient errors.
 - **Thread titles update when topic changes** — Thread titles now regenerate via LLM every 5 user turns (down from 10), starting at turn 3 (down from 5), using the last 10 messages with a prompt that focuses on the current topic rather than the original message.

--- a/packages/core/src/brief-schema.ts
+++ b/packages/core/src/brief-schema.ts
@@ -85,8 +85,18 @@ function firstMeaningfulLine(report: string): string | null {
   return report
     .split("\n")
     .map((line) => line.trim())
-    .find((line) => line.length > 0 && !line.startsWith("#") && !line.startsWith("|") && !line.startsWith(">"))
+    .find((line) => isBriefContentLine(line))
     ?? null;
+}
+
+const META_BRIEF_LINE_PATTERN =
+  /\b(let me|i (need|would need|can|can't|cannot)|should i|would you like|explicit direction|placeholder|meta[-\s]?commentary|compile the top|top \d+ stories|research findings (aren't|are not) converting)\b/i;
+
+export function isBriefContentLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("|") || trimmed.startsWith(">")) return false;
+  if (META_BRIEF_LINE_PATTERN.test(trimmed)) return false;
+  return true;
 }
 
 /** Extract a short title from the report — first markdown heading or first sentence */
@@ -128,7 +138,8 @@ function structuredRecommendation(parsed: Record<string, unknown> | null): strin
   ];
   for (const candidate of candidates) {
     if (typeof candidate === "string" && candidate.trim().length > 0) {
-      return candidate.trim();
+      const trimmed = candidate.trim();
+      if (isBriefContentLine(trimmed)) return trimmed;
     }
   }
   return null;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -108,7 +108,7 @@ export type { Owner } from "./auth.js";
 // Research schemas
 export { detectResearchDomain } from "./research-schemas.js";
 export type { FlightQuery, FlightOption, FlightReport, StockMetrics, ChartArtifact, StockReport, ResearchResult, ResearchResultType } from "./research-schemas.js";
-export { buildReportBriefSection, buildBriefSignalHash, stripEnrichmentFromGoal } from "./brief-schema.js";
+export { buildReportBriefSection, buildBriefSignalHash, stripEnrichmentFromGoal, isBriefContentLine } from "./brief-schema.js";
 export type { StandardBriefSection } from "./brief-schema.js";
 export {
   extractPresentationBlocks,

--- a/packages/core/test/brief-schema.test.ts
+++ b/packages/core/test/brief-schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildBriefSignalHash, buildReportBriefSection, stripEnrichmentFromGoal } from "../src/brief-schema.js";
+import { buildBriefSignalHash, buildReportBriefSection, isBriefContentLine, stripEnrichmentFromGoal } from "../src/brief-schema.js";
 
 describe("stripEnrichmentFromGoal", () => {
   it("returns the original goal when no enrichment is present", () => {
@@ -208,5 +208,24 @@ describe("brief-schema", () => {
     expect(sameHash).toHaveLength(64);
     expect(sameHashAgain).toBe(sameHash);
     expect(changedHash).not.toBe(sameHash);
+  });
+
+  it("filters meta placeholder lines so recommendation/changes use real content", () => {
+    const section = buildReportBriefSection({
+      goal: "Track daily AI news",
+      execution: "research",
+      report: [
+        "# Daily news",
+        "Let me compile the top 5 stories for you.",
+        "OpenAI released a new safety eval benchmark with reproducible scoring.",
+      ].join("\n"),
+      structuredResult: JSON.stringify({
+        recommendation: "I need explicit direction before I proceed.",
+      }),
+    });
+
+    expect(isBriefContentLine("Let me compile the top 5 stories for you.")).toBe(false);
+    expect(section.recommendation.summary).toBe("OpenAI released a new safety eval benchmark with reproducible scoring.");
+    expect(section.what_changed[0]).toBe("OpenAI released a new safety eval benchmark with reproducible scoring.");
   });
 });

--- a/packages/server/src/routes/programs.ts
+++ b/packages/server/src/routes/programs.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import {
   recordProductEvent,
+  isBriefContentLine,
 } from "@personal-ai/core";
 import {
   listPrograms,
@@ -57,7 +58,8 @@ function parseRecommendationSummary(sectionsRaw: string): string | null {
     const parsed = JSON.parse(sectionsRaw) as Record<string, unknown>;
     const recommendation = parsed.recommendation as Record<string, unknown> | undefined;
     if (recommendation && typeof recommendation.summary === "string" && recommendation.summary.trim().length > 0) {
-      return recommendation.summary;
+      const summary = recommendation.summary.trim();
+      if (isBriefContentLine(summary)) return summary;
     }
     if (typeof parsed.goal === "string" && parsed.goal.trim().length > 0) {
       return parsed.goal;
@@ -66,7 +68,7 @@ function parseRecommendationSummary(sectionsRaw: string): string | null {
       const firstMeaningfulLine = parsed.report
         .split("\n")
         .map((line) => line.trim())
-        .find((line) => line.length > 0 && !line.startsWith("#") && !line.startsWith(">") && !line.startsWith("|"));
+        .find((line) => isBriefContentLine(line));
       return firstMeaningfulLine ?? null;
     }
   } catch {

--- a/packages/server/src/routes/watches.ts
+++ b/packages/server/src/routes/watches.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import {
   recordProductEvent,
+  isBriefContentLine,
 } from "@personal-ai/core";
 import {
   listWatches,
@@ -65,7 +66,8 @@ function parseRecommendationSummary(sectionsRaw: string): string | null {
     const parsed = JSON.parse(sectionsRaw) as Record<string, unknown>;
     const recommendation = parsed.recommendation as Record<string, unknown> | undefined;
     if (recommendation && typeof recommendation.summary === "string" && recommendation.summary.trim().length > 0) {
-      return recommendation.summary;
+      const summary = recommendation.summary.trim();
+      if (isBriefContentLine(summary)) return summary;
     }
     if (typeof parsed.goal === "string" && parsed.goal.trim().length > 0) {
       return parsed.goal;
@@ -74,7 +76,7 @@ function parseRecommendationSummary(sectionsRaw: string): string | null {
       const firstMeaningfulLine = parsed.report
         .split("\n")
         .map((line) => line.trim())
-        .find((line) => line.length > 0 && !line.startsWith("#") && !line.startsWith(">") && !line.startsWith("|"));
+        .find((line) => isBriefContentLine(line));
       return firstMeaningfulLine ?? null;
     }
   } catch {


### PR DESCRIPTION
### Motivation
- Briefs and Watch summaries were sometimes populated with self-referential or placeholder LLM lines (e.g. "Let me compile…", "I need explicit direction…") which produced unhelpful `recommendation` and `what_changed` content in the UI and APIs.

### Description
- Added a new helper `isBriefContentLine()` in `packages/core/src/brief-schema.ts` that rejects meta/placeholder lines and exported it from `@personal-ai/core` via `packages/core/src/index.ts`.
- Wired the filter into `firstMeaningfulLine()` and `structuredRecommendation()` so brief assembly (`buildReportBriefSection`) ignores filler lines when deriving titles, recommendations, and change signals.
- Applied the same filter in server routes `packages/server/src/routes/programs.ts` and `packages/server/src/routes/watches.ts` so API list/card summaries prefer substantive brief content over placeholder text.
- Added a regression test in `packages/core/test/brief-schema.test.ts` and updated `CHANGELOG.md` describing the fix.

### Testing
- Ran `pnpm -s vitest packages/core/test/brief-schema.test.ts` which passed (8 tests).
- Ran full verification `pnpm verify` (typecheck + tests + coverage) which completed successfully (all tests passed in this environment).
- Ran harness scenario `pnpm harness:core-loop` which reported `PASS` for the core-loop harness run.
- `pnpm e2e` failed to run in this environment due to missing Playwright browser binaries (error: Chromium executable not found), so browser E2E could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf40ffeddc832f942d198526e98871)