### PR TITLE
Ground digest fallback floor in research finding deltas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Digest deterministic floor is finding-delta grounded** — Daily digests now build the fallback brief from research finding deltas (with source URLs, ranked by significance/authority), corrected beliefs, and completed actions instead of self-referential program/memory meta-text. Quiet days emit an honest "No material change since last brief" recommendation, and the LLM step is instructed to rewrite/tighten that grounded floor rather than invent filler.
+
 ### Added
 - **Capability-driven chat welcome prompts** — The four starter suggestions on a new chat now each exercise a distinct capability (live web search, deep research, recurring watches, product feedback to the pai developers) so first-time users are immediately exposed to what pai can do.
 

--- a/packages/server/src/briefing.ts
+++ b/packages/server/src/briefing.ts
@@ -84,6 +84,8 @@ export interface BriefingDeltaFinding {
   summary: string;
   domain: string;
   watchId?: string;
+  confidence: number;
+  sources: Array<{ url: string; title: string; authorityScore?: number }>;
   delta?: { changed: string[]; significance: number };
 }
 
@@ -94,6 +96,39 @@ export interface BriefingDelta {
   correctedBeliefs: Array<{ statement: string; type: string; confidence: number }>;
   completedActions: Array<{ title: string; completedAt: string | null }>;
   sinceTimestamp: string;
+}
+
+/** Findings at or above this significance count as material change. New findings without a delta are treated as material. */
+export const MATERIAL_FINDING_SIGNIFICANCE = 0.15;
+
+export function findingSignificance(finding: BriefingDeltaFinding): number {
+  return finding.delta?.significance ?? 0.5;
+}
+
+export function isMaterialBriefingDelta(delta: BriefingDelta): boolean {
+  const hasSignificantFinding = delta.newFindings.some(
+    (finding) => findingSignificance(finding) >= MATERIAL_FINDING_SIGNIFICANCE,
+  );
+  return (
+    hasSignificantFinding
+    || delta.changedInsights.length > 0
+    || delta.correctedBeliefs.length > 0
+    || delta.completedActions.length > 0
+  );
+}
+
+function maxAuthorityScore(finding: BriefingDeltaFinding): number {
+  return finding.sources.reduce((max, source) => Math.max(max, source.authorityScore ?? 0), 0);
+}
+
+function rankDeltaFinding(finding: BriefingDeltaFinding): number {
+  return findingSignificance(finding) * 10 + maxAuthorityScore(finding) + finding.confidence;
+}
+
+export function rankMaterialFindings(delta: BriefingDelta): BriefingDeltaFinding[] {
+  return [...delta.newFindings]
+    .filter((finding) => findingSignificance(finding) >= MATERIAL_FINDING_SIGNIFICANCE)
+    .sort((left, right) => rankDeltaFinding(right) - rankDeltaFinding(left));
 }
 
 export function buildBriefingDelta(
@@ -113,6 +148,12 @@ export function buildBriefingDelta(
         summary: f.summary,
         domain: f.domain,
         watchId: f.watchId,
+        confidence: f.confidence,
+        sources: f.sources.map((source) => ({
+          url: source.url,
+          title: source.title,
+          authorityScore: source.authorityScore,
+        })),
         delta: f.delta,
       }));
   } catch {
@@ -1197,66 +1238,166 @@ function normalizeBriefingSections(raw: unknown, fallback: BriefingSection): Bri
   };
 }
 
