### PR TITLE
Fix empty web search when time_range=day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Web search no longer returns empty on `time_range=day`** — When SearXNG news/general engines return no hits for a narrow day filter (common for Bing/Google News), `webSearch` now widens to `week` and then unfiltered instead of silently returning nothing.
+
 ### Added
 - **Capability-driven chat welcome prompts** — The four starter suggestions on a new chat now each exercise a distinct capability (live web search, deep research, recurring watches, product feedback to the pai developers) so first-time users are immediately exposed to what pai can do.
 

--- a/packages/plugin-assistant/src/tools.ts
+++ b/packages/plugin-assistant/src/tools.ts
@@ -251,7 +251,7 @@ export function createAgentTools(ctx: AgentContext) {
       inputSchema: z.object({
         query: z.string().describe("The search query"),
         category: z.enum(["general", "news", "it", "images", "videos", "social media", "files"]).default("general").describe("Search category — pick the best fit for the query"),
-        time_range: z.enum(["", "day", "week", "month", "year"]).default("").describe("Time range filter — use 'week' for latest/recent/current queries, 'day' for today only, 'month' for this month. Empty for no filter."),
+        time_range: z.enum(["", "day", "week", "month", "year"]).default("").describe("Time range filter — use 'week' for 'this week'/latest/recent queries (news engines often return nothing for 'day'). Use 'day' only for today-only headlines. Empty for no filter."),
       }),
       execute: async ({ query, category, time_range }) => {
         if (ctx.config.webSearchEnabled === false) {

--- a/packages/plugin-assistant/src/web-search.ts
+++ b/packages/plugin-assistant/src/web-search.ts
@@ -36,18 +36,19 @@ export function resolveSearchUrl(configUrl?: string): string {
 
 export type TimeRange = "day" | "week" | "month" | "year" | "";
 
-/**
- * Fetches search results from a SearXNG instance.
- * Returns up to `maxResults` results (default 5).
- */
-export async function webSearch(
+const TIME_RANGE_FALLBACKS: Record<Exclude<TimeRange, "">, TimeRange[]> = {
+  day: ["week", ""],
+  week: [""],
+  month: [""],
+  year: [""],
+};
+
+async function fetchSearxResults(
+  baseUrl: string,
   query: string,
-  maxResults = 5,
-  category: SearchCategory = "general",
-  configUrl?: string,
-  timeRange: TimeRange = "",
-): Promise<SearchResult[]> {
-  const baseUrl = resolveSearchUrl(configUrl);
+  category: SearchCategory,
+  timeRange: TimeRange,
+): Promise<Array<{ title?: string; url?: string; content?: string; thumbnail?: string; img_src?: string }>> {
   const params = new URLSearchParams({
     q: query,
     format: "json",
@@ -65,8 +66,33 @@ export async function webSearch(
     throw new Error(`SearXNG search failed: ${response.status}`);
   }
 
-  const data = (await response.json()) as { results?: Array<{ title?: string; url?: string; content?: string; thumbnail?: string; img_src?: string }> };
-  const results = data.results ?? [];
+  const data = (await response.json()) as {
+    results?: Array<{ title?: string; url?: string; content?: string; thumbnail?: string; img_src?: string }>;
+  };
+  return data.results ?? [];
+}
+
+/**
+ * Fetches search results from a SearXNG instance.
+ * Returns up to `maxResults` results (default 5).
+ * When a narrow time_range (especially `day`) returns nothing — common for news engines —
+ * widens to week / unfiltered so the tool does not silently return empty.
+ */
+export async function webSearch(
+  query: string,
+  maxResults = 5,
+  category: SearchCategory = "general",
+  configUrl?: string,
+  timeRange: TimeRange = "",
+): Promise<SearchResult[]> {
+  const baseUrl = resolveSearchUrl(configUrl);
+  const ranges: TimeRange[] = [timeRange, ...(timeRange ? TIME_RANGE_FALLBACKS[timeRange] : [])];
+
+  let results: Array<{ title?: string; url?: string; content?: string; thumbnail?: string; img_src?: string }> = [];
+  for (const range of ranges) {
+    results = await fetchSearxResults(baseUrl, query, category, range);
+    if (results.length > 0) break;
+  }
 
   return results.slice(0, maxResults).map((r) => ({
     title: r.title ?? "",

--- a/packages/plugin-assistant/test/web-search.test.ts
+++ b/packages/plugin-assistant/test/web-search.test.ts
@@ -174,6 +174,60 @@ describe("webSearch", () => {
     expect(results[0]!.snippet).toBe("");
   });
 
+  it("passes time_range to SearXNG", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: [{ title: "T", url: "https://a.com", content: "c" }] }),
+    });
+
+    await webSearch("AI news", 5, "news", undefined, "day");
+
+    const callUrl = mockFetch.mock.calls[0]![0] as string;
+    expect(callUrl).toContain("categories=news");
+    expect(callUrl).toContain("time_range=day");
+  });
+
+  it("widens day to week when the day filter returns no results", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ results: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [{ title: "Weekly hit", url: "https://example.com/w", content: "Fresh AI news" }],
+        }),
+      });
+
+    const results = await webSearch("AI news this week", 5, "news", undefined, "day");
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0]![0] as string).toContain("time_range=day");
+    expect(mockFetch.mock.calls[1]![0] as string).toContain("time_range=week");
+    expect(results).toEqual([
+      { title: "Weekly hit", url: "https://example.com/w", snippet: "Fresh AI news" },
+    ]);
+  });
+
+  it("falls back to unfiltered search when week is also empty", async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ results: [] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ results: [] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [{ title: "Any hit", url: "https://example.com/a", content: "Something" }],
+        }),
+      });
+
+    const results = await webSearch("obscure", 5, "news", undefined, "day");
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockFetch.mock.calls[2]![0] as string).not.toContain("time_range=");
+    expect(results[0]?.title).toBe("Any hit");
+  });
+
   it("throws on non-ok response", async () => {
     mockFetch.mockResolvedValueOnce({ ok: false, status: 503 });
 

--- a/packages/server/test/quality.test.ts
+++ b/packages/server/test/quality.test.ts
@@ -35,35 +35,55 @@ describe("getSystemQualityScore", () => {
   });
 
   it("computes recent learning, memory, feedback, and compounding quality ratios", () => {
+    const daysAgo = (days: number, hour = 9, minute = 0) => {
+      const stamp = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+      stamp.setUTCHours(hour, minute, 0, 0);
+      return stamp.toISOString();
+    };
+    const day3 = daysAgo(3);
+    const day3Open = daysAgo(3, 9, 5);
+    const day3Accept = daysAgo(3, 9, 10);
+    const day3Task = daysAgo(3, 9, 15);
+    const day3Done = daysAgo(3, 12, 0);
+    const day2 = daysAgo(2);
+    const day2Open = daysAgo(2, 9, 5);
+    const day2Task = daysAgo(2, 9, 15);
+    const day2Correct = daysAgo(2, 10, 0);
+    const day1 = daysAgo(1);
+    const learnOk = daysAgo(3, 10, 0);
+    const learnOkDone = daysAgo(3, 10, 1);
+    const learnFail = daysAgo(2, 10, 0);
+    const learnFailDone = daysAgo(2, 10, 1);
+
     storage.run(
       `INSERT INTO beliefs (
         id, statement, confidence, status, type, importance, subject, origin, freshness_at, correction_state, sensitive, access_count
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      ["b1", "User prefers concise status reports", 0.82, "active", "preference", 8, "owner", "user-said", "2026-03-01T00:00:00Z", "active", 0, 3],
+      ["b1", "User prefers concise status reports", 0.82, "active", "preference", 8, "owner", "user-said", daysAgo(20), "active", 0, 3],
     );
     storage.run(
       `INSERT INTO beliefs (
         id, statement, confidence, status, type, importance, subject, origin, freshness_at, correction_state, sensitive, access_count
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      ["b2", "User values reproducible builds", 0.74, "active", "preference", 7, "owner", "user-said", "2026-03-01T00:00:00Z", "active", 0, 1],
+      ["b2", "User values reproducible builds", 0.74, "active", "preference", 7, "owner", "user-said", daysAgo(20), "active", 0, 1],
     );
     storage.run(
       `INSERT INTO beliefs (
         id, statement, confidence, status, type, importance, subject, origin, freshness_at, correction_state, sensitive, access_count
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      ["b3", "User follows infrastructure releases", 0.6, "active", "factual", 6, "owner", "inferred", "2026-03-01T00:00:00Z", "active", 0, 5],
+      ["b3", "User follows infrastructure releases", 0.6, "active", "factual", 6, "owner", "inferred", daysAgo(20), "active", 0, 5],
     );
     storage.run(
       `INSERT INTO beliefs (
         id, statement, confidence, status, type, importance, subject, origin, freshness_at, correction_state, sensitive, access_count
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      ["b4", "Old assumption", 0.4, "invalidated", "factual", 5, "owner", "inferred", "2026-03-01T00:00:00Z", "invalidated", 0, 0],
+      ["b4", "Old assumption", 0.4, "invalidated", "factual", 5, "owner", "inferred", daysAgo(20), "invalidated", 0, 0],
     );
     storage.run(
       `INSERT INTO beliefs (
         id, statement, confidence, status, type, importance, subject, origin, freshness_at, correction_state, sensitive, access_count, supersedes
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      ["b5", "Updated assumption", 0.86, "active", "factual", 5, "owner", "user-said", "2026-03-21T09:30:00Z", "confirmed", 0, 1, "b4"],
+      ["b5", "Updated assumption", 0.86, "active", "factual", 5, "owner", "user-said", day2Correct, "confirmed", 0, 1, "b4"],
     );
     storage.run("UPDATE beliefs SET superseded_by = ? WHERE id = ?", ["b5", "b4"]);
     storage.run(
@@ -79,10 +99,10 @@ describe("getSystemQualityScore", () => {
       ["bp3", "b5", "briefing", "brief-2", "Digest correction", "prompted-correction"],
     );
 
-    const successRun = insertLearningRun(storage, "2026-03-20T10:00:00Z");
+    const successRun = insertLearningRun(storage, learnOk);
     updateLearningRun(storage, successRun, {
       status: "done",
-      completedAt: "2026-03-20T10:01:00Z",
+      completedAt: learnOkDone,
       threadsCount: 1,
       messagesCount: 4,
       factsExtracted: 4,
@@ -90,10 +110,10 @@ describe("getSystemQualityScore", () => {
       beliefsReinforced: 2,
       durationMs: 1_000,
     });
-    const failedRun = insertLearningRun(storage, "2026-03-21T10:00:00Z");
+    const failedRun = insertLearningRun(storage, learnFail);
     updateLearningRun(storage, failedRun, {
       status: "error",
-      completedAt: "2026-03-21T10:01:00Z",
+      completedAt: learnFailDone,
       threadsCount: 1,
       messagesCount: 2,
       error: "provider timeout",
@@ -102,35 +122,35 @@ describe("getSystemQualityScore", () => {
 
     storage.run(
       "INSERT INTO briefings (id, generated_at, sections, status, type, source_kind) VALUES (?, ?, ?, ?, ?, ?)",
-      ["brief-1", "2026-03-20T09:00:00Z", "{}", "ready", "daily", "maintenance"],
+      ["brief-1", day3, "{}", "ready", "daily", "maintenance"],
     );
     storage.run(
       "INSERT INTO briefings (id, generated_at, sections, status, type, source_kind) VALUES (?, ?, ?, ?, ?, ?)",
-      ["brief-2", "2026-03-21T09:00:00Z", "{}", "ready", "daily", "maintenance"],
+      ["brief-2", day2, "{}", "ready", "daily", "maintenance"],
     );
     storage.run(
       "INSERT INTO briefings (id, generated_at, sections, status, type, source_kind) VALUES (?, ?, ?, ?, ?, ?)",
-      ["brief-3", "2026-03-22T09:00:00Z", "{}", "ready", "daily", "maintenance"],
+      ["brief-3", day1, "{}", "ready", "daily", "maintenance"],
     );
     recordProductEvent(storage, {
       eventType: "brief_opened",
-      occurredAt: "2026-03-20T09:05:00Z",
+      occurredAt: day3Open,
       briefId: "brief-1",
     });
     recordProductEvent(storage, {
       eventType: "brief_opened",
-      occurredAt: "2026-03-21T09:05:00Z",
+      occurredAt: day2Open,
       briefId: "brief-2",
     });
     recordProductEvent(storage, {
       eventType: "recommendation_accepted",
-      occurredAt: "2026-03-20T09:10:00Z",
+      occurredAt: day3Accept,
       briefId: "brief-1",
     });
     rateDigest(storage, "brief-1", 4, "Useful");
     recordProductEvent(storage, {
       eventType: "belief_corrected",
-      occurredAt: "2026-03-21T10:00:00Z",
+      occurredAt: day2Correct,
       briefId: "brief-2",
       beliefId: "b5",
     });
@@ -140,15 +160,15 @@ describe("getSystemQualityScore", () => {
     );
     storage.run(
       "INSERT INTO tasks (id, title, description, status, priority, created_at, completed_at, source_type, source_id, source_label) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-      ["task-1", "Follow updated assumption", null, "done", "medium", "2026-03-20T09:15:00Z", "2026-03-20T12:00:00Z", "briefing", "brief-1", "Brief 1"],
+      ["task-1", "Follow updated assumption", null, "done", "medium", day3Task, day3Done, "briefing", "brief-1", "Brief 1"],
     );
     storage.run(
       "INSERT INTO tasks (id, title, description, status, priority, created_at, completed_at, source_type, source_id, source_label) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-      ["task-2", "Re-check platform choice", null, "open", "high", "2026-03-21T09:15:00Z", null, "briefing", "brief-2", "Brief 2"],
+      ["task-2", "Re-check platform choice", null, "open", "high", day2Task, null, "briefing", "brief-2", "Brief 2"],
     );
     recordProductEvent(storage, {
       eventType: "brief_action_completed",
-      occurredAt: "2026-03-20T12:00:00Z",
+      occurredAt: day3Done,
       briefId: "brief-1",
       actionId: "task-1",
     });
@@ -158,15 +178,15 @@ describe("getSystemQualityScore", () => {
       ["watch-1", "Infra Watch", "research", "Track inference infra", 24],
     );
     const sourcesA = [
-      { url: "https://www.sec.gov/ixviewer/ix.html", title: "SEC filing", fetchedAt: "2026-03-20T09:00:00Z", relevance: 0.9 },
-      { url: "https://www.reuters.com/technology/example", title: "Reuters", fetchedAt: "2026-03-20T09:00:00Z", relevance: 0.85 },
+      { url: "https://www.sec.gov/ixviewer/ix.html", title: "SEC filing", fetchedAt: day3, relevance: 0.9 },
+      { url: "https://www.reuters.com/technology/example", title: "Reuters", fetchedAt: day3, relevance: 0.85 },
     ];
     const sourcesB = [
-      { url: "https://docs.anthropic.com/en/docs/overview", title: "Documentation", fetchedAt: "2026-03-21T09:00:00Z", relevance: 0.85 },
-      { url: "https://www.theverge.com/ai/example", title: "The Verge", fetchedAt: "2026-03-21T09:00:00Z", relevance: 0.8 },
+      { url: "https://docs.anthropic.com/en/docs/overview", title: "Documentation", fetchedAt: day2, relevance: 0.85 },
+      { url: "https://www.theverge.com/ai/example", title: "The Verge", fetchedAt: day2, relevance: 0.8 },
     ];
     const sourcesC = [
-      { url: "https://example.com/analysis", title: "Independent analysis", fetchedAt: "2026-03-22T09:00:00Z", relevance: 0.8 },
+      { url: "https://example.com/analysis", title: "Independent analysis", fetchedAt: day1, relevance: 0.8 },
     ];
     const finding1 = createFinding(storage, { watchId: "watch-1", goal: "Inference infra", domain: "general", summary: "Vendor consolidation is accelerating", confidence: 0.8, agentName: "test", depthLevel: "standard", sources: sourcesA });
     const finding2 = createFinding(storage, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`web_search(..., time_range="day")` was often returning **no results** because news engines (Bing/Google News via SearXNG) frequently return empty for a 1-day window. That made chat look broken (“no output”).

## Fix
- `webSearch` now falls back `day → week → unfiltered` when a narrow time range returns empty
- Tool description nudges the model to prefer `week` for “this week / latest” queries

## Validation
- [x] `pnpm verify`
- Live SearXNG check: `day` alone empty/sparse; with fallback returns results

## Residual risk
Widening the window can surface slightly older headlines when “today only” truly has nothing — preferable to silent empty tool output.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afe12014-877a-429f-8f5f-dec03da485f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afe12014-877a-429f-8f5f-dec03da485f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

