### PR TITLE
Filter truncation-diagnostic meta text from research digest recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Watch/brief placeholder text suppression** — Brief generation and watch summary parsing now filter meta placeholder lines (e.g. “Let me compile…” / “I need explicit direction…”) so recommendations and “what changed” use substantive findings instead of self-referential filler.
+- **Research truncation warning leakage in digests** — Brief extraction now also suppresses truncation-diagnostic/meta lines (e.g. “Output truncation blocks delivery”, “pull raw research logs”, token-limit warnings) so recommendation cards show actual findings instead of pipeline troubleshooting text.
 - **Duplicate watch brief spam suppression** — Research and swarm watch runs now skip creating a new briefing when the computed signal hash matches the last delivered briefing, preventing identical day-after-day repeats when nothing materially changed.
 - **Settings edit no longer clears API tokens** — Saving settings when the LLM API key, Linear API key, or Telegram token was provided via environment variables no longer silently drops those secrets from the config file. Preservation now falls back to the in-memory config (which includes env-var-sourced values).
 - **Scheduled research retries with exponential backoff** — Rate-limited research and swarm jobs now retry up to 3 times with exponential backoff (30s → 60s → 120s) instead of silently failing after 2 immediate retries. Swarm jobs now also retry on transient errors.

--- a/packages/core/src/brief-schema.ts
+++ b/packages/core/src/brief-schema.ts
@@ -90,7 +90,7 @@ function firstMeaningfulLine(report: string): string | null {
 }
 
 const META_BRIEF_LINE_PATTERN =
-  /\b(let me|i (need|would need|can|can't|cannot)|should i|would you like|explicit direction|placeholder|meta[-\s]?commentary|compile the top|top \d+ stories|research findings (aren't|are not) converting)\b/i;
+  /\b(let me|i (need|would need|can|can't|cannot)|should i|would you like|explicit direction|placeholder|meta[-\s]?commentary|compile the top|top \d+ stories|research findings (aren't|are not) converting|output truncation|truncated output|token limit|max(?:imum)? (?:token|context) limit|recoverable before .* overwrite|pull raw research logs)\b/i;
 
 export function isBriefContentLine(line: string): boolean {
   const trimmed = line.trim();

--- a/packages/core/test/brief-schema.test.ts
+++ b/packages/core/test/brief-schema.test.ts
@@ -228,4 +228,22 @@ describe("brief-schema", () => {
     expect(section.recommendation.summary).toBe("OpenAI released a new safety eval benchmark with reproducible scoring.");
     expect(section.what_changed[0]).toBe("OpenAI released a new safety eval benchmark with reproducible scoring.");
   });
+
+  it("filters truncation-diagnosis meta lines from report-first recommendations", () => {
+    const section = buildReportBriefSection({
+      goal: "Track daily AI news",
+      execution: "research",
+      report: [
+        "# Daily Digest",
+        "Research Data Exists — Output Truncation Blocks Delivery",
+        "Pull raw research logs from today's runs immediately — output truncation prevents delivery.",
+        "OpenAI released a new model card update with expanded red-team disclosures.",
+      ].join("\n"),
+    });
+
+    expect(isBriefContentLine("Research Data Exists — Output Truncation Blocks Delivery")).toBe(false);
+    expect(isBriefContentLine("Pull raw research logs from today's runs immediately — output truncation prevents delivery.")).toBe(false);
+    expect(section.recommendation.summary).toBe("OpenAI released a new model card update with expanded red-team disclosures.");
+    expect(section.what_changed[0]).toBe("OpenAI released a new model card update with expanded red-team disclosures.");
+  });
 });


### PR DESCRIPTION
### Motivation
- Research/digest reports occasionally included pipeline/troubleshooting lines (e.g. “Output truncation blocks delivery”, token-limit warnings, “pull raw research logs”) which were being picked up as the first "meaningful" line and surfaced as the brief recommendation instead of the actual finding.

### Description
- Expand the meta-line filter `META_BRIEF_LINE_PATTERN` in `packages/core/src/brief-schema.ts` to include truncation- and token-limit diagnostic phrases so these lines are treated as non-content. 
- Add a regression test `filters truncation-diagnosis meta lines from report-first recommendations` in `packages/core/test/brief-schema.test.ts` to ensure diagnostic lines are ignored and the next substantive line becomes the recommendation/what-changed. 
- Update `CHANGELOG.md` with a user-facing note describing the fix.

### Testing
- Ran the focused unit test with `pnpm vitest run packages/core/test/brief-schema.test.ts`, which passed. 
- Ran the full verification suite with `pnpm verify` (typecheck + tests + coverage), which completed successfully (all tests passed in this environment). 
- Executed the harness with `pnpm harness:core-loop`, which passed; attempted `pnpm e2e` failed in this environment due to missing Playwright browser binaries (`pnpm exec playwright install` required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3c392a98c832fbf63757f3860a1ac)