-function buildFallbackBriefing(rawContext: BriefingContextInput): BriefingSection {
-  const primaryProgram = selectPrimaryProgram(rawContext.programs, rawContext.actionSignals);
-  const recentBeliefs = rawContext.beliefs.slice(0, 2);
-  const actionLead = buildActionLead(rawContext, primaryProgram);
-  const recommendationSummary = actionLead
-    ? actionLead.recommendationSummary
-    : primaryProgram
-      ? `Keep ${primaryProgram.title} as the top watch for the next brief.`
-      : rawContext.tasks[0]
-        ? `Keep momentum on ${rawContext.tasks[0].title} before starting something new.`
-        : "Keep the current watchlist active and tighten the next follow-up around the clearest open question.";
-  const recommendationRationale = actionLead
-    ? actionLead.recommendationRationale
-    : primaryProgram
-      ? `${primaryProgram.question} ${primaryProgram.constraints.length > 0 ? `Current constraints: ${primaryProgram.constraints.slice(0, 2).join("; ")}.` : ""}`.trim()
-      : rawContext.tasks[0]
-        ? `Keep momentum on ${rawContext.tasks[0].title} before starting something new.`
-        : rawContext.recentlyCompleted.length > 0
-          ? `${rawContext.recentlyCompleted.length} recent completion${rawContext.recentlyCompleted.length === 1 ? "" : "s"} give enough signal for a concise next-step brief.`
-          : "This fallback brief is grounded in the stored Program, memory, and activity context.";
+export interface BuildFallbackBriefingOptions {
+  delta?: BriefingDelta;
+  programTitles?: Map<string, string>;
+}
 
+function findingChangeBullet(
+  finding: BriefingDeltaFinding,
+  programTitles: Map<string, string>,
+): string {
+  const watchLabel = finding.watchId
+    ? (programTitles.get(finding.watchId) ?? finding.goal)
+    : finding.goal;
+  if (finding.delta && finding.delta.changed.length > 0) {
+    const change = finding.delta.changed[0]!.replace(/^[+-]\s*/, "").trim();
+    return `${watchLabel}: ${change}`;
+  }
+  return `${watchLabel}: ${finding.summary.slice(0, 180).trim()}`;
+}
+
+function findingEvidenceItem(
+  finding: BriefingDeltaFinding,
+  programTitles: Map<string, string>,
+): BriefingSection["evidence"][number] {
+  const watchLabel = finding.watchId
+    ? (programTitles.get(finding.watchId) ?? finding.goal)
+    : finding.goal;
+  const topSource = [...finding.sources].sort(
+    (left, right) => (right.authorityScore ?? 0) - (left.authorityScore ?? 0),
+  )[0];
+  const detail = finding.delta && finding.delta.changed.length > 0
+    ? finding.delta.changed.slice(0, 2).map((line) => line.replace(/^[+-]\s*/, "").trim()).join("; ")
+    : finding.summary.slice(0, 240).trim();
+  return {
+    title: topSource?.title || finding.goal,
+    detail,
+    sourceLabel: watchLabel,
+    sourceUrl: topSource?.url,
+    freshness: finding.delta
+      ? `Significance ${finding.delta.significance.toFixed(2)}`
+      : "New finding",
+  };
+}
+
+function buildDeltaGroundedChanges(
+  delta: BriefingDelta,
+  programTitles: Map<string, string>,
+): { whatChanged: string[]; evidence: BriefingSection["evidence"] } {
+  const rankedFindings = rankMaterialFindings(delta);
   const whatChanged = dedupeStrings([
-    ...(actionLead?.whatChanged ?? []),
-    primaryProgram
-      ? `${primaryProgram.title} remains active with ${primaryProgram.intervalHours >= 24 ? "a recurring brief cadence" : "short-interval follow-through"}.`
-      : "No active Program was selected, so this brief is using the strongest recent context instead.",
-    rawContext.recentlyCompleted.length > 0
-      ? `${rawContext.recentlyCompleted.length} recent completion${rawContext.recentlyCompleted.length === 1 ? "" : "s"} may shift the next recommendation.`
-      : "There were no recent completions worth elevating into a change signal.",
-    recentBeliefs.length > 0
-      ? `${recentBeliefs.length} recent memory signal${recentBeliefs.length === 1 ? "" : "s"} are available for the next recommendation.`
-      : "No recent memory updates were detected, so assumptions are coming from the Program definition.",
+    ...rankedFindings.slice(0, 4).map((finding) => findingChangeBullet(finding, programTitles)),
+    ...delta.changedInsights.slice(0, 2).map((insight) => `${insight.topic}: ${insight.insight}`),
+    ...delta.correctedBeliefs.slice(0, 2).map((belief) => `Corrected assumption: ${belief.statement}`),
+    ...delta.completedActions.slice(0, 2).map((action) => `Completed: ${action.title}`),
   ]).slice(0, 4);
 
   const evidence = dedupeEvidence([
-    ...(actionLead?.evidence ?? []),
-    primaryProgram
-      ? {
-        title: "Program definition",
-        detail: primaryProgram.question,
-        sourceLabel: "Program",
-        freshness: `Next brief ${primaryProgram.nextRunAt}`,
-      }
-      : {
-        title: "Observed activity",
-        detail: rawContext.recentActivity[0] ?? "No recent activity was stored.",
-        sourceLabel: "Activity log",
-      },
-    ...primaryProgram?.constraints.slice(0, 2).map((constraint) => ({
-      title: "Program constraint",
-      detail: constraint,
-      sourceLabel: "Program",
-    })) ?? [],
-    ...rawContext.knowledgeSources.slice(0, 1).map((source) => ({
-      title: source.title,
-      detail: "Reference source available for grounding future recommendations.",
-      sourceLabel: "Knowledge source",
-      sourceUrl: source.url,
+    ...rankedFindings.slice(0, 4).map((finding) => findingEvidenceItem(finding, programTitles)),
+    ...delta.changedInsights.slice(0, 2).map((insight) => ({
+      title: insight.topic,
+      detail: insight.insight,
+      sourceLabel: "Topic insight",
+      freshness: `Confidence ${insight.confidence.toFixed(2)} · ${insight.cycleCount} cycles`,
     })),
-  ].filter((item) => item.detail.trim().length > 0));
+    ...delta.correctedBeliefs.slice(0, 2).map((belief) => ({
+      title: "Corrected belief",
+      detail: belief.statement,
+      sourceLabel: "Memory correction",
+      freshness: confidenceLabel(belief.confidence),
+    })),
+    ...delta.completedActions.slice(0, 2).map((action) => ({
+      title: "Completed action",
+      detail: action.title,
+      sourceLabel: "Task",
+      freshness: action.completedAt ?? "Completed recently",
+    })),
+  ].filter((item) => item.detail.trim().length > 0)).slice(0, 4);
+
+  return { whatChanged, evidence };
+}
+
+export function buildFallbackBriefing(
+  rawContext: BriefingContextInput,
+  options: BuildFallbackBriefingOptions = {},
+): BriefingSection {
+  const primaryProgram = selectPrimaryProgram(rawContext.programs, rawContext.actionSignals);
+  const recentBeliefs = rawContext.beliefs.slice(0, 2);
+  const actionLead = buildActionLead(rawContext, primaryProgram);
+  const delta = options.delta;
+  const programTitles = options.programTitles ?? new Map(rawContext.programs.map((program) => [program.id, program.title]));
+  const materialDelta = delta ? isMaterialBriefingDelta(delta) : false;
+  const deltaGrounded = delta && materialDelta
+    ? buildDeltaGroundedChanges(delta, programTitles)
+    : { whatChanged: [] as string[], evidence: [] as BriefingSection["evidence"] };
+  const forceOpenAction = Boolean(actionLead?.forceRecommendation);
+  const quietDay = Boolean(delta) && !materialDelta && !forceOpenAction;
+
+  const topFinding = delta ? rankMaterialFindings(delta)[0] : undefined;
+  const recommendationSummary = forceOpenAction && actionLead
+    ? actionLead.recommendationSummary
+    : quietDay
+      ? "No material change since last brief."
+      : topFinding
+        ? findingChangeBullet(topFinding, programTitles)
+        : actionLead
+          ? actionLead.recommendationSummary
+          : primaryProgram
+            ? `Review the latest signal for ${primaryProgram.title} and decide the next concrete follow-up.`
+            : rawContext.tasks[0]
+              ? `Keep momentum on ${rawContext.tasks[0].title} before starting something new.`
+              : "No material change since last brief.";
+  const recommendationRationale = forceOpenAction && actionLead
+    ? actionLead.recommendationRationale
+    : quietDay
+      ? "No significant new findings, corrections, or completed actions were recorded since the last digest."
+      : topFinding
+        ? `Grounded in research finding for ${topFinding.goal}${topFinding.delta ? ` (significance ${topFinding.delta.significance.toFixed(2)})` : ""}.`
+        : actionLead
+          ? actionLead.recommendationRationale
+          : primaryProgram
+            ? `${primaryProgram.question} ${primaryProgram.constraints.length > 0 ? `Current constraints: ${primaryProgram.constraints.slice(0, 2).join("; ")}.` : ""}`.trim()
+            : rawContext.tasks[0]
+              ? `Keep momentum on ${rawContext.tasks[0].title} before starting something new.`
+              : "No significant state delta was available for this brief.";
+
+  const whatChanged = quietDay
+    ? ["No material change since the last brief."]
+    : dedupeStrings([
+      ...(actionLead?.whatChanged ?? []),
+      ...deltaGrounded.whatChanged,
+      ...(!delta && rawContext.recentlyCompleted.length > 0
+        ? [`${rawContext.recentlyCompleted.length} recent completion${rawContext.recentlyCompleted.length === 1 ? "" : "s"} may shift the next recommendation.`]
+        : []),
+    ]).slice(0, 4);
+
+  const evidence = quietDay
+    ? [{
+      title: "State delta",
+      detail: "No significant new findings, corrections, or completed actions since the last brief.",
+      sourceLabel: "Digest delta",
+    }]
+    : dedupeEvidence([
+      ...(actionLead?.evidence ?? []),
+      ...deltaGrounded.evidence,
+      ...(!delta && primaryProgram
+        ? [{
+          title: primaryProgram.title,
+          detail: primaryProgram.question,
+          sourceLabel: "Watch",
+          freshness: `Next brief ${primaryProgram.nextRunAt}`,
+        }]
+        : []),
+      ...(!delta
+        ? rawContext.knowledgeSources.slice(0, 1).map((source) => ({
+          title: source.title,
+          detail: source.title,
+          sourceLabel: "Knowledge source",
+          sourceUrl: source.url,
+        }))
+        : []),
+    ].filter((item) => item.detail.trim().length > 0)).slice(0, 4);
 
   const memoryAssumptions = [
     ...primaryProgram?.preferences.slice(0, 2).map((preference) => ({
@@ -1276,48 +1417,60 @@ function buildFallbackBriefing(rawContext: BriefingContextInput): BriefingSectio
     })),
   ];
 
-  const nextActions = [
-    ...(actionLead?.nextActions ?? []),
-    primaryProgram?.openQuestions[0]
-      ? {
-        title: "Resolve the top open question",
-        timing: "Before the next brief",
-        detail: primaryProgram.openQuestions[0],
-      }
-      : null,
-    primaryProgram
-      ? {
-        title: "Review the Program definition",
-        timing: "Now",
-        detail: `Confirm that ${primaryProgram.title} still has the right priorities and constraints.`,
-      }
-      : null,
-    rawContext.tasks[0]
-      ? {
-        title: "Close the most immediate task",
-        timing: "Today",
-        detail: `${rawContext.tasks[0].title} is the clearest actionable item in the current context.`,
-      }
-      : null,
-  ]
-    .filter((item): item is NonNullable<typeof item> => item !== null)
-    .filter((item, index, items) => items.findIndex((candidate) => candidate.title.trim().toLowerCase() === item.title.trim().toLowerCase()) === index)
-    .slice(0, 3);
+  const nextActions = quietDay
+    ? [{
+      title: "Wait for the next material change",
+      timing: "Until the next brief",
+      detail: primaryProgram
+        ? `No significant delta landed for ${primaryProgram.title}; reopen only if a new external signal or correction arrives.`
+        : "No significant delta landed; reopen only if a new external signal or correction arrives.",
+    }]
+    : [
+      ...(actionLead?.nextActions ?? []),
+      primaryProgram?.openQuestions[0]
+        ? {
+          title: "Resolve the top open question",
+          timing: "Before the next brief",
+          detail: primaryProgram.openQuestions[0],
+        }
+        : null,
+      topFinding
+        ? {
+          title: "Act on the top finding",
+          timing: "Today",
+          detail: findingChangeBullet(topFinding, programTitles),
+        }
+        : null,
+      rawContext.tasks[0]
+        ? {
+          title: "Close the most immediate task",
+          timing: "Today",
+          detail: `${rawContext.tasks[0].title} is the clearest actionable item in the current context.`,
+        }
+        : null,
+    ]
+      .filter((item): item is NonNullable<typeof item> => item !== null)
+      .filter((item, index, items) => items.findIndex((candidate) => candidate.title.trim().toLowerCase() === item.title.trim().toLowerCase()) === index)
+      .slice(0, 3);
 
   return {
     title: primaryProgram?.title ?? "Daily Briefing",
     recommendation: {
       summary: recommendationSummary,
-      confidence: actionLead?.recommendationConfidence ?? (primaryProgram || rawContext.tasks.length > 0 ? "medium" : "low"),
+      confidence: quietDay
+        ? "medium"
+        : actionLead?.recommendationConfidence ?? (topFinding || primaryProgram || rawContext.tasks.length > 0 ? "medium" : "low"),
       rationale: recommendationRationale,
     },
-    what_changed: whatChanged,
+    what_changed: whatChanged.length > 0
+      ? whatChanged
+      : ["No material change since the last brief."],
     evidence: evidence.length > 0
       ? evidence
       : [{
-        title: "Program context",
-        detail: "No external evidence was attached, so this brief is grounded in stored product context only.",
-        sourceLabel: "System",
+        title: "State delta",
+        detail: "No significant external evidence was attached to this brief.",
+        sourceLabel: "Digest delta",
       }],
     memory_assumptions: memoryAssumptions.length > 0
       ? memoryAssumptions
@@ -1329,15 +1482,57 @@ function buildFallbackBriefing(rawContext: BriefingContextInput): BriefingSectio
     next_actions: nextActions.length > 0
       ? nextActions
       : [{
-        title: "Add a Program",
+        title: "Add a Watch",
         timing: "Now",
-        detail: "Create a Program so the next brief has a stable recurring object to follow.",
+        detail: "Create a Watch so the next brief has a stable recurring object to follow.",
       }],
     correction_hook: {
       prompt: primaryProgram
         ? `Correction for ${primaryProgram.title}: tell pai what changed, what assumption is wrong, or what should matter more next time.`
         : "Correction: tell pai what assumption is wrong or what should matter more next time.",
     },
+  };
+}
+
+function evidenceHasSourceUrls(evidence: BriefingSection["evidence"]): boolean {
+  return evidence.some((item) => typeof item.sourceUrl === "string" && item.sourceUrl.trim().length > 0);
+}
+
+function preferGroundedBriefingSections(
+  llmSections: BriefingSection,
+  groundedFloor: BriefingSection,
+  delta: BriefingDelta | undefined,
+): BriefingSection {
+  if (!delta) return llmSections;
+
+  const material = isMaterialBriefingDelta(delta);
+  const groundedHasFindingEvidence = evidenceHasSourceUrls(groundedFloor.evidence)
+    || rankMaterialFindings(delta).length > 0;
+
+  if (!material) {
+    const llmLooksLikeFiller = /keep (watching|monitoring)|continue monitoring|no active program|memory signal|recurring brief cadence/i
+      .test(`${llmSections.recommendation.summary} ${llmSections.what_changed.join(" ")}`);
+    if (llmLooksLikeFiller || groundedFloor.recommendation.summary.startsWith("No material change")) {
+      return {
+        ...llmSections,
+        recommendation: groundedFloor.recommendation,
+        what_changed: groundedFloor.what_changed,
+        evidence: groundedFloor.evidence,
+        next_actions: llmSections.next_actions.length > 0 ? llmSections.next_actions : groundedFloor.next_actions,
+      };
+    }
+    return llmSections;
+  }
+
+  if (!groundedHasFindingEvidence) return llmSections;
+
+  return {
+    ...llmSections,
+    what_changed: dedupeStrings([...groundedFloor.what_changed, ...llmSections.what_changed]).slice(0, 4),
+    evidence: dedupeEvidence([
+      ...groundedFloor.evidence,
+      ...llmSections.evidence,
+    ]).slice(0, 4),
   };
 }
 
@@ -1435,7 +1630,6 @@ export async function generateBriefing(
   // Fetch recent research findings from Library — this makes digests aware of accumulated research
   let recentFindings: Array<{ goal: string; summary: string; domain: string; createdAt: string; watchId?: string }> = [];
   try {
-    const { listFindings } = await import("@personal-ai/library");
     recentFindings = listFindings(ctx.storage).slice(0, 10).map((f) => ({
       goal: f.goal,
       summary: f.summary,
@@ -1563,7 +1757,10 @@ export async function generateBriefing(
     knowledgeSources: sources.map((source) => ({ title: source.title ?? source.url, url: source.url })),
   };
 
-  const fallbackSections = buildFallbackBriefing(rawContext);
+  const fallbackSections = buildFallbackBriefing(rawContext, {
+    delta: stateDelta,
+    programTitles,
+  });
 
   // Digest feedback loop — surface user satisfaction signals to the LLM
   let feedbackContext = "";
@@ -1580,10 +1777,17 @@ export async function generateBriefing(
     feedbackContext = "";
   }
 
+  const groundedFloorJson = JSON.stringify(fallbackSections, null, 2);
+  const materialDelta = isMaterialBriefingDelta(stateDelta);
   const prompt = `You are a personal AI assistant generating a daily briefing for ${ownerName}.
 Today is ${rawContext.date}, ${rawContext.time}.
 
-Generate a FRESH, decision-ready briefing based on the following context. The output must stay recommendation-first, highlight what changed, and make correction easy.
+Your job is to REWRITE AND TIGHTEN the grounded floor below into a decision-ready briefing. Do not invent plumbing text about schedules, memory counts, or internal system state. Prefer the floor's evidence and what_changed; you may tighten wording and improve the recommendation, but keep claims traceable to the floor or STATE DELTA.
+
+GROUNDED FLOOR (deterministic baseline — rewrite/tighten this, do not replace with filler):
+${groundedFloorJson}
+
+CHANGE WORTHINESS: ${materialDelta ? "MATERIAL — surface the real finding/correction/action deltas." : "QUIET — preserve an honest \"No material change since last brief\" recommendation unless the floor already forces an open linked action."}
 
 OPEN TASKS (${tasks.length}):
 ${JSON.stringify(rawContext.tasks, null, 2)}
@@ -1613,12 +1817,14 @@ ${deltaPromptSection}${recentFindings.length > 0 ? `RECENT RESEARCH FINDINGS (fr
 ${knowledgeContext ? `RELEVANT KNOWLEDGE (from docs, research reports, and previous digests — use as context):\n${knowledgeContext}\n` : ""}
 ${previousBriefingSummary ? `PREVIOUS BRIEFINGS (you MUST NOT repeat these — choose DIFFERENT angles):\n${previousBriefingSummary}\n` : ""}${feedbackContext ? `${feedbackContext}\n` : ""}
 Guidelines:
-- Recommendation comes first. Tell the user what to DO based on what was found — a specific action, decision, or insight. NEVER recommend "keep watching" or "continue monitoring" — that's the default and adds no value. If nothing actionable was found, summarize the most interesting finding instead.
+- Start from the grounded floor. Rewrite for clarity; do not invent sections from system meta-text.
+- Recommendation comes first. Tell the user what to DO based on what was found — a specific action, decision, or insight. NEVER recommend "keep watching" or "continue monitoring" — that's the default and adds no value. If the floor says there was no material change, keep that honesty.
+- Preserve sourceUrl on evidence items whenever the floor or STATE DELTA provides one.
 - Use active watches as the primary context when they exist. Avoid talking about raw schedules, jobs, programs, or internal mechanics.
 - Linked actions are existing follow-through attached to Programs or previous Briefs. Treat them as product context, not as anonymous tasks.
 - If a linked action is already complete, use that completion as a change signal and do not repeat it as a next action.
 - If a linked action is still open or stale, make that explicit in the recommendation, evidence, or next actions instead of inventing duplicate follow-through.
-- what_changed should be concise and specific. Prefer 2-4 bullets.
+- what_changed should be concise and specific. Prefer 2-4 bullets grounded in findings, corrections, or completed actions.
 - evidence sourceLabel MUST be human-readable — use the watch title, finding goal, or topic name (e.g. "AI Agents Tracker", "H4 Visa research", "GitHub trending"). NEVER expose internal IDs, provenance tags, or system labels to the user. The bracketed tags in the data (e.g. [finding:abc123]) are for YOUR reference only — translate them into plain language for sourceLabel.
 - memory_assumptions MUST NOT be empty when beliefs are provided above. Name the specific beliefs that influenced the recommendation. provenance should be human-readable (e.g. "User preference", "Observed from research", "Inferred from activity") — never raw belief IDs.
 - next_actions should be specific and concrete. Keep them short.
@@ -1688,9 +1894,13 @@ Respond ONLY with a valid JSON object matching this exact shape (no markdown, no
       let jsonText = result.text.trim();
       const fenceMatch = jsonText.match(/```(?:json)?\s*([\s\S]*?)```/);
       if (fenceMatch?.[1]) jsonText = fenceMatch[1].trim();
-      parsed = mergeActionLeadIntoBriefing(
-        normalizeBriefingSections(JSON.parse(jsonText), fallbackSections),
-        buildActionLead(rawContext, selectPrimaryProgram(rawContext.programs, rawContext.actionSignals)),
+      parsed = preferGroundedBriefingSections(
+        mergeActionLeadIntoBriefing(
+          normalizeBriefingSections(JSON.parse(jsonText), fallbackSections),
+          buildActionLead(rawContext, selectPrimaryProgram(rawContext.programs, rawContext.actionSignals)),
+        ),
+        fallbackSections,
+        stateDelta,
       );
     } catch (error) {
       ctx.logger.warn("Briefing generation fell back to deterministic brief", {

--- a/packages/server/test/briefing.test.ts
+++ b/packages/server/test/briefing.test.ts
@@ -17,8 +17,12 @@ import {
   linkBriefBeliefs,
   getBriefBeliefs,
   buildBriefingDelta,
+  buildFallbackBriefing,
+  isMaterialBriefingDelta,
+  rankMaterialFindings,
+  MATERIAL_FINDING_SIGNIFICANCE,
 } from "../src/briefing.js";
-import type { BriefingSection, BriefingDelta } from "../src/briefing.js";
+import type { BriefingSection, BriefingDelta, BriefingContextInput } from "../src/briefing.js";
 import { findingsMigrations, createFinding } from "@personal-ai/library";
 import type { Belief } from "@personal-ai/core";
 
@@ -511,7 +515,7 @@ describe("generateBriefing", () => {
   const sampleSections: BriefingSection = {
     title: "Project Atlas launch readiness",
     recommendation: {
-      summary: "Keep Project Atlas as the top watch for the next brief.",
+      summary: "Confirm rollback owners before the Atlas launch window.",
       confidence: "medium",
       rationale: "Release blockers still matter more than broad status updates.",
     },
@@ -527,7 +531,7 @@ describe("generateBriefing", () => {
     const result = await generateBriefing(ctx);
     expect(result).not.toBeNull();
     expect(result!.status).toBe("ready");
-    expect(result!.sections.recommendation.summary).toContain("watch");
+    expect(result!.sections.recommendation.summary).toBe("No material change since last brief.");
   });
 
   it("falls back to a deterministic brief when LLM health check throws", async () => {
@@ -549,9 +553,10 @@ describe("generateBriefing", () => {
 
     expect(result).not.toBeNull();
     expect(result!.status).toBe("ready");
-    expect(result!.sections.recommendation.summary).toBe("Keep Project Atlas as the top watch for the next brief.");
-    expect(result!.sections.what_changed).toHaveLength(1);
-    expect(result!.sections.next_actions).toHaveLength(1);
+    // Quiet-day floor wins over LLM inventing change when the state delta is empty.
+    expect(result!.sections.recommendation.summary).toBe("No material change since last brief.");
+    expect(result!.sections.what_changed).toEqual(["No material change since the last brief."]);
+    expect(result!.sections.next_actions.length).toBeGreaterThan(0);
 
     // Verify it was persisted in the DB
     const fromDb = getBriefingById(storage, result!.id);
@@ -569,7 +574,46 @@ describe("generateBriefing", () => {
     const result = await generateBriefing(ctx);
 
     expect(result).not.toBeNull();
-    expect(result!.sections.recommendation.summary).toBe("Keep Project Atlas as the top watch for the next brief.");
+    expect(result!.sections.recommendation.summary).toBe("No material change since last brief.");
+  });
+
+  it("keeps LLM rewrite when the grounded floor has material finding deltas", async () => {
+    storage.migrate("findings", findingsMigrations);
+    const program = createProgram(storage, {
+      title: "Project Atlas launch readiness",
+      question: "Track blockers, rollback readiness, and launch signoff for Project Atlas.",
+      family: "work",
+      executionMode: "research",
+      intervalHours: 168,
+    });
+    createFinding(storage, {
+      goal: "Atlas rollback",
+      domain: "work",
+      summary: "Rollback drill failed on staging.",
+      confidence: 0.9,
+      agentName: "Researcher",
+      depthLevel: "standard",
+      watchId: program.id,
+      sources: [{
+        url: "https://status.example/atlas",
+        title: "Atlas status",
+        fetchedAt: new Date().toISOString(),
+        relevance: 0.9,
+        authorityScore: 0.9,
+      }],
+      delta: { changed: ["+ Rollback drill failed on staging."], significance: 0.8 },
+    });
+
+    const { generateText } = await import("ai");
+    (generateText as ReturnType<typeof vi.fn>).mockResolvedValue({
+      text: JSON.stringify(sampleSections),
+    });
+
+    const result = await generateBriefing(makeCtx(true));
+    expect(result).not.toBeNull();
+    expect(result!.sections.recommendation.summary).toBe("Confirm rollback owners before the Atlas launch window.");
+    expect(result!.sections.evidence.some((item) => item.sourceUrl === "https://status.example/atlas")).toBe(true);
+    expect(result!.sections.what_changed.some((line) => line.includes("Rollback"))).toBe(true);
   });
 
   it("falls back to a deterministic brief when generateText throws", async () => {
@@ -988,6 +1032,255 @@ describe("buildBriefingDelta", () => {
     const delta = buildBriefingDelta(storage, "2025-01-01T00:00:00.000Z");
     expect(delta.newFindings[0].delta).toBeDefined();
     expect(delta.newFindings[0].delta!.changed).toContain("+ Price dropped $100.");
+    expect(delta.newFindings[0].sources).toEqual([]);
+    expect(delta.newFindings[0].confidence).toBe(0.85);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delta-grounded deterministic floor
+// ---------------------------------------------------------------------------
+describe("delta-grounded fallback briefing", () => {
+  const emptyContext = (): BriefingContextInput => ({
+    ownerName: "Alex",
+    date: "2026-07-11",
+    time: "08:00",
+    tasks: [],
+    recentlyCompleted: [],
+    goals: [],
+    programs: [{
+      id: "watch-gpu",
+      title: "GPU price watch",
+      question: "Track RTX 4090 street price.",
+      family: "buying",
+      executionMode: "research",
+      intervalHours: 24,
+      lastRunAt: null,
+      nextRunAt: "2026-07-12T08:00:00.000Z",
+      preferences: ["Prefer authoritative retailers."],
+      constraints: ["Ignore rumor posts."],
+      openQuestions: ["Is the drop durable?"],
+    }],
+    actionSignals: [],
+    beliefs: [],
+    recentActivity: [],
+    stats: { totalBeliefs: 0, avgConfidence: 0, episodes: 0 },
+    knowledgeSources: [],
+  });
+
+  const emptyDelta = (overrides: Partial<BriefingDelta> = {}): BriefingDelta => ({
+    newFindings: [],
+    changedInsights: [],
+    newBeliefs: [],
+    correctedBeliefs: [],
+    completedActions: [],
+    sinceTimestamp: "2026-07-10T08:00:00.000Z",
+    ...overrides,
+  });
+
+  it("isMaterialBriefingDelta treats corrections and completed actions as material", () => {
+    expect(isMaterialBriefingDelta(emptyDelta())).toBe(false);
+    expect(isMaterialBriefingDelta(emptyDelta({
+      correctedBeliefs: [{ statement: "Visa is approved", type: "factual", confidence: 0.9 }],
+    }))).toBe(true);
+    expect(isMaterialBriefingDelta(emptyDelta({
+      completedActions: [{ title: "Email landlord", completedAt: "2026-07-11T01:00:00.000Z" }],
+    }))).toBe(true);
+  });
+
+  it("ranks findings by significance and authority", () => {
+    const delta = emptyDelta({
+      newFindings: [
+        {
+          id: "low",
+          goal: "Low signal",
+          summary: "Minor note.",
+          domain: "general",
+          confidence: 0.4,
+          sources: [{ url: "https://forum.example/a", title: "Forum", authorityScore: 0.4 }],
+          delta: { changed: ["+ Minor note."], significance: 0.2 },
+        },
+        {
+          id: "high",
+          goal: "GPU prices",
+          summary: "RTX 4090 dropped to $1499 at Best Buy.",
+          domain: "general",
+          confidence: 0.9,
+          sources: [{ url: "https://bestbuy.com/gpu", title: "Best Buy", authorityScore: 0.95 }],
+          delta: { changed: ["+ Price dropped to $1499."], significance: 0.8 },
+        },
+      ],
+    });
+
+    expect(rankMaterialFindings(delta)[0]?.id).toBe("high");
+    expect(MATERIAL_FINDING_SIGNIFICANCE).toBeLessThanOrEqual(0.2);
+  });
+
+  it("grounds what_changed and evidence in finding deltas with sourceUrl", () => {
+    const delta = emptyDelta({
+      newFindings: [{
+        id: "f1",
+        goal: "GPU prices",
+        summary: "RTX 4090 dropped to $1499 at Best Buy.",
+        domain: "general",
+        watchId: "watch-gpu",
+        confidence: 0.9,
+        sources: [{ url: "https://bestbuy.com/gpu", title: "Best Buy listing", authorityScore: 0.95 }],
+        delta: { changed: ["+ Price dropped to $1499."], significance: 0.7 },
+      }],
+    });
+
+    const brief = buildFallbackBriefing(emptyContext(), {
+      delta,
+      programTitles: new Map([["watch-gpu", "GPU price watch"]]),
+    });
+
+    expect(brief.recommendation.summary).toContain("Price dropped to $1499");
+    expect(brief.what_changed.some((line) => line.includes("Price dropped to $1499"))).toBe(true);
+    expect(brief.evidence[0]?.sourceUrl).toBe("https://bestbuy.com/gpu");
+    expect(brief.evidence[0]?.sourceLabel).toBe("GPU price watch");
+    expect(brief.what_changed.join(" ")).not.toMatch(/remains active|memory signal|recurring brief cadence/i);
+  });
+
+  it("emits an honest no-material-change brief on a quiet day", () => {
+    const brief = buildFallbackBriefing(emptyContext(), {
+      delta: emptyDelta({
+        newFindings: [{
+          id: "tiny",
+          goal: "GPU prices",
+          summary: "Negligible wording tweak.",
+          domain: "general",
+          confidence: 0.3,
+          sources: [],
+          delta: { changed: ["+ Negligible wording tweak."], significance: 0.05 },
+        }],
+      }),
+      programTitles: new Map([["watch-gpu", "GPU price watch"]]),
+    });
+
+    expect(brief.recommendation.summary).toBe("No material change since last brief.");
+    expect(brief.what_changed).toEqual(["No material change since the last brief."]);
+    expect(brief.evidence[0]?.detail).toMatch(/No significant/);
+    expect(brief.next_actions[0]?.title).toMatch(/material change/i);
+  });
+
+  it("still elevates forced open linked actions over the quiet-day gate", () => {
+    const ctx = emptyContext();
+    ctx.actionSignals = [{
+      sourceType: "program",
+      sourceId: "watch-gpu",
+      sourceLabel: "GPU price watch",
+      openCount: 1,
+      staleOpenCount: 0,
+      recentlyCompletedCount: 0,
+      highestPriorityOpen: "high",
+      openTitles: ["Confirm Best Buy stock"],
+      recentlyCompletedTitles: [],
+    }];
+
+    const brief = buildFallbackBriefing(ctx, {
+      delta: emptyDelta(),
+      programTitles: new Map([["watch-gpu", "GPU price watch"]]),
+    });
+
+    expect(brief.recommendation.summary).toContain("Close the open linked action");
+    expect(brief.next_actions[0]?.title).toBe("Confirm Best Buy stock");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: generateBriefing uses finding-grounded deterministic floor
+// ---------------------------------------------------------------------------
+describe("generateBriefing delta-grounded floor", () => {
+  let dir: string;
+  let storage: Storage;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pai-brief-floor-"));
+    storage = createStorage(dir);
+    storage.migrate("briefing", briefingMigrations);
+    storage.migrate("schedules", scheduleMigrations);
+    storage.migrate("findings", findingsMigrations);
+    vi.clearAllMocks();
+    mockListTasks.mockImplementation((_storage: Storage, status = "open") => (status === "done" ? [] : []));
+    mockListGoals.mockReturnValue([]);
+    mockListBeliefs.mockReturnValue([]);
+    mockMemoryStats.mockReturnValue({
+      beliefs: { active: 0, forgotten: 0, invalidated: 0 },
+      avgConfidence: 0,
+      episodes: 0,
+    });
+    mockListSources.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    storage.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function makeCtx(healthOk = false) {
+    return {
+      config: { timezone: "America/Los_Angeles", llm: { provider: "ollama", model: "test-model" } } as never,
+      storage,
+      llm: {
+        health: vi.fn().mockResolvedValue({ ok: healthOk }),
+        getModel: vi.fn().mockReturnValue("mock-model"),
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    } as never;
+  }
+
+  it("surfaces finding deltas in deterministic digests", async () => {
+    const program = createProgram(storage, {
+      title: "GPU price watch",
+      question: "Track RTX 4090 street price.",
+      family: "buying",
+      executionMode: "research",
+      intervalHours: 24,
+    });
+    createFinding(storage, {
+      goal: "GPU prices",
+      domain: "general",
+      summary: "RTX 4090 dropped to $1499 at Best Buy.",
+      confidence: 0.9,
+      agentName: "Researcher",
+      depthLevel: "standard",
+      watchId: program.id,
+      sources: [{
+        url: "https://bestbuy.com/gpu",
+        title: "Best Buy listing",
+        fetchedAt: new Date().toISOString(),
+        relevance: 0.9,
+        authorityScore: 0.95,
+      }],
+      delta: { changed: ["+ Price dropped to $1499."], significance: 0.7 },
+    });
+
+    const result = await generateBriefing(makeCtx(false));
+    expect(result).not.toBeNull();
+    expect(result!.sections.what_changed.join(" ")).toContain("Price dropped to $1499");
+    expect(result!.sections.evidence.some((item) => item.sourceUrl === "https://bestbuy.com/gpu")).toBe(true);
+    expect(result!.sections.recommendation.summary).not.toMatch(/remains active|memory signal/i);
+  });
+
+  it("says no material change when the delta is empty", async () => {
+    createProgram(storage, {
+      title: "Quiet watch",
+      question: "Anything new?",
+      family: "general",
+      executionMode: "research",
+      intervalHours: 24,
+    });
+
+    const result = await generateBriefing(makeCtx(false));
+    expect(result).not.toBeNull();
+    expect(result!.sections.recommendation.summary).toBe("No material change since last brief.");
+    expect(result!.sections.what_changed[0]).toMatch(/No material change/i);
   });
 });
 

--- a/packages/server/test/quality.test.ts
+++ b/packages/server/test/quality.test.ts
@@ -35,35 +35,55 @@ describe("getSystemQualityScore", () => {
   });
 
   it("computes recent learning, memory, feedback, and compounding quality ratios", () => {
+    const daysAgo = (days: number, hour = 9, minute = 0) => {
+      const stamp = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+      stamp.setUTCHours(hour, minute, 0, 0);
+      return stamp.toISOString();
+    };
+    const day3 = daysAgo(3);
+    const day3Open = daysAgo(3, 9, 5);
+    const day3Accept = daysAgo(3, 9, 10);
+    const day3Task = daysAgo(3, 9, 15);
+    const day3Done = daysAgo(3, 12, 0);
+    const day2 = daysAgo(2);
+    const day2Open = daysAgo(2, 9, 5);
+    const day2Task = daysAgo(2, 9, 15);
+    const day2Correct = daysAgo(2, 10, 0);
+    const day1 = daysAgo(1);
+    const learnOk = daysAgo(3, 10, 0);
+    const learnOkDone = daysAgo(3, 10, 1);
+    const learnFail = daysAgo(2, 10, 0);
+    const learnFailDone = daysAgo(2, 10, 1);
+
     storage.run(
       `INSERT INTO beliefs (
         id, statement, confidence, status, type, importance, subject, origin, freshness_at, correction_state, sensitive, access_count
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      ["b1", "User prefers concise status reports", 0.82, "active", "preference", 8, "owner", "user-said", "2026-03-01T00:00:00Z", "active", 0, 3],
+      ["b1", "User prefers concise status reports", 0.82, "active", "preference", 8, "owner", "user-said", daysAgo(20), "active", 0, 3],
     );
     storage.run(
       `INSERT INTO beliefs (
         id, statement, confidence, status, type, importance, subject, origin, freshness_at, correction_state, sensitive, access_count
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      ["b2", "User values reproducible builds", 0.74, "active", "preference", 7, "owner", "user-said", "2026-03-01T00:00:00Z", "active", 0, 1],
+      ["b2", "User values reproducible builds", 0.74, "active", "preference", 7, "owner", "user-said", daysAgo(20), "active", 0, 1],
     );
     storage.run(
       `INSERT INTO beliefs (
         id, statement, confidence, status, type, importance, subject, origin, freshness_at, correction_state, sensitive, access_count
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      ["b3", "User follows infrastructure releases", 0.6, "active", "factual", 6, "owner", "inferred", "2026-03-01T00:00:00Z", "active", 0, 5],
+      ["b3", "User follows infrastructure releases", 0.6, "active", "factual", 6, "owner", "inferred", daysAgo(20), "active", 0, 5],
     );
     storage.run(
       `INSERT INTO beliefs (
         id, statement, confidence, status, type, importance, subject, origin, freshness_at, correction_state, sensitive, access_count
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      ["b4", "Old assumption", 0.4, "invalidated", "factual", 5, "owner", "inferred", "2026-03-01T00:00:00Z", "invalidated", 0, 0],
+      ["b4", "Old assumption", 0.4, "invalidated", "factual", 5, "owner", "inferred", daysAgo(20), "invalidated", 0, 0],
     );
     storage.run(
       `INSERT INTO beliefs (
         id, statement, confidence, status, type, importance, subject, origin, freshness_at, correction_state, sensitive, access_count, supersedes
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      ["b5", "Updated assumption", 0.86, "active", "factual", 5, "owner", "user-said", "2026-03-21T09:30:00Z", "confirmed", 0, 1, "b4"],
+      ["b5", "Updated assumption", 0.86, "active", "factual", 5, "owner", "user-said", day2Correct, "confirmed", 0, 1, "b4"],
     );
     storage.run("UPDATE beliefs SET superseded_by = ? WHERE id = ?", ["b5", "b4"]);
     storage.run(
@@ -79,10 +99,10 @@ describe("getSystemQualityScore", () => {
       ["bp3", "b5", "briefing", "brief-2", "Digest correction", "prompted-correction"],
     );
 
-    const successRun = insertLearningRun(storage, "2026-03-20T10:00:00Z");
+    const successRun = insertLearningRun(storage, learnOk);
     updateLearningRun(storage, successRun, {
       status: "done",
-      completedAt: "2026-03-20T10:01:00Z",
+      completedAt: learnOkDone,
       threadsCount: 1,
       messagesCount: 4,
       factsExtracted: 4,
@@ -90,10 +110,10 @@ describe("getSystemQualityScore", () => {
       beliefsReinforced: 2,
       durationMs: 1_000,
     });
-    const failedRun = insertLearningRun(storage, "2026-03-21T10:00:00Z");
+    const failedRun = insertLearningRun(storage, learnFail);
     updateLearningRun(storage, failedRun, {
       status: "error",
-      completedAt: "2026-03-21T10:01:00Z",
+      completedAt: learnFailDone,
       threadsCount: 1,
       messagesCount: 2,
       error: "provider timeout",
@@ -102,35 +122,35 @@ describe("getSystemQualityScore", () => {
 
     storage.run(
       "INSERT INTO briefings (id, generated_at, sections, status, type, source_kind) VALUES (?, ?, ?, ?, ?, ?)",
-      ["brief-1", "2026-03-20T09:00:00Z", "{}", "ready", "daily", "maintenance"],
+      ["brief-1", day3, "{}", "ready", "daily", "maintenance"],
     );
     storage.run(
       "INSERT INTO briefings (id, generated_at, sections, status, type, source_kind) VALUES (?, ?, ?, ?, ?, ?)",
-      ["brief-2", "2026-03-21T09:00:00Z", "{}", "ready", "daily", "maintenance"],
+      ["brief-2", day2, "{}", "ready", "daily", "maintenance"],
     );
     storage.run(
       "INSERT INTO briefings (id, generated_at, sections, status, type, source_kind) VALUES (?, ?, ?, ?, ?, ?)",
-      ["brief-3", "2026-03-22T09:00:00Z", "{}", "ready", "daily", "maintenance"],
+      ["brief-3", day1, "{}", "ready", "daily", "maintenance"],
     );
     recordProductEvent(storage, {
       eventType: "brief_opened",
-      occurredAt: "2026-03-20T09:05:00Z",
+      occurredAt: day3Open,
       briefId: "brief-1",
     });
     recordProductEvent(storage, {
       eventType: "brief_opened",
-      occurredAt: "2026-03-21T09:05:00Z",
+      occurredAt: day2Open,
       briefId: "brief-2",
     });
     recordProductEvent(storage, {
       eventType: "recommendation_accepted",
-      occurredAt: "2026-03-20T09:10:00Z",
+      occurredAt: day3Accept,
       briefId: "brief-1",
     });
     rateDigest(storage, "brief-1", 4, "Useful");
     recordProductEvent(storage, {
       eventType: "belief_corrected",
-      occurredAt: "2026-03-21T10:00:00Z",
+      occurredAt: day2Correct,
       briefId: "brief-2",
       beliefId: "b5",
     });
@@ -140,15 +160,15 @@ describe("getSystemQualityScore", () => {
     );
     storage.run(
       "INSERT INTO tasks (id, title, description, status, priority, created_at, completed_at, source_type, source_id, source_label) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-      ["task-1", "Follow updated assumption", null, "done", "medium", "2026-03-20T09:15:00Z", "2026-03-20T12:00:00Z", "briefing", "brief-1", "Brief 1"],
+      ["task-1", "Follow updated assumption", null, "done", "medium", day3Task, day3Done, "briefing", "brief-1", "Brief 1"],
     );
     storage.run(
       "INSERT INTO tasks (id, title, description, status, priority, created_at, completed_at, source_type, source_id, source_label) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-      ["task-2", "Re-check platform choice", null, "open", "high", "2026-03-21T09:15:00Z", null, "briefing", "brief-2", "Brief 2"],
+      ["task-2", "Re-check platform choice", null, "open", "high", day2Task, null, "briefing", "brief-2", "Brief 2"],
     );
     recordProductEvent(storage, {
       eventType: "brief_action_completed",
-      occurredAt: "2026-03-20T12:00:00Z",
+      occurredAt: day3Done,
       briefId: "brief-1",
       actionId: "task-1",
     });
@@ -158,15 +178,15 @@ describe("getSystemQualityScore", () => {
       ["watch-1", "Infra Watch", "research", "Track inference infra", 24],
     );
     const sourcesA = [
-      { url: "https://www.sec.gov/ixviewer/ix.html", title: "SEC filing", fetchedAt: "2026-03-20T09:00:00Z", relevance: 0.9 },
-      { url: "https://www.reuters.com/technology/example", title: "Reuters", fetchedAt: "2026-03-20T09:00:00Z", relevance: 0.85 },
+      { url: "https://www.sec.gov/ixviewer/ix.html", title: "SEC filing", fetchedAt: day3, relevance: 0.9 },
+      { url: "https://www.reuters.com/technology/example", title: "Reuters", fetchedAt: day3, relevance: 0.85 },
     ];
     const sourcesB = [
-      { url: "https://docs.anthropic.com/en/docs/overview", title: "Documentation", fetchedAt: "2026-03-21T09:00:00Z", relevance: 0.85 },
-      { url: "https://www.theverge.com/ai/example", title: "The Verge", fetchedAt: "2026-03-21T09:00:00Z", relevance: 0.8 },
+      { url: "https://docs.anthropic.com/en/docs/overview", title: "Documentation", fetchedAt: day2, relevance: 0.85 },
+      { url: "https://www.theverge.com/ai/example", title: "The Verge", fetchedAt: day2, relevance: 0.8 },
     ];
     const sourcesC = [
-      { url: "https://example.com/analysis", title: "Independent analysis", fetchedAt: "2026-03-22T09:00:00Z", relevance: 0.8 },
+      { url: "https://example.com/analysis", title: "Independent analysis", fetchedAt: day1, relevance: 0.8 },
     ];
     const finding1 = createFinding(storage, { watchId: "watch-1", goal: "Inference infra", domain: "general", summary: "Vendor consolidation is accelerating", confidence: 0.8, agentName: "test", depthLevel: "standard", sources: sourcesA });
     const finding2 = createFinding(storage, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Daily digests now build their deterministic floor from real state deltas instead of self-referential program/memory meta-text.

- `buildFallbackBriefing` consumes ranked finding deltas (significance + authority), corrected beliefs, and completed actions for `what_changed` / `evidence` (including `sourceUrl`)
- Quiet days emit an honest **No material change since last brief** recommendation instead of filler
- LLM generation is reframed as rewrite/tighten of that grounded floor; quiet-day honesty is preserved when the model invents keep-watching fluff
- Forced open linked actions still win over the quiet-day gate

Also fixes a pre-existing quality scorecard fixture that used March 2026 dates outside the 30-day product-event window (zeroing `trustedDecisionLoopRate`).

## Validation
- [x] `pnpm verify` (typecheck + unit tests + coverage)
- [x] `pnpm harness:core-loop`
- [x] `pnpm e2e`

## Residual risk
Conservative significance threshold (`0.15`) may classify subtle finding deltas as quiet; corrected beliefs and completed actions always count as material.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afe12014-877a-429f-8f5f-dec03da485f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afe12014-877a-429f-8f5f-dec03da485f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

