### PR TITLE
Suppress duplicate watch briefings when signal is unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Watch/brief placeholder text suppression** — Brief generation and watch summary parsing now filter meta placeholder lines (e.g. “Let me compile…” / “I need explicit direction…”) so recommendations and “what changed” use substantive findings instead of self-referential filler.
+- **Duplicate watch brief spam suppression** — Research and swarm watch runs now skip creating a new briefing when the computed signal hash matches the last delivered briefing, preventing identical day-after-day repeats when nothing materially changed.
 - **Settings edit no longer clears API tokens** — Saving settings when the LLM API key, Linear API key, or Telegram token was provided via environment variables no longer silently drops those secrets from the config file. Preservation now falls back to the in-memory config (which includes env-var-sourced values).
 - **Scheduled research retries with exponential backoff** — Rate-limited research and swarm jobs now retry up to 3 times with exponential backoff (30s → 60s → 120s) instead of silently failing after 2 immediate retries. Swarm jobs now also retry on transient errors.
 - **Recurring job failures now surface to retry logic** — Research and swarm background runners now rethrow terminal execution errors after marking job state, so the dispatcher can apply transient retry/backoff and failure notifications for scheduled runs instead of treating failed runs as successful completions.

--- a/packages/plugin-research/src/research.ts
+++ b/packages/plugin-research/src/research.ts
@@ -707,11 +707,9 @@ export async function runResearchInBackground(
       execution: "research",
     });
 
-    const shouldDeliver = !program
-      || program.deliveryMode !== "change-gated"
-      || !program.lastSignalHash
-      || program.lastSignalHash !== signalHash
-      || !program.latestBriefId;
+    const hasPreviousSignal = !!program?.latestBriefId && !!program?.lastSignalHash;
+    const signalChanged = !hasPreviousSignal || program!.lastSignalHash !== signalHash;
+    const shouldDeliver = !program || signalChanged;
 
     const briefingId = shouldDeliver ? `research-${jobId}` : null;
     try {

--- a/packages/plugin-research/test/research.test.ts
+++ b/packages/plugin-research/test/research.test.ts
@@ -441,6 +441,42 @@ describe("Research jobs", () => {
       expect(lastMsg.role).toBe("assistant");
     });
 
+    it("suppresses duplicate briefings when the signal hash has not changed", async () => {
+      const { generateText } = await import("ai");
+      (generateText as ReturnType<typeof vi.fn>).mockResolvedValue({
+        text: "# Report\n\nNo material change in the market today.",
+        steps: [],
+      });
+
+      storage.run(
+        "INSERT INTO scheduled_jobs (id, label, type, goal, interval_hours, next_run_at, status, delivery_mode) VALUES (?, ?, ?, ?, ?, datetime('now'), 'active', 'interval')",
+        ["watch-dup", "Duplicate Watch", "research", "Track daily updates", 24],
+      );
+
+      const ctx = makeCtx();
+      const first = createResearchJob(storage, {
+        goal: "Track daily updates",
+        threadId: null,
+        sourceScheduleId: "watch-dup",
+      });
+      await runResearchInBackground(ctx, first);
+
+      const second = createResearchJob(storage, {
+        goal: "Track daily updates",
+        threadId: null,
+        sourceScheduleId: "watch-dup",
+      });
+      await runResearchInBackground(ctx, second);
+
+      const rows = storage.query<{ count: number }>(
+        "SELECT COUNT(*) as count FROM briefings WHERE program_id = ?",
+        ["watch-dup"],
+      );
+      expect(rows[0]?.count).toBe(1);
+      expect(getResearchJob(storage, first)?.briefingId).toBeTruthy();
+      expect(getResearchJob(storage, second)?.briefingId).toBeNull();
+    });
+
     it("posts failure message to thread when research fails", async () => {
       const { generateText } = await import("ai");
       (generateText as ReturnType<typeof vi.fn>).mockRejectedValue(

--- a/packages/plugin-swarm/src/swarm.ts
+++ b/packages/plugin-swarm/src/swarm.ts
@@ -326,13 +326,9 @@ export async function runSwarmInBackground(
       resultType: presentation.resultType,
       execution: "analysis",
     });
-    const briefingId = !program
-      || program.deliveryMode !== "change-gated"
-      || !program.lastSignalHash
-      || program.lastSignalHash !== signalHash
-      || !program.latestBriefId
-      ? `swarm-${jobId}`
-      : null;
+    const hasPreviousSignal = !!program?.latestBriefId && !!program?.lastSignalHash;
+    const signalChanged = !hasPreviousSignal || program!.lastSignalHash !== signalHash;
+    const briefingId = !program || signalChanged ? `swarm-${jobId}` : null;
     try {
       if (briefingId) {
         ctx.storage.run(


### PR DESCRIPTION
### Motivation
- Users were receiving identical watch briefings day-after-day when a scheduled run produced no material change, causing inbox spam and noise.
- The change detects whether a newly computed `signal_hash` actually differs from the last delivered one and avoids emitting a new briefing when it does not.

### Description
- Change delivery logic in `packages/plugin-research/src/research.ts` to compute `hasPreviousSignal`/`signalChanged` and only create a new `research-<jobId>` briefing when the signal changed instead of unconditionally on interval runs.
- Apply the same duplicate-signal suppression to swarm analysis in `packages/plugin-swarm/src/swarm.ts`, gating `swarm-<jobId>` brief creation on the signal change.
- Add a regression test in `packages/plugin-research/test/research.test.ts` that runs the same watch twice and asserts only one briefing row is created for the program.
- Update `CHANGELOG.md` with a user-facing note describing the duplicate-brief suppression.

### Testing
- Ran `pnpm verify` (typecheck + unit tests + coverage) and all unit tests passed (`vitest`: 1219 tests passed) and typecheck succeeded. ✅
- Ran the core harness `pnpm harness:core-loop` and the harness report passed. ✅
- Ran `pnpm e2e` which failed in this environment because Playwright browsers are not installed (error: please run `pnpm exec playwright install`), so browser E2E tests did not complete. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d49648dd14832f917abcc19c80eaf6)