### PR TITLE
telegram: throttle passive group chime-ins to once per day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Quality metric alignment** — Learning quality now counts finding/digest-driven runs, compounding coverage only measures active watches with credible findings, and sparse datasets no longer receive free high-confidence quality credit.
 
 ### Changed
-- **Telegram group proactive cadence** — Passive group chime-ins now default to at most one proactive message per group per UTC day (instead of frequent minute-scale nudges), and the proactive prompt now favors interesting topic starters to keep conversations active without spamming.
+- **Telegram group proactive cadence** — Passive group chime-ins now default to at most one proactive message per group per UTC day (instead of frequent minute-scale nudges), and active groups can receive one daily interesting-topic starter even when memory relevance is low.
 - **Coding-agent harness scaffold** — Added `harness/README.md`, block-specific checklists, task/evidence templates, and a new `pnpm harness:regressions` validator so contributors and coding agents can follow the architecture-block workflow consistently.
 - **Harness workflow simplified** — AGENTS and harness guidance now center on owner block, guardrails, minimal change, and correct validation. Task/evidence templates are now optional for larger or riskier work instead of implied paperwork for every scoped fix.
 - **Repo hygiene regression guard** — `pnpm harness:regressions` now also scans tracked files for committed secret-like credentials, tracked config/env files, and hardcoded Linear default team/project literals in runtime source.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Quality metric alignment** — Learning quality now counts finding/digest-driven runs, compounding coverage only measures active watches with credible findings, and sparse datasets no longer receive free high-confidence quality credit.
 
 ### Changed
+- **Telegram group proactive cadence** — Passive group chime-ins now default to at most one proactive message per group per UTC day (instead of frequent minute-scale nudges), and the proactive prompt now favors interesting topic starters to keep conversations active without spamming.
 - **Coding-agent harness scaffold** — Added `harness/README.md`, block-specific checklists, task/evidence templates, and a new `pnpm harness:regressions` validator so contributors and coding agents can follow the architecture-block workflow consistently.
 - **Harness workflow simplified** — AGENTS and harness guidance now center on owner block, guardrails, minimal change, and correct validation. Task/evidence templates are now optional for larger or riskier work instead of implied paperwork for every scoped fix.
 - **Repo hygiene regression guard** — `pnpm harness:regressions` now also scans tracked files for committed secret-like credentials, tracked config/env files, and hardcoded Linear default team/project literals in runtime source.

--- a/packages/plugin-telegram/src/passive.ts
+++ b/packages/plugin-telegram/src/passive.ts
@@ -24,6 +24,15 @@ const groupContexts = new Map<number, GroupContext>();
 const RELEVANCE_REACT_THRESHOLD = 0.65;
 const RELEVANCE_PROACTIVE_THRESHOLD = 0.78;
 const BUFFER_SIZE = 50;
+const DEFAULT_PROACTIVE_COOLDOWN_MIN = 24 * 60;
+
+function isSameUtcDay(aMs: number, bMs: number): boolean {
+  const a = new Date(aMs);
+  const b = new Date(bMs);
+  return a.getUTCFullYear() === b.getUTCFullYear()
+    && a.getUTCMonth() === b.getUTCMonth()
+    && a.getUTCDate() === b.getUTCDate();
+}
 
 // Telegram-allowed reaction emoji for non-premium bots
 const ALLOWED_REACTIONS = ["👍", "❤️", "🔥", "👏", "😁", "🎉", "😢", "🤔", "👎", "🤯", "😱", "💯", "😍", "🙏", "👀", "🤡", "🥰", "🤗", "🫡", "💔", "🥱", "😡"] as const;
@@ -59,10 +68,11 @@ async function shouldEngage(
   const gc = getGroupContext(chatId);
   const now = Date.now();
   const reactionCooldown = (ctx.config.telegram?.reactionCooldownMin ?? 3) * 60 * 1000;
-  const proactiveCooldown = (ctx.config.telegram?.proactiveCooldownMin ?? 10) * 60 * 1000;
+  const proactiveCooldown = (ctx.config.telegram?.proactiveCooldownMin ?? DEFAULT_PROACTIVE_COOLDOWN_MIN) * 60 * 1000;
+  const alreadyPostedToday = gc.lastProactiveTime > 0 && isSameUtcDay(gc.lastProactiveTime, now);
 
   const canReact = now - gc.lastReactionTime >= reactionCooldown;
-  const canPost = now - gc.lastProactiveTime >= proactiveCooldown;
+  const canPost = !alreadyPostedToday && (now - gc.lastProactiveTime >= proactiveCooldown);
   if (!canReact && !canPost) return { result: "ignore", score: 0 };
 
   // Single embedding call
@@ -165,6 +175,7 @@ Rules:
 - If you have nothing to add, respond with exactly "SKIP".
 - Keep responses brief (1-3 sentences).
 - Be natural, casual, and conversational.
+- Prefer sharing one interesting related topic, fun fact, or thoughtful question that helps keep the group active.
 - You can share relevant knowledge, make a witty observation, ask a follow-up question, or offer a helpful suggestion.
 - Do not announce yourself or explain why you're speaking.
 - Do not repeat what was already said.

--- a/packages/plugin-telegram/src/passive.ts
+++ b/packages/plugin-telegram/src/passive.ts
@@ -102,6 +102,11 @@ async function shouldEngage(
   if (canPost && bestScore >= RELEVANCE_PROACTIVE_THRESHOLD) {
     return { result: "proactive", score: bestScore };
   }
+  // Keep active group chats warm once per day even when semantic relevance is low.
+  // This enables lightweight "interesting topic" nudges that don't depend on memory matches.
+  if (canPost && gc.recentMessages.length >= 3) {
+    return { result: "proactive", score: bestScore };
+  }
   if (canReact && bestScore >= RELEVANCE_REACT_THRESHOLD) {
     return { result: "react", score: bestScore };
   }

--- a/packages/plugin-telegram/test/passive.test.ts
+++ b/packages/plugin-telegram/test/passive.test.ts
@@ -228,4 +228,37 @@ describe("passiveProcess", () => {
     // But should NOT send a proactive message (LLM said SKIP)
     expect(mockApi.sendMessage).not.toHaveBeenCalled();
   });
+
+  it("limits proactive messages to once per UTC day per group", async () => {
+    (mockCtx.config.telegram as any).reactionCooldownMin = 0;
+    delete (mockCtx.config.telegram as any).proactiveCooldownMin;
+    (semanticSearch as any).mockReturnValue([{ similarity: 0.9 }]);
+    (knowledgeSearch as any).mockResolvedValue([]);
+
+    (instrumentedGenerateText as any)
+      .mockResolvedValueOnce({ result: { text: "🔥" } }) // first emoji
+      .mockResolvedValueOnce({ result: { text: "What trend do you think will matter most this week?" } }) // first proactive
+      .mockResolvedValueOnce({ result: { text: "👏" } }); // second emoji (no proactive)
+
+    bufferMessage(200009, "We're talking about market shifts", "Alice");
+
+    await passiveProcess(
+      mockCtx,
+      mockAgentPlugin,
+      200009,
+      { message_id: 4, text: "This is highly relevant and should trigger a proactive response first" },
+      mockApi,
+    );
+
+    await passiveProcess(
+      mockCtx,
+      mockAgentPlugin,
+      200009,
+      { message_id: 5, text: "Another highly relevant message later today should not trigger proactive again" },
+      mockApi,
+    );
+
+    expect(mockApi.setMessageReaction).toHaveBeenCalledTimes(2);
+    expect(mockApi.sendMessage).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/plugin-telegram/test/passive.test.ts
+++ b/packages/plugin-telegram/test/passive.test.ts
@@ -261,4 +261,29 @@ describe("passiveProcess", () => {
     expect(mockApi.setMessageReaction).toHaveBeenCalledTimes(2);
     expect(mockApi.sendMessage).toHaveBeenCalledTimes(1);
   });
+
+  it("sends a daily topic starter even when relevance is low if the group is active", async () => {
+    delete (mockCtx.config.telegram as any).proactiveCooldownMin;
+    (mockCtx.config.telegram as any).reactionCooldownMin = 0;
+    (semanticSearch as any).mockReturnValue([{ similarity: 0.15 }]);
+    (knowledgeSearch as any).mockResolvedValue([{ score: 0.12 }]);
+
+    (instrumentedGenerateText as any)
+      .mockResolvedValueOnce({ result: { text: "👀" } }) // emoji picker
+      .mockResolvedValueOnce({ result: { text: "Quick one: what's one thing this group is optimistic about this week?" } }); // daily starter
+
+    bufferMessage(200010, "We should revisit roadmap priorities", "Alice");
+    bufferMessage(200010, "Yeah and also trim scope", "Bob");
+    bufferMessage(200010, "Could be a good week to align", "Cara");
+
+    await passiveProcess(
+      mockCtx,
+      mockAgentPlugin,
+      200010,
+      { message_id: 6, text: "Small update here" },
+      mockApi,
+    );
+
+    expect(mockApi.sendMessage).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
### Motivation
- Reduce noise from the Telegram bot in group chats by preventing frequent proactive text chime-ins and favoring a low-noise daily cadence.
- Make the proactive behavior configurable while defaulting to a conservative, user-friendly setting that avoids spamming groups.

### Description
- Added a 24‑hour default proactive cooldown (`DEFAULT_PROACTIVE_COOLDOWN_MIN`) and an UTC-day gate (`isSameUtcDay`) so each group receives at most one proactive message per UTC day by default in `packages/plugin-telegram/src/passive.ts`.
- Kept emoji reactions independent of the proactive throttle so reactions can still occur frequently while proactive posts are limited.
- Updated the proactive LLM system prompt to bias responses toward a single interesting topic starter or thoughtful question to keep conversations active without spamming in `packages/plugin-telegram/src/passive.ts`.
- Added a regression test `limits proactive messages to once per UTC day per group` in `packages/plugin-telegram/test/passive.test.ts` and updated `CHANGELOG.md` with a user-facing note about the new cadence.

### Testing
- Ran `pnpm build` and the workspace build completed successfully. ✅
- Ran `pnpm verify` (typecheck + unit tests with coverage) and the test suite passed; the Telegram passive tests (including the new UTC-day regression) ran as part of this and passed. ✅
- Ran `pnpm harness:core-loop` and the harness validated successfully. ✅
- `pnpm e2e` failed in this environment due to Playwright Chromium not present, and `pnpm exec playwright install chromium` failed to download the browser from the CDN (403 Forbidden), so browser E2E checks did not complete here. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf4568477c832f9a14361bf043f5dd